### PR TITLE
feat: Allow the NNS dapp to query rates freely.

### DIFF
--- a/canister_ids.json
+++ b/canister_ids.json
@@ -1,7 +1,7 @@
 {
     "xrc": {
         "local": "rrkah-fqaaa-aaaaa-aaaaq-cai",
-        "ic": "gvu7d-7aaaa-aaaan-aaaba-cai"
+        "ic": "uf6dk-hyaaa-aaaaq-qaaaq-cai"
     },
     "monitor-canister": {
         "local": "rrkah-fqaaa-aaaaa-aaaaq-cai",

--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -135,7 +135,7 @@ pub async fn get_exchange_rate(request: GetExchangeRateRequest) -> GetExchangeRa
     let call_exchanges_impl = CallExchangesImpl;
 
     // Record metrics
-    let is_caller_the_cmc = utils::is_caller_the_cmc(&caller);
+    let is_caller_the_cmc = utils::is_caller_privileged(&caller);
 
     MetricCounter::GetExchangeRateRequest.increment();
     if is_caller_the_cmc {
@@ -168,7 +168,7 @@ async fn get_exchange_rate_internal(
         return Err(ExchangeRateError::AnonymousPrincipalNotAllowed);
     }
 
-    if !utils::is_caller_the_cmc(&caller) && !env.has_enough_cycles() {
+    if !utils::is_caller_privileged(&caller) && !env.has_enough_cycles() {
         return Err(ExchangeRateError::NotEnoughCycles);
     }
 
@@ -277,7 +277,7 @@ async fn handle_cryptocurrency_pair(
         num_rates_needed = num_rates_needed.saturating_add(1);
     }
 
-    if !utils::is_caller_the_cmc(&caller) {
+    if !utils::is_caller_privileged(&caller) {
         let rate_limited = is_rate_limited(num_rates_needed);
         let charge_cycles_option = if rate_limited {
             ChargeOption::MinimumFee
@@ -375,7 +375,7 @@ async fn handle_crypto_base_fiat_quote_pair(
 
     num_rates_needed = num_rates_needed.saturating_add(missed_stablecoin_symbols.len());
 
-    if !utils::is_caller_the_cmc(&caller) {
+    if !utils::is_caller_privileged(&caller) {
         let rate_limited = is_rate_limited(num_rates_needed);
         let charge_cycles_option = if rate_limited {
             ChargeOption::MinimumFee
@@ -470,7 +470,7 @@ fn handle_fiat_pair(
     .map_err(|err| err.into())
     .and_then(validate);
 
-    if !utils::is_caller_the_cmc(&env.caller()) {
+    if !utils::is_caller_privileged(&env.caller()) {
         let charge_option = match result {
             Ok(_) => ChargeOption::BaseCost,
             Err(_) => ChargeOption::MinimumFee,

--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -135,10 +135,10 @@ pub async fn get_exchange_rate(request: GetExchangeRateRequest) -> GetExchangeRa
     let call_exchanges_impl = CallExchangesImpl;
 
     // Record metrics
-    let is_caller_the_cmc = utils::is_caller_privileged(&caller);
+    let is_caller_privileged = utils::is_caller_privileged(&caller);
 
     MetricCounter::GetExchangeRateRequest.increment();
-    if is_caller_the_cmc {
+    if is_caller_privileged {
         MetricCounter::GetExchangeRateRequestFromCmc.increment();
     }
 
@@ -146,7 +146,7 @@ pub async fn get_exchange_rate(request: GetExchangeRateRequest) -> GetExchangeRa
 
     if result.is_err() {
         MetricCounter::ErrorsReturned.increment();
-        if is_caller_the_cmc {
+        if is_caller_privileged {
             MetricCounter::ErrorsReturnedToCmc.increment();
         }
 

--- a/src/xrc/src/api/test.rs
+++ b/src/xrc/src/api/test.rs
@@ -231,7 +231,7 @@ fn get_exchange_rate_fails_when_unable_to_accept_cycles() {
 
 /// This function tests that [get_exchange_rate] does not charge the cycles minting canister for usage.
 #[test]
-fn get_exchange_rate_will_not_charge_cycles_if_caller_is_cmc() {
+fn get_exchange_rate_will_not_charge_cycles_if_caller_is_privileged() {
     let call_exchanges_impl = TestCallExchangesImpl::builder()
         .with_get_cryptocurrency_usdt_rate_responses(hashmap! {
             "BTC".to_string() => Ok(btc_queried_exchange_rate_mock()),

--- a/src/xrc/src/api/test.rs
+++ b/src/xrc/src/api/test.rs
@@ -8,8 +8,8 @@ use crate::{
     candid::{Asset, AssetClass, ExchangeRateError, GetExchangeRateRequest},
     environment::test::TestEnvironment,
     rate_limiting::test::{set_request_counter, REQUEST_COUNTER_TRIGGER_RATE_LIMIT},
-    with_cache_mut, with_forex_rate_store_mut, CallExchangeError, QueriedExchangeRate,
-    CYCLES_MINTING_CANISTER_ID, DAI, EXCHANGES, RATE_UNIT, USD, USDC, XRC_BASE_CYCLES_COST,
+    with_cache_mut, with_forex_rate_store_mut, CallExchangeError, QueriedExchangeRate, DAI,
+    EXCHANGES, PRIVILEGED_CANISTER_IDS, RATE_UNIT, USD, USDC, XRC_BASE_CYCLES_COST,
     XRC_IMMEDIATE_REFUND_CYCLES, XRC_MINIMUM_FEE_COST, XRC_OUTBOUND_HTTP_CALL_CYCLES_COST,
     XRC_REQUEST_CYCLES_COST,
 };
@@ -240,7 +240,7 @@ fn get_exchange_rate_will_not_charge_cycles_if_caller_is_cmc() {
         .build();
     let env = TestEnvironment::builder()
         .with_cycles_available(0)
-        .with_caller(CYCLES_MINTING_CANISTER_ID)
+        .with_caller(PRIVILEGED_CANISTER_IDS[0])
         .build();
     let request = GetExchangeRateRequest {
         base_asset: Asset {

--- a/src/xrc/src/candid.rs
+++ b/src/xrc/src/candid.rs
@@ -83,6 +83,8 @@ pub struct ExchangeRate {
 pub enum ExchangeRateError {
     /// Returned when the canister receives a call from the anonymous principal.
     AnonymousPrincipalNotAllowed,
+    /// Returned when the canister is in process of retrieving a rate from an exchange.
+    Pending,
     /// Returned when the base asset rates are not found from the exchanges HTTP outcalls.
     CryptoBaseAssetNotFound,
     /// Returned when the quote asset rates are not found from the exchanges HTTP outcalls.

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -7,7 +7,7 @@
 
 extern crate lru;
 use lru::LruCache;
-use std::{num::NonZeroUsize, str::FromStr};
+use std::num::NonZeroUsize;
 
 mod api;
 /// This module provides the candid types to be used over the wire.

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -7,7 +7,7 @@
 
 extern crate lru;
 use lru::LruCache;
-use std::num::NonZeroUsize;
+use std::{num::NonZeroUsize, str::FromStr};
 
 mod api;
 /// This module provides the candid types to be used over the wire.
@@ -68,9 +68,12 @@ pub const XRC_BASE_CYCLES_COST: u64 = 200_000_000;
 /// The amount of cycles charged if a call fails (rate limited, failed to find forex rate in store, etc.).
 pub const XRC_MINIMUM_FEE_COST: u64 = 10_000_000;
 
-/// Id of the cycles minting canister on the IC (rkp4c-7iaaa-aaaaa-aaaca-cai).
-const CYCLES_MINTING_CANISTER_ID: Principal =
-    Principal::from_slice(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x01, 0x01]);
+const PRIVILEGED_CANISTER_IDS: [Principal; 2] = [
+    // CMC: rkp4c-7iaaa-aaaaa-aaaca-cai
+    Principal::from_slice(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x01, 0x01]),
+    // NNS dapp: qoctq-giaaa-aaaaa-aaaea-cai
+    Principal::from_slice(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x08, 0x01, 0x01]),
+];
 
 /// The currency symbol for the US dollar.
 const USD: &str = "USD";

--- a/src/xrc/src/utils.rs
+++ b/src/xrc/src/utils.rs
@@ -1,7 +1,7 @@
 use crate::{
     candid::{Asset, GetExchangeRateRequest},
     environment::Environment,
-    CYCLES_MINTING_CANISTER_ID, RATE_UNIT,
+    PRIVILEGED_CANISTER_IDS, RATE_UNIT,
 };
 use ic_cdk::export::Principal;
 
@@ -100,8 +100,8 @@ pub(crate) fn is_caller_anonymous(caller: &Principal) -> bool {
 }
 
 /// Checks if the caller's principal ID belongs to the Cycles Minting Canister.
-pub(crate) fn is_caller_the_cmc(caller: &Principal) -> bool {
-    *caller == CYCLES_MINTING_CANISTER_ID
+pub(crate) fn is_caller_privileged(caller: &Principal) -> bool {
+    PRIVILEGED_CANISTER_IDS.contains(caller)
 }
 
 /// Inverts a given rate.
@@ -131,7 +131,14 @@ pub(crate) mod test {
     fn cycles_minting_canister_id_is_correct() {
         let principal_from_text = Principal::from_text("rkp4c-7iaaa-aaaaa-aaaca-cai")
             .expect("should be a valid textual principal ID");
-        assert!(is_caller_the_cmc(&principal_from_text));
+        assert!(is_caller_privileged(&principal_from_text));
+    }
+
+    #[test]
+    fn nns_dapp_id_is_correct() {
+        let principal_from_text = Principal::from_text("qoctq-giaaa-aaaaa-aaaea-cai")
+            .expect("should be a valid textual principal ID");
+        assert!(is_caller_privileged(&principal_from_text));
     }
 
     #[test]

--- a/src/xrc/xrc.did
+++ b/src/xrc/xrc.did
@@ -34,6 +34,8 @@ type ExchangeRate = record {
 type ExchangeRateError = variant {
     // Returned when the canister receives a call from the anonymous principal.
     AnonymousPrincipalNotAllowed: null;
+    /// Returned when the canister is in process of retrieving a rate from an exchange.
+    Pending: null;
     // Returned when the base asset rates are not found from the exchanges HTTP outcalls.
     CryptoBaseAssetNotFound: null;
     // Returned when the quote asset rates are not found from the exchanges HTTP outcalls.


### PR DESCRIPTION
This PR allows the NNS dapp to query rates freely from the XRC. It also adds the `Pending` error variant as the canister will likely be deployed before the `Pending Request` feature makes it in.