### PR TITLE
Update log message when an a failure to extract rate occurs

### DIFF
--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -224,8 +224,9 @@ async fn get_exchange_rate_internal(
 
     if let Err(ref error) = result {
         ic_cdk::println!(
-            "{} Request: {:?} Error: {:?}",
+            "{} Timestamp: {} Request: {:?} Error: {:?}",
             LOG_PREFIX,
+            timestamp,
             sanitized_request,
             error
         );

--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -65,7 +65,13 @@ impl CallExchanges for CallExchangesImpl {
             match result {
                 Ok(rate) => rates.push(rate),
                 Err(err) => {
-                    ic_cdk::println!("{} Error while calling: {}", LOG_PREFIX, err);
+                    ic_cdk::println!(
+                        "{} Error while calling for asset {:?} @ {}: {}",
+                        LOG_PREFIX,
+                        asset,
+                        timestamp,
+                        err
+                    );
                     errors.push(err);
                 }
             }


### PR DESCRIPTION
This PR includes a minor improvement to the log messages when a rate fails to be extracted from an exchange.