### PR TITLE
Update Binance URL to the Binance.US API

### DIFF
--- a/src/xrc/src/exchanges.rs
+++ b/src/xrc/src/exchanges.rs
@@ -425,7 +425,7 @@ mod test {
         let timestamp = 1661524016;
         let binance = Binance;
         let query_string = binance.get_url("btc", "icp", timestamp);
-        assert_eq!(query_string, "https://api.binance.com/api/v3/klines?symbol=BTCICP&interval=1m&startTime=1661523960000&endTime=1661523960000");
+        assert_eq!(query_string, "https://api.binance.us/api/v3/klines?symbol=BTCICP&interval=1m&startTime=1661523960000&endTime=1661523960000");
 
         let coinbase = Coinbase;
         let query_string = coinbase.get_url("btc", "icp", timestamp);
@@ -452,7 +452,7 @@ mod test {
     #[test]
     fn ipv6_support() {
         let binance = Binance;
-        assert!(!binance.supports_ipv6());
+        assert!(binance.supports_ipv6());
         let coinbase = Coinbase;
         assert!(coinbase.supports_ipv6());
         let kucoin = KuCoin;


### PR DESCRIPTION
This PR addresses the following access issue with Binance:

`Service unavailable from a restricted location according to 'b. Eligibility' in https://www.binance.com/en/terms`

This PR changes the base URL from `api.binance.com` to `api.binance.us` (Binance US's API). This change appears to be accessible from multiple locations unlike `api.binance.com`. This switch comes with a bonus that `api.binance.us` does support IPv6.