### PR TITLE
Extended and modified the response metadata

### DIFF
--- a/src/xrc/src/candid.rs
+++ b/src/xrc/src/candid.rs
@@ -21,36 +21,40 @@ pub struct Asset {
 /// The type the user sends when requesting a rate.
 #[derive(CandidType, Deserialize)]
 pub struct GetExchangeRateRequest {
-    /// An optional parameter used to find a rate at a specific time.
-    pub timestamp: Option<u64>,
-    /// The asset to be used as the starting asset. For example, using
-    /// ICP/USD, USD would be the quote asset.
-    pub quote_asset: Asset,
     /// The asset to be used as the resulting asset. For example, using
     /// ICP/USD, ICP would be the base asset.
     pub base_asset: Asset,
+    /// The asset to be used as the starting asset. For example, using
+    /// ICP/USD, USD would be the quote asset.
+    pub quote_asset: Asset,
+    /// An optional parameter used to find a rate at a specific time.
+    pub timestamp: Option<u64>,
 }
 
 /// Metadata information to give background on how the rate was determined.
 #[derive(CandidType, Deserialize)]
 pub struct ExchangeRateInformationMetadata {
-    /// The timestamp associated with the returned rate.
-    pub timestamp: u64,
     /// The number of exchanges queried to determine the results.
     pub number_of_queried_sources: u64,
-    /// The standard deviation of the received rates.
-    pub standard_deviation_permyriad: u64,
     /// The number rates successfully received from the queried sources.
     pub number_of_received_rates: u64,
+    /// The standard deviation of the received rates.
+    pub standard_deviation_permyriad: u64,
 }
 
 /// When a rate is determined, this struct is used to present the information
 /// to the user.
 #[derive(CandidType, Deserialize)]
 pub struct ExchangeRateInformation {
+    /// The base asset.
+    pub base_asset: Asset,
+    /// The quote asset.
+    pub quote_asset: Asset,
+    /// The timestamp associated with the returned rate.
+    pub timestamp: u64,
     /// The median rate from the received rates in permyriad.
     pub rate_permyriad: u64,
-    /// Metadata information to give background on how the rate was determined.
+    /// Metadata providing additional information about the exchange rate calculation.
     pub metadata: ExchangeRateInformationMetadata,
 }
 

--- a/src/xrc/xrc.did
+++ b/src/xrc/xrc.did
@@ -14,7 +14,6 @@ type GetExchangeRateRequest = record {
 }; 
 
 type ExchangeRateInformationMetadata = record {
-    timestamp: nat64;
     number_of_received_rates: nat64;
     number_of_queried_sources: nat64;
     standard_deviation_permyriad: nat64;
@@ -23,6 +22,9 @@ type ExchangeRateInformationMetadata = record {
 };
 
 type ExchangeRateInformation = record {
+    base_asset: Asset;
+    quote_asset: Asset;
+    timestamp: nat64;
     rate_permyriad: nat64;
     metadata: ExchangeRateInformationMetadata;
 };


### PR DESCRIPTION
The metadata of a response should contain the timestamp, which is added in this PR.
Moreover, the PR changes `spread` to `standard_deviation_permyriad` because the term "spread" usually means the smallest difference between bids and offers.

Edit: The PR now adds more information to the exchange response, including the base and quote assets.