### PR TITLE
Forex: Add Bank of Canada

### DIFF
--- a/src/xrc/src/forex.rs
+++ b/src/xrc/src/forex.rs
@@ -928,7 +928,7 @@ impl IsForex for BankOfCanada {
                         } else {
                             // It is a series value - get the corresponding symbol and put into the map
                             if let Ok(val) = f64::from_str(&value.to_string()) {
-                                if let Some(Val::Str(symbol_pair)) = series.get(&key.to_string()) {
+                                if let Some(Val::Str(symbol_pair)) = series.get(key) {
                                     if let Some(symbol) = symbol_pair.to_string().split('/').next()
                                     {
                                         values_by_symbol


### PR DESCRIPTION
This PR adds Bank of Canada as a forex source.
Rebased on top of #75 