### PR TITLE
Setting the IC Integrations team as the owner of the repository

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
-* @dfinity-ryancroote @THLO @yotamhc
+# The IC Integrations team is the owner of this repository.
+*	@dfinity/integrations


### PR DESCRIPTION
The CODEOWNERS file now specifies the IC Integrations team as the owner of the repository.