### PR TITLE
feat: Add monitor canister ID to canister_ids.json, update candid, and cycles cost.

### DIFF
--- a/canister_ids.json
+++ b/canister_ids.json
@@ -4,6 +4,7 @@
         "ic": "gvu7d-7aaaa-aaaan-aaaba-cai"
     },
     "monitor-canister": {
-        "local": "r7inp-6aaaa-aaaaa-aaabq-cai"
+        "local": "rrkah-fqaaa-aaaaa-aaaaq-cai",
+        "ic": "fedux-oaaaa-aaaak-ad4sa-cai"
     }
 }

--- a/src/monitor-canister/monitor-canister.did
+++ b/src/monitor-canister/monitor-canister.did
@@ -31,6 +31,8 @@ type ExchangeRate = record {
 };
 
 type ExchangeRateError = variant {
+    // Returned when the canister receives a call from the anonymous principal.
+    AnonymousPrincipalNotAllowed: null;
     // Returned when the base asset rates are not found from the exchanges HTTP outcalls.
     CryptoBaseAssetNotFound: null;
     // Returned when the quote asset rates are not found from the exchanges HTTP outcalls.
@@ -64,13 +66,6 @@ type ExchangeRateError = variant {
         // A description of the error that occurred.
         description: text;
     }
-};
-
-type GetExchangeRateResult = variant {
-    // Successfully retrieved the exchange rate from the cache or API calls.
-    Ok: ExchangeRate;
-    // Failed to retrieve the exchange rate due to invalid API calls, invalid timestamp, etc.
-    Err: opt ExchangeRateError;
 };
 
 type RejectionCode = variant {

--- a/src/monitor-canister/src/periodic.rs
+++ b/src/monitor-canister/src/periodic.rs
@@ -3,6 +3,7 @@ use candid::encode_one;
 use ic_cdk::export::Principal;
 use std::cell::Cell;
 use xrc::candid::{Asset, AssetClass, GetExchangeRateRequest, GetExchangeRateResult};
+use xrc::XRC_REQUEST_CYCLES_COST;
 
 use crate::{
     state::{with_config, with_entries},
@@ -11,7 +12,6 @@ use crate::{
 };
 
 const ONE_MINUTE_SECONDS: u64 = 60;
-const XRC_REQUEST_CYCLES_COST: u64 = 5_000_000_000;
 const NANOS_PER_SEC: u64 = 1_000_000_000;
 
 thread_local! {


### PR DESCRIPTION
This PR updates the monitor canister with the following:

* A canister ID on mainnet.
* The anonymous principal error variant field.
* Updating the amount of cycles to send.