### PR TITLE
Log all errors that can be encountered when making outbound HTTP calls.

### DIFF
--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -64,7 +64,10 @@ impl CallExchanges for CallExchangesImpl {
         for result in results {
             match result {
                 Ok(rate) => rates.push(rate),
-                Err(err) => errors.push(err),
+                Err(err) => {
+                    ic_cdk::println!("{} Error while calling: {}", LOG_PREFIX, err);
+                    errors.push(err);
+                }
             }
         }
 

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -589,18 +589,16 @@ pub fn transform_exchange_http_response(args: TransformArgs) -> HttpResponse {
 
     let index = match Exchange::decode_context(&args.context) {
         Ok(index) => index,
-        Err(err) => {
-            utils::print_and_trap(format!("{} Failed to decode context: {}", LOG_PREFIX, err));
-        }
+        Err(err) => ic_cdk::trap(&format!("Failed to decode context: {}", err)),
     };
 
     // It should be ok to trap here as this does not modify state.
     let exchange = match EXCHANGES.get(index) {
         Some(exchange) => exchange,
         None => {
-            utils::print_and_trap(format!(
-                "{} Provided index {} does not map to any supported exchange.",
-                LOG_PREFIX, index
+            ic_cdk::trap(&format!(
+                "Provided index {} does not map to any supported exchange.",
+                index
             ));
         }
     };
@@ -608,19 +606,16 @@ pub fn transform_exchange_http_response(args: TransformArgs) -> HttpResponse {
     let rate = match exchange.extract_rate(&sanitized.body) {
         Ok(rate) => rate,
         Err(err) => {
-            utils::print_and_trap(format!(
-                "{} {} failed to extract rate: {}",
-                LOG_PREFIX, exchange, err
-            ));
+            ic_cdk::trap(&format!("{} failed to extract rate: {}", exchange, err));
         }
     };
 
     sanitized.body = match Exchange::encode_response(rate) {
         Ok(body) => body,
         Err(err) => {
-            utils::print_and_trap(format!(
-                "{} {} failed to encode rate ({}): {}",
-                LOG_PREFIX, exchange, rate, err
+            ic_cdk::trap(&format!(
+                "{} failed to encode rate ({}): {}",
+                exchange, rate, err
             ));
         }
     };
@@ -641,16 +636,16 @@ pub fn transform_forex_http_response(args: TransformArgs) -> HttpResponse {
     let context = match Forex::decode_context(&args.context) {
         Ok(context) => context,
         Err(err) => {
-            utils::print_and_trap(format!("{} Failed to decode context: {}", LOG_PREFIX, err));
+            ic_cdk::trap(&format!("Failed to decode context: {}", err));
         }
     };
 
     let forex = match FOREX_SOURCES.get(context.id) {
         Some(forex) => forex,
         None => {
-            utils::print_and_trap(format!(
-                "{} Provided forex index {} does not map to any supported forex source.",
-                LOG_PREFIX, context.id
+            ic_cdk::trap(&format!(
+                "Provided forex index {} does not map to any supported forex source.",
+                context.id
             ));
         }
     };
@@ -658,10 +653,7 @@ pub fn transform_forex_http_response(args: TransformArgs) -> HttpResponse {
     sanitized.body = match forex.transform_http_response_body(&sanitized.body, &context.payload) {
         Ok(body) => body,
         Err(err) => {
-            utils::print_and_trap(format!(
-                "{} {} failed to extract rate: {}",
-                LOG_PREFIX, forex, err
-            ));
+            ic_cdk::trap(&format!("{} failed to extract rate: {}", forex, err));
         }
     };
 

--- a/src/xrc/src/periodic.rs
+++ b/src/xrc/src/periodic.rs
@@ -8,7 +8,7 @@ use crate::{
     call_forex,
     forex::{ForexContextArgs, ForexRateMap, FOREX_SOURCES},
     with_forex_rate_collector, with_forex_rate_collector_mut, with_forex_rate_store_mut,
-    CallForexError,
+    CallForexError, LOG_PREFIX,
 };
 
 thread_local! {
@@ -158,7 +158,11 @@ async fn update_forex_store(
     set_is_updating_forex_store(true);
 
     let start_of_day = start_of_day_timestamp(timestamp);
-    let (forex_rates, _) = forex_sources.call(start_of_day).await;
+    let (forex_rates, errors) = forex_sources.call(start_of_day).await;
+    for (forex, error) in errors {
+        ic_cdk::println!("{} {} {}", LOG_PREFIX, forex, error);
+    }
+
     let mut timestamps_to_update: HashSet<u64> = HashSet::new();
     for (source, timestamp, rates) in forex_rates {
         // Try to update the collector with data from this source

--- a/src/xrc/src/utils.rs
+++ b/src/xrc/src/utils.rs
@@ -104,11 +104,6 @@ pub(crate) fn invert_rate(rate: u64) -> u64 {
     (RATE_UNIT * RATE_UNIT) / rate
 }
 
-pub(crate) fn print_and_trap(message: String) -> ! {
-    ic_cdk::println!("{}", message);
-    ic_cdk::trap(&message);
-}
-
 #[cfg(test)]
 mod test {
     use crate::candid::AssetClass;


### PR DESCRIPTION
This PR reverts a few logging statements in the transforms in favor of logging near the calling code. This allows us to capture all errors in the logs when making outbound HTTP calls. There will be a follow up PR to clean up the logging further and use the various environments.