### PR TITLE
refactor: Check for cycles earlier in the call.

### DIFF
--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -168,6 +168,10 @@ async fn get_exchange_rate_internal(
         return Err(ExchangeRateError::AnonymousPrincipalNotAllowed);
     }
 
+    if !utils::is_caller_the_cmc(&caller) && !env.has_enough_cycles() {
+        return Err(ExchangeRateError::NotEnoughCycles);
+    }
+
     let sanitized_request = utils::sanitize_request(request);
     let timestamp = utils::get_normalized_timestamp(env, &sanitized_request);
 

--- a/src/xrc/src/environment.rs
+++ b/src/xrc/src/environment.rs
@@ -42,10 +42,15 @@ pub(crate) trait Environment {
         msg_cycles_accept(max_amount)
     }
 
+    /// Checks if the call has enough cycles attached.
+    fn has_enough_cycles(&self) -> bool {
+        self.cycles_available() >= XRC_REQUEST_CYCLES_COST
+    }
+
     /// Checks if enough cycles have been sent as defined by [XRC_REQUEST_CYCLES_COST].
     /// If there are enough cycles, accept the cycles up to the [XRC_REQUEST_CYCLES_COST].
     fn charge_cycles(&self, outbound_rates_needed: usize) -> Result<(), ChargeCyclesError> {
-        if self.cycles_available() < XRC_REQUEST_CYCLES_COST {
+        if !self.has_enough_cycles() {
             return Err(ChargeCyclesError::NotEnoughCycles);
         }
 


### PR DESCRIPTION
This is a minor refactor to have `get_exchange_rate` to exit early if there are not enough cycles attach to the request.