### PR TITLE
Adding support for OKX

### DIFF
--- a/src/xrc/src/exchanges.rs
+++ b/src/xrc/src/exchanges.rs
@@ -215,6 +215,7 @@ impl IsExchange for Okx {
 
     fn format_timestamp(&self, timestamp: u64) -> String {
         // Convert seconds to milliseconds.
+        timestamp.saturating_mul(1000).to_string()
     }
 }
 
@@ -257,17 +258,6 @@ mod test {
         let okx = Okx;
         let query_string = okx.get_url("btc", "icp", timestamp);
         assert_eq!(query_string, "https://www.okx.com/api/v5/market/history-candles?instId=BTC-ICP&bar=1m&before=1661523899999&after=1661523960001");
-    }
-
-    /// The function tests if the Binance struct returns the correct exchange rate.
-    #[test]
-    fn extract_rate_from_binance_test() {
-        let binance = Binance;
-        let query_response = r#"[[1637161860000,"42.04000000","42.07000000","41.97000000","41.98000000","1110.01000000",1637161919999,"46648.25930000",59,"325.56000000","13689.16380000","0"],[1637161920000,"41.96000000","42.07000000","41.96000000","42.06000000","771.33000000",1637161979999,"32396.87850000",63,"504.38000000","21177.00270000","0"]]"#
-            .as_bytes();
-        let timestamp: u64 = 1637161920;
-        let extracted_rate = binance.extract_rate(query_response, timestamp);
-        assert!(matches!(extracted_rate, Ok(rate) if rate == 419_600));
     }
 
     /// The function tests if the Binance struct returns the correct exchange rate.


### PR DESCRIPTION
This PR adds support for OKX.
This is the last IPv6-enabled exchange that we currently plan to support.