### PR TITLE
Bug fix: jaq filters that include timestamps in milliseconds fail compilation inside of the canister.

### DIFF
--- a/src/xrc/src/exchanges.rs
+++ b/src/xrc/src/exchanges.rs
@@ -142,7 +142,7 @@ trait IsExchange {
 /// Binance
 impl IsExchange for Binance {
     fn get_base_filter(&self) -> &str {
-        "map(select(.[0] == TIMESTAMP))[0][1] | tonumber"
+        "map(select(.[0] | tostring == \"TIMESTAMP\"))[0][1] | tonumber"
     }
 
     fn get_base_url(&self) -> &str {
@@ -195,7 +195,7 @@ impl IsExchange for KuCoin {
 /// OKX
 impl IsExchange for Okx {
     fn get_base_filter(&self) -> &str {
-        ".data | map(select(.[0] | tonumber == TIMESTAMP))[0][1] | tonumber"
+        ".data | map(select(.[0] == \"TIMESTAMP\"))[0][1] | tonumber"
     }
 
     fn get_base_url(&self) -> &str {


### PR DESCRIPTION
When running the `xrc` canister through the upcoming e2e tests, it was noticed that Binance and Okx were failing to retrieve their rates. The `dfx` log file showed the following error:

```
    Extract {
        exchange: "Binance",
        error: MalformedFilterExpression {
            filter: "map(select(.[0] == 1614596340000))[0][1] | tonumber",
            errors: [
                "found end of input",
            ],
        },
    }
```

The error is caused by `jaq` trying to box the timestamp into a `u32`. The solution is to compare the timestamps as strings for these exchanges.