### PR TITLE
`refactor`: Remove `time_secs` call from `ForexRateStore::get`.

### DIFF
--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -310,8 +310,9 @@ async fn handle_crypto_base_fiat_quote_pair(
 
     let maybe_crypto_base_rate =
         with_cache_mut(|cache| cache.get(&base_asset.symbol, timestamp, time));
-    let forex_rate = with_forex_rate_store(|store| store.get(timestamp, &quote_asset.symbol, USD))
-        .map_err(ExchangeRateError::from)?;
+    let forex_rate =
+        with_forex_rate_store(|store| store.get(timestamp, time, &quote_asset.symbol, USD))
+            .map_err(ExchangeRateError::from)?;
 
     let mut num_rates_needed: usize = 0;
     if maybe_crypto_base_rate.is_none() {
@@ -410,8 +411,14 @@ fn handle_fiat_pair(
         env.charge_cycles(0)?;
     }
 
+    let current_timestamp = env.time_secs();
     let result = with_forex_rate_store(|store| {
-        store.get(timestamp, &base_asset.symbol, &quote_asset.symbol)
+        store.get(
+            timestamp,
+            current_timestamp,
+            &base_asset.symbol,
+            &quote_asset.symbol,
+        )
     })
     .map_err(|err| err.into());
     if let Ok(rate) = result {

--- a/src/xrc/src/periodic.rs
+++ b/src/xrc/src/periodic.rs
@@ -241,7 +241,8 @@ mod test {
         update_forex_store(timestamp, &mock_forex_sources)
             .now_or_never()
             .expect("should have executed");
-        let result = with_forex_rate_store(|store| store.get(start_of_day, "eur", "usd"));
+        let result =
+            with_forex_rate_store(|store| store.get(start_of_day, timestamp, "eur", "usd"));
         assert!(matches!(result, Ok(forex_rate) if forex_rate.rates == vec![10_000]));
     }
 


### PR DESCRIPTION
This PR removes the `time_secs` call from `ForexRateStore::get`. The call causes the unit tests when running them on M1 Macs. This is resolved by adding a parameter to `get` to intake the current timestamp. This allows a timestamp to be provided by an `Environment` implementation in the unit tests.