### PR TITLE
Introduce ForexMultiRateMap in addition to ForexRateMap

### DIFF
--- a/src/xrc/src/forex.rs
+++ b/src/xrc/src/forex.rs
@@ -26,7 +26,7 @@ pub struct ForexRate {
 }
 
 /// A map of multiple forex rates with one source per forex. The key is the forex symbol and the value is the corresponding rate.
-pub type ForexRateMap = HashMap<String, u64>;
+type ForexRateMap = HashMap<String, u64>;
 
 /// A map of multiple forex rates with possibly multiple sources per forex. The key is the forex symbol and the value is the corresponding rate and the number of sources used to compute it.
 pub type ForexMultiRateMap = HashMap<String, ForexRate>;


### PR DESCRIPTION
In parts of the forex code we have code that operates on `ForexRate` objects (which compound rate and `num_sources`), despite having `num_sources` always equals to 1 (e.g., reports from one source). This PR fixes it by introducing another type of mapping for rates. `ForexRateMap` is now defined as `Map<String, u64>`, while `ForexMultiRateMap` is defined as `Map<String, ForexRate>`. All internal code uses `ForexRateMap` as before, while the external facing `ForexRateStore` uses the `ForexMultiRateMap` type.