### PR TITLE
feat: Up the cycle cost to `10_000_000_000`

### DIFF
--- a/src/xrc/src/api/test.rs
+++ b/src/xrc/src/api/test.rs
@@ -8,7 +8,7 @@ use crate::{
     candid::{Asset, AssetClass, ExchangeRateError, GetExchangeRateRequest},
     environment::test::TestEnvironment,
     with_cache_mut, CallExchangeError, QueriedExchangeRate, CACHE_RETENTION_PERIOD_SEC,
-    CYCLES_MINTING_CANISTER_ID, EXCHANGES, XRC_BASE_CYCLES_COST,
+    CYCLES_MINTING_CANISTER_ID, EXCHANGES, XRC_BASE_CYCLES_COST, XRC_IMMEDIATE_REFUND_CYCLES,
     XRC_OUTBOUND_HTTP_CALL_CYCLES_COST, XRC_REQUEST_CYCLES_COST,
 };
 
@@ -251,7 +251,7 @@ fn get_exchange_rate_will_charge_cycles() {
         .build();
     let env = TestEnvironment::builder()
         .with_cycles_available(XRC_REQUEST_CYCLES_COST)
-        .with_accepted_cycles(5_000_000_000)
+        .with_accepted_cycles(XRC_IMMEDIATE_REFUND_CYCLES)
         .build();
     let request = GetExchangeRateRequest {
         base_asset: Asset {

--- a/src/xrc/src/api/test.rs
+++ b/src/xrc/src/api/test.rs
@@ -251,7 +251,7 @@ fn get_exchange_rate_will_charge_cycles() {
         .build();
     let env = TestEnvironment::builder()
         .with_cycles_available(XRC_REQUEST_CYCLES_COST)
-        .with_accepted_cycles(XRC_REQUEST_CYCLES_COST)
+        .with_accepted_cycles(5_000_000_000)
         .build();
     let request = GetExchangeRateRequest {
         base_asset: Asset {

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -51,10 +51,14 @@ const RATE_DEVIATION_DIVISOR: u64 = 10;
 const LOG_PREFIX: &str = "[xrc]";
 
 /// The number of cycles needed to use the `xrc` canister.
-pub const XRC_REQUEST_CYCLES_COST: u64 = 5_000_000_000;
+pub const XRC_REQUEST_CYCLES_COST: u64 = 10_000_000_000;
 
 /// The cost in cycles needed to make an outbound HTTP call.
 pub const XRC_OUTBOUND_HTTP_CALL_CYCLES_COST: u64 = 2_400_000_000;
+
+/// The amount of cycles refunded off the top of a call. Number will be adjusted based
+/// on the number of sources the canister will use.
+pub const XRC_IMMEDIATE_REFUND_CYCLES: u64 = 5_000_000_000;
 
 /// The base cost in cycles that will always be charged when using the `xrc` canister.
 pub const XRC_BASE_CYCLES_COST: u64 = 200_000_000;


### PR DESCRIPTION
This PR ups the cycle cost for the `get_exchange_rate` endpoint to `10_000_000_000` cycles. `5_000_000_000` is immediately refunded.