### PR TITLE
refactor: Clean up errors from transforms

### DIFF
--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -66,11 +66,11 @@ impl CallExchanges for CallExchangesImpl {
                 Ok(rate) => rates.push(rate),
                 Err(err) => {
                     ic_cdk::println!(
-                        "{} Error while calling for asset {:?} @ {}: {}",
+                        "{} Timestamp: {}, Asset: {:?}, Error: {}",
                         LOG_PREFIX,
-                        asset,
                         timestamp,
-                        err
+                        asset,
+                        err,
                     );
                     errors.push(err);
                 }


### PR DESCRIPTION
This PR removes an unused arm from `CallExchangeError` and provides an error to read format when calling an exchange fails.