### PR TITLE
Fix e2e tests so they do not execute on `cargo test`

### DIFF
--- a/scripts/e2e-tests
+++ b/scripts/e2e-tests
@@ -6,4 +6,4 @@
 ./scripts/e2e-tests-build-base
 mkdir -p src/xrc-tests/gen/canister
 mv xrc.wasm src/xrc-tests/gen/canister
-cargo test --tests --package xrc-tests -- --exact --nocapture
+cargo test --tests --package xrc-tests -- --ignored --exact --nocapture

--- a/scripts/e2e-tests-custom-wasm
+++ b/scripts/e2e-tests-custom-wasm
@@ -13,4 +13,4 @@ dfx build --check
 mkdir -p src/xrc-tests/gen/canister
 cp target/wasm32-unknown-unknown/release/xrc.wasm src/xrc-tests/gen/canister
 # Run the system tests
-cargo test --tests --package xrc-tests -- --exact --nocapture
+cargo test --tests --package xrc-tests -- --ignored --exact --nocapture

--- a/src/xrc-tests/Cargo.toml
+++ b/src/xrc-tests/Cargo.toml
@@ -2,8 +2,6 @@
 name = "xrc-tests"
 version = "0.1.0"
 edition = "2021"
-# Indicates that the crate is used for integration tests only.
-test = true
 
 [dependencies]
 candid = "0.7.14"

--- a/src/xrc-tests/src/lib.rs
+++ b/src/xrc-tests/src/lib.rs
@@ -1,6 +1,3 @@
-// Temporary for e2e-test PRs
-#![allow(dead_code)]
-
 #[cfg(test)]
 mod container;
 #[cfg(test)]

--- a/src/xrc-tests/src/tests.rs
+++ b/src/xrc-tests/src/tests.rs
@@ -3,6 +3,7 @@ use xrc::EXCHANGES;
 
 use crate::container::{run_scenario, Container, ExchangeResponse};
 
+#[ignore]
 #[test]
 fn can_successfully_retrieve_rate() {
     let request = xrc::candid::GetExchangeRateRequest {


### PR DESCRIPTION
This PR updates the e2e tests so that they do not run when `cargo test` executes. As the e2e tests are expensive to run, the tests are marked with `#[ignore]`. The pipeline will run these tests as it includes the `--ignored` flag.