### PR TITLE
refactor: Rate limiting guard should track the calculated HTTP requests and add `is_available` to exchanges and forex sources to clean up feature flag check.

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -39,7 +39,8 @@ jobs:
       - name: Run Tests
         shell: bash
         run: |
-          cargo test --package xrc --release --all-targets --all-features
+          cargo test --package xrc --release --all-targets --features ipv4-support
+          cargo test --package xrc --release --all-targets
         env:
           RUST_BACKTRACE: 1
 

--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -269,8 +269,10 @@ async fn handle_cryptocurrency_pair(
         num_rates_needed = num_rates_needed.saturating_add(1);
     }
 
+    let available_exchanges_count = EXCHANGES.iter().filter(|e| e.is_available()).count();
+    let http_requests_needed = num_rates_needed.saturating_mul(available_exchanges_count);
     if !utils::is_caller_the_cmc(&caller) {
-        if is_rate_limited(num_rates_needed) {
+        if is_rate_limited(http_requests_needed) {
             return Err(ExchangeRateError::RateLimited);
         }
         env.charge_cycles(num_rates_needed)?;
@@ -284,8 +286,6 @@ async fn handle_cryptocurrency_pair(
 
     let base_asset = base_asset.clone();
     let quote_asset = quote_asset.clone();
-    let available_exchanges_count = EXCHANGES.iter().filter(|e| e.is_available()).count();
-    let http_requests_needed = num_rates_needed.saturating_mul(available_exchanges_count);
     with_request_counter(http_requests_needed, async move {
         let base_rate = match maybe_base_rate {
             Some(base_rate) => base_rate,
@@ -355,8 +355,10 @@ async fn handle_crypto_base_fiat_quote_pair(
 
     num_rates_needed = num_rates_needed.saturating_add(missed_stablecoin_symbols.len());
 
+    let available_exchanges_count = EXCHANGES.iter().filter(|e| e.is_available()).count();
+    let http_requests_needed = num_rates_needed.saturating_mul(available_exchanges_count);
     if !utils::is_caller_the_cmc(&caller) {
-        if is_rate_limited(num_rates_needed) {
+        if is_rate_limited(http_requests_needed) {
             return Err(ExchangeRateError::RateLimited);
         }
         env.charge_cycles(num_rates_needed)?;

--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -285,8 +285,8 @@ async fn handle_cryptocurrency_pair(
     let base_asset = base_asset.clone();
     let quote_asset = quote_asset.clone();
     let available_exchanges_count = EXCHANGES.iter().filter(|e| e.is_available()).count();
-    let requests_needed = num_rates_needed.saturating_mul(available_exchanges_count);
-    with_request_counter(requests_needed, async move {
+    let http_requests_needed = num_rates_needed.saturating_mul(available_exchanges_count);
+    with_request_counter(http_requests_needed, async move {
         let base_rate = match maybe_base_rate {
             Some(base_rate) => base_rate,
             None => {
@@ -373,8 +373,8 @@ async fn handle_crypto_base_fiat_quote_pair(
 
     let base_asset = base_asset.clone();
     let available_exchanges_count = EXCHANGES.iter().filter(|e| e.is_available()).count();
-    let requests_needed = num_rates_needed.saturating_mul(available_exchanges_count);
-    with_request_counter(requests_needed, async move {
+    let http_requests_needed = num_rates_needed.saturating_mul(available_exchanges_count);
+    with_request_counter(http_requests_needed, async move {
         // Retrieve the missing stablecoin results. For each rate retrieved, cache it and add it to the
         // stablecoin rates vector.
         let stablecoin_results = call_exchanges_impl

--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -276,10 +276,8 @@ async fn handle_cryptocurrency_pair(
         num_rates_needed = num_rates_needed.saturating_add(1);
     }
 
-    let available_exchanges_count = EXCHANGES.iter().filter(|e| e.is_available()).count();
-    let http_requests_needed = num_rates_needed.saturating_mul(available_exchanges_count);
     if !utils::is_caller_the_cmc(&caller) {
-        if is_rate_limited(http_requests_needed) {
+        if is_rate_limited(num_rates_needed) {
             return Err(ExchangeRateError::RateLimited);
         }
         env.charge_cycles(num_rates_needed)?;
@@ -293,7 +291,7 @@ async fn handle_cryptocurrency_pair(
 
     let base_asset = base_asset.clone();
     let quote_asset = quote_asset.clone();
-    with_request_counter(http_requests_needed, async move {
+    with_request_counter(num_rates_needed, async move {
         let base_rate = match maybe_base_rate {
             Some(base_rate) => base_rate,
             None => {
@@ -362,10 +360,8 @@ async fn handle_crypto_base_fiat_quote_pair(
 
     num_rates_needed = num_rates_needed.saturating_add(missed_stablecoin_symbols.len());
 
-    let available_exchanges_count = EXCHANGES.iter().filter(|e| e.is_available()).count();
-    let http_requests_needed = num_rates_needed.saturating_mul(available_exchanges_count);
     if !utils::is_caller_the_cmc(&caller) {
-        if is_rate_limited(http_requests_needed) {
+        if is_rate_limited(num_rates_needed) {
             return Err(ExchangeRateError::RateLimited);
         }
         env.charge_cycles(num_rates_needed)?;
@@ -381,9 +377,7 @@ async fn handle_crypto_base_fiat_quote_pair(
     }
 
     let base_asset = base_asset.clone();
-    let available_exchanges_count = EXCHANGES.iter().filter(|e| e.is_available()).count();
-    let http_requests_needed = num_rates_needed.saturating_mul(available_exchanges_count);
-    with_request_counter(http_requests_needed, async move {
+    with_request_counter(num_rates_needed, async move {
         // Retrieve the missing stablecoin results. For each rate retrieved, cache it and add it to the
         // stablecoin rates vector.
         let stablecoin_results = call_exchanges_impl

--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -44,7 +44,7 @@ impl CallExchanges for CallExchangesImpl {
         timestamp: u64,
     ) -> Result<QueriedExchangeRate, CallExchangeError> {
         let futures = EXCHANGES.iter().filter_map(|exchange| {
-            if exchange.is_available() {
+            if !exchange.is_available() {
                 return None;
             }
 
@@ -284,7 +284,8 @@ async fn handle_cryptocurrency_pair(
 
     let base_asset = base_asset.clone();
     let quote_asset = quote_asset.clone();
-    let requests_needed = num_rates_needed.saturating_mul(utils::available_exchanges_count());
+    let available_exchanges_count = EXCHANGES.iter().filter(|e| e.is_available()).count();
+    let requests_needed = num_rates_needed.saturating_mul(available_exchanges_count);
     with_request_counter(requests_needed, async move {
         let base_rate = match maybe_base_rate {
             Some(base_rate) => base_rate,
@@ -371,7 +372,8 @@ async fn handle_crypto_base_fiat_quote_pair(
     }
 
     let base_asset = base_asset.clone();
-    let requests_needed = num_rates_needed.saturating_mul(utils::available_exchanges_count());
+    let available_exchanges_count = EXCHANGES.iter().filter(|e| e.is_available()).count();
+    let requests_needed = num_rates_needed.saturating_mul(available_exchanges_count);
     with_request_counter(requests_needed, async move {
         // Retrieve the missing stablecoin results. For each rate retrieved, cache it and add it to the
         // stablecoin rates vector.

--- a/src/xrc/src/exchanges.rs
+++ b/src/xrc/src/exchanges.rs
@@ -115,8 +115,11 @@ macro_rules! exchanges {
                 }
             }
 
-            /// This method returns whether the exchange should be called.
-            /// Currently, only IPv6 support determines whether is should be used.
+            /// This method returns whether the exchange should be called. Availability
+            /// is determined by whether or not the `ipv4-support` flag was used to compile the
+            /// canister or the exchange supports IPv6 out-of-the-box.
+            ///
+            /// NOTE: This will be removed when IPv4 support is added to HTTP outcalls.
             pub fn is_available(&self) -> bool {
                 utils::is_ipv4_support_available() || self.supports_ipv6()
             }

--- a/src/xrc/src/exchanges.rs
+++ b/src/xrc/src/exchanges.rs
@@ -669,4 +669,18 @@ mod test {
         let exchange = Exchange::Mexc(Mexc);
         assert_eq!(exchange.max_response_bytes(), ONE_KIB);
     }
+
+    #[test]
+    #[cfg(not(feature = "ipv4-support"))]
+    fn is_available() {
+        let available_exchanges_count = EXCHANGES.iter().filter(|e| e.is_available()).count();
+        assert_eq!(available_exchanges_count, 3);
+    }
+
+    #[test]
+    #[cfg(feature = "ipv4-support")]
+    fn is_available_ipv4() {
+        let available_exchanges_count = EXCHANGES.iter().filter(|e| e.is_available()).count();
+        assert_eq!(available_exchanges_count, 6);
+    }
 }

--- a/src/xrc/src/exchanges.rs
+++ b/src/xrc/src/exchanges.rs
@@ -6,7 +6,7 @@ use serde::de::DeserializeOwned;
 
 use crate::{
     candid::{Asset, AssetClass},
-    ONE_KIB,
+    utils, ONE_KIB,
 };
 use crate::{ExtractError, RATE_UNIT};
 use crate::{DAI, USDC, USDT};
@@ -113,6 +113,12 @@ macro_rules! exchanges {
                 match self {
                     $(Exchange::$name(exchange) => exchange.max_response_bytes()),*,
                 }
+            }
+
+            /// This method returns whether the exchange should be called.
+            /// Currently, only IPv6 support determines whether is should be used.
+            pub fn is_available(&self) -> bool {
+                utils::is_ipv4_support_available() || self.supports_ipv6()
             }
         }
     }

--- a/src/xrc/src/forex.rs
+++ b/src/xrc/src/forex.rs
@@ -1895,4 +1895,20 @@ mod test {
         let forex = Forex::CentralBankOfUzbekistan(CentralBankOfUzbekistan);
         assert_eq!(forex.max_response_bytes(), 30 * ONE_KIB);
     }
+
+    #[test]
+    #[cfg(not(feature = "ipv4-support"))]
+    fn is_available() {
+        let available_forex_sources_count =
+            FOREX_SOURCES.iter().filter(|e| e.is_available()).count();
+        assert_eq!(available_forex_sources_count, 4);
+    }
+
+    #[test]
+    #[cfg(feature = "ipv4-support")]
+    fn is_available_ipv4() {
+        let available_forex_sources_count =
+            FOREX_SOURCES.iter().filter(|e| e.is_available()).count();
+        assert_eq!(available_forex_sources_count, 7);
+    }
 }

--- a/src/xrc/src/forex.rs
+++ b/src/xrc/src/forex.rs
@@ -7,9 +7,11 @@ use std::collections::{HashSet, VecDeque};
 use std::mem::size_of_val;
 use std::{collections::HashMap, convert::TryInto};
 
-use crate::candid::{Asset, AssetClass, ExchangeRateError};
-use crate::{median, standard_deviation, AllocatedBytes, ONE_KIB, RATE_UNIT};
-use crate::{ExtractError, QueriedExchangeRate, USD};
+use crate::{
+    candid::{Asset, AssetClass, ExchangeRateError},
+    median, standard_deviation, utils, AllocatedBytes, ExtractError, QueriedExchangeRate, ONE_KIB,
+    RATE_UNIT, USD,
+};
 
 /// The IMF SDR weights used to compute the XDR rate.
 pub(crate) const USD_XDR_WEIGHT_PER_MILLION: u128 = 582_520;
@@ -179,6 +181,12 @@ macro_rules! forex {
                 match self {
                     $(Forex::$name(forex) => forex.max_response_bytes()),*,
                 }
+            }
+
+            /// This method returns whether the exchange should be called.
+            /// Currently, only IPv6 support determines whether is should be used.
+            pub fn is_available(&self) -> bool {
+                utils::is_ipv4_support_available() || self.supports_ipv6()
             }
         }
     }

--- a/src/xrc/src/forex.rs
+++ b/src/xrc/src/forex.rs
@@ -183,8 +183,11 @@ macro_rules! forex {
                 }
             }
 
-            /// This method returns whether the exchange should be called.
-            /// Currently, only IPv6 support determines whether is should be used.
+            /// This method returns whether the exchange should be called. Availability
+            /// is determined by whether or not the `ipv4-support` flag was used to compile the
+            /// canister or the exchange supports IPv6 out-of-the-box.
+            ///
+            /// NOTE: This will be removed when IPv4 support is added to HTTP outcalls.
             pub fn is_available(&self) -> bool {
                 utils::is_ipv4_support_available() || self.supports_ipv6()
             }

--- a/src/xrc/src/periodic.rs
+++ b/src/xrc/src/periodic.rs
@@ -81,7 +81,8 @@ impl ForexSources for ForexSourcesImpl {
                     return None;
                 }
             }
-            if !cfg!(feature = "ipv4-support") && !forex.supports_ipv6() {
+
+            if forex.is_available() {
                 return None;
             }
 

--- a/src/xrc/src/periodic.rs
+++ b/src/xrc/src/periodic.rs
@@ -82,7 +82,7 @@ impl ForexSources for ForexSourcesImpl {
                 }
             }
 
-            if forex.is_available() {
+            if !forex.is_available() {
                 return None;
             }
 

--- a/src/xrc/src/rate_limiting.rs
+++ b/src/xrc/src/rate_limiting.rs
@@ -48,8 +48,7 @@ impl RateLimitingRequestCounterGuard {
         let available_exchanges_count = available_exchanges_count();
         let http_requests_needed = available_exchanges_count.saturating_mul(num_rates_needed);
         RATE_LIMITING_REQUEST_COUNTER.with(|cell| {
-            let value = cell.get();
-            let value = value.saturating_add(http_requests_needed);
+            let value = cell.get().saturating_add(http_requests_needed);
             cell.set(value);
         });
         Self {
@@ -62,8 +61,7 @@ impl Drop for RateLimitingRequestCounterGuard {
     /// Decrement the counter when guard is dropped.
     fn drop(&mut self) {
         RATE_LIMITING_REQUEST_COUNTER.with(|cell| {
-            let value = cell.get();
-            let value = value.saturating_sub(self.http_requests_needed);
+            let value = cell.get().saturating_sub(self.http_requests_needed);
             cell.set(value);
         });
     }

--- a/src/xrc/src/rate_limiting.rs
+++ b/src/xrc/src/rate_limiting.rs
@@ -1,4 +1,6 @@
-use crate::{candid::ExchangeRateError, QueriedExchangeRate, RATE_LIMITING_REQUEST_COUNTER};
+use crate::{
+    candid::ExchangeRateError, QueriedExchangeRate, EXCHANGES, RATE_LIMITING_REQUEST_COUNTER,
+};
 
 /// A limit for how many HTTP requests the exchange rate canister may issue at any given time.
 /// The request counter is not allowed to go over this limit.
@@ -19,9 +21,11 @@ where
 }
 
 /// Checks that a request can be made.
-pub(crate) fn is_rate_limited(requests_needed: usize) -> bool {
+pub(crate) fn is_rate_limited(num_rates_needed: usize) -> bool {
     let request_counter = get_request_counter();
-    requests_needed.saturating_add(request_counter) > REQUEST_COUNTER_LIMIT
+    let available_exchanges_count = available_exchanges_count();
+    let http_requests_needed = available_exchanges_count.saturating_mul(num_rates_needed);
+    http_requests_needed.saturating_add(request_counter) > REQUEST_COUNTER_LIMIT
 }
 
 /// Returns the value of the request counter.
@@ -29,31 +33,38 @@ pub(crate) fn get_request_counter() -> usize {
     RATE_LIMITING_REQUEST_COUNTER.with(|cell| cell.get())
 }
 
+fn available_exchanges_count() -> usize {
+    EXCHANGES.iter().filter(|e| e.is_available()).count()
+}
+
 /// Guard to ensure the rate limiting request counter is incremented and decremented properly.
 struct RateLimitingRequestCounterGuard {
-    http_requests_needed: usize,
+    num_rates_needed: usize,
 }
 
 impl RateLimitingRequestCounterGuard {
     /// Increment the counter and return the guard.
-    fn new(http_requests_needed: usize) -> Self {
+    fn new(num_rates_needed: usize) -> Self {
+        let available_exchanges_count = available_exchanges_count();
         RATE_LIMITING_REQUEST_COUNTER.with(|cell| {
             let value = cell.get();
+            let http_requests_needed = available_exchanges_count.saturating_mul(num_rates_needed);
             let value = value.saturating_add(http_requests_needed);
             cell.set(value);
         });
-        Self {
-            http_requests_needed,
-        }
+        Self { num_rates_needed }
     }
 }
 
 impl Drop for RateLimitingRequestCounterGuard {
     /// Decrement the counter when guard is dropped.
     fn drop(&mut self) {
+        let available_exchanges_count = available_exchanges_count();
         RATE_LIMITING_REQUEST_COUNTER.with(|cell| {
             let value = cell.get();
-            let value = value.saturating_sub(self.http_requests_needed);
+            let http_requests_needed =
+                available_exchanges_count.saturating_mul(self.num_rates_needed);
+            let value = value.saturating_sub(http_requests_needed);
             cell.set(value);
         });
     }
@@ -69,9 +80,12 @@ mod test {
     /// block, the counter increments and decrements correctly.
     #[test]
     fn with_request_counter_with_ok_result_returned() {
-        let http_requests_needed = 3;
-        let rate = with_request_counter(http_requests_needed, async move {
-            assert_eq!(get_request_counter(), http_requests_needed);
+        let num_rates_needed = 2;
+        let rate = with_request_counter(num_rates_needed, async move {
+            assert_eq!(
+                get_request_counter(),
+                num_rates_needed * available_exchanges_count()
+            );
             Ok(QueriedExchangeRate::default())
         })
         .now_or_never()
@@ -85,9 +99,12 @@ mod test {
     /// block, the counter increments and decrements correctly.
     #[test]
     fn with_request_counter_with_error_returned() {
-        let http_requests_needed = 3;
-        let error = with_request_counter(http_requests_needed, async move {
-            assert_eq!(get_request_counter(), http_requests_needed);
+        let num_rates_needed = 2;
+        let error = with_request_counter(num_rates_needed, async move {
+            assert_eq!(
+                get_request_counter(),
+                num_rates_needed * available_exchanges_count()
+            );
             Err(ExchangeRateError::StablecoinRateNotFound)
         })
         .now_or_never()
@@ -109,7 +126,7 @@ mod test {
     /// then the request is rate limited.
     #[test]
     fn is_rate_limited_checks_against_a_hard_limit() {
-        RATE_LIMITING_REQUEST_COUNTER.with(|c| c.set(54));
-        assert!(is_rate_limited(3));
+        RATE_LIMITING_REQUEST_COUNTER.with(|c| c.set(52));
+        assert!(is_rate_limited(2));
     }
 }

--- a/src/xrc/src/rate_limiting.rs
+++ b/src/xrc/src/rate_limiting.rs
@@ -9,14 +9,14 @@ const REQUEST_COUNTER_LIMIT: usize = 56;
 /// This function is used to wrap HTTP outcalls so that the requests can be rate limited.
 /// If the caller is the CMC, it will ignore the rate limiting.
 pub(crate) async fn with_request_counter<F>(
-    http_requests_needed: usize,
+    num_rates_needed: usize,
     future: F,
 ) -> Result<QueriedExchangeRate, ExchangeRateError>
 where
     F: std::future::Future<Output = Result<QueriedExchangeRate, ExchangeRateError>>,
 {
     // Need to set the guard to maintain the lifetime until the future is complete.
-    let _guard = RateLimitingRequestCounterGuard::new(http_requests_needed);
+    let _guard = RateLimitingRequestCounterGuard::new(num_rates_needed);
     future.await
 }
 

--- a/src/xrc/src/utils.rs
+++ b/src/xrc/src/utils.rs
@@ -1,7 +1,7 @@
 use crate::{
     candid::{Asset, GetExchangeRateRequest},
     environment::Environment,
-    CYCLES_MINTING_CANISTER_ID, EXCHANGES, RATE_UNIT,
+    CYCLES_MINTING_CANISTER_ID, RATE_UNIT,
 };
 use ic_cdk::export::Principal;
 
@@ -112,10 +112,6 @@ pub(crate) fn invert_rate(rate: u64) -> u64 {
 /// Checks if the canister is supporting IPv4 exchanges and forex sources.
 pub(crate) fn is_ipv4_support_available() -> bool {
     cfg!(feature = "ipv4-support")
-}
-
-pub(crate) fn available_exchanges_count() -> usize {
-    EXCHANGES.iter().filter(|e| e.is_available()).count()
 }
 
 #[cfg(test)]

--- a/src/xrc/src/utils.rs
+++ b/src/xrc/src/utils.rs
@@ -1,7 +1,7 @@
 use crate::{
     candid::{Asset, GetExchangeRateRequest},
     environment::Environment,
-    CYCLES_MINTING_CANISTER_ID, RATE_UNIT,
+    CYCLES_MINTING_CANISTER_ID, EXCHANGES, RATE_UNIT,
 };
 use ic_cdk::export::Principal;
 
@@ -107,6 +107,15 @@ pub(crate) fn is_caller_the_cmc(caller: &Principal) -> bool {
 /// Inverts a given rate.
 pub(crate) fn invert_rate(rate: u64) -> u64 {
     (RATE_UNIT * RATE_UNIT) / rate
+}
+
+/// Checks if the canister is supporting IPv4 exchanges and forex sources.
+pub(crate) fn is_ipv4_support_available() -> bool {
+    cfg!(feature = "ipv4-support")
+}
+
+pub(crate) fn available_exchanges_count() -> usize {
+    EXCHANGES.iter().filter(|e| e.is_available()).count()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR refactors the following two items:

1. The rate limiting guard now takes the number of HTTP requests needed instead of the number of rates needed. This moves the calculation out. This also fixes a bug when IPv4 support is not available causing more requests to be reserved than required.

2. It adds an `is_available` to `Exchange` and `Forex` to make it easier to determine if the exchange or forex can be used as the IPv4 feature flag was used to compile the canister or they support IPv6 out-of-the-box.