### PR TITLE
feat: Add the ability to mark requests as pending

### DIFF
--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -8,7 +8,7 @@ use crate::{
     call_exchange,
     candid::{Asset, AssetClass, ExchangeRateError, GetExchangeRateRequest, GetExchangeRateResult},
     environment::{CanisterEnvironment, ChargeOption, Environment},
-    inflight::{is_inflight, with_inflight},
+    inflight::{is_inflight, with_inflight_tracking},
     rate_limiting::{is_rate_limited, with_request_counter},
     stablecoin, utils, with_cache_mut, with_forex_rate_store, CallExchangeArgs, CallExchangeError,
     Exchange, MetricCounter, QueriedExchangeRate, DAI, EXCHANGES, LOG_PREFIX, USD, USDC, USDT,
@@ -303,7 +303,7 @@ async fn handle_cryptocurrency_pair(
             / maybe_quote_rate.expect("rate should exist"));
     }
 
-    with_inflight(
+    with_inflight_tracking(
         vec![base_asset.symbol.clone(), quote_asset.symbol.clone()],
         timestamp,
         with_request_counter(num_rates_needed, async move {
@@ -412,7 +412,7 @@ async fn handle_crypto_base_fiat_quote_pair(
     }
 
     let base_asset = base_asset.clone();
-    with_inflight(
+    with_inflight_tracking(
         vec![base_asset.symbol.clone()],
         timestamp,
         with_request_counter(num_rates_needed, async move {

--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -281,7 +281,7 @@ async fn handle_cryptocurrency_pair(
     if !utils::is_caller_privileged(&caller) {
         let rate_limited = is_rate_limited(num_rates_needed);
         let already_inflight =
-            is_inflight(&base_asset, timestamp) || is_inflight(&quote_asset, timestamp);
+            is_inflight(base_asset, timestamp) || is_inflight(quote_asset, timestamp);
         let charge_cycles_option = if rate_limited || already_inflight {
             ChargeOption::MinimumFee
         } else {
@@ -311,7 +311,7 @@ async fn handle_cryptocurrency_pair(
                 Some(base_rate) => base_rate,
                 None => {
                     let base_rate = call_exchanges_impl
-                        .get_cryptocurrency_usdt_rate(&base_asset, timestamp)
+                        .get_cryptocurrency_usdt_rate(base_asset, timestamp)
                         .await
                         .map_err(|_| ExchangeRateError::CryptoBaseAssetNotFound)?;
                     with_cache_mut(|cache| {
@@ -325,7 +325,7 @@ async fn handle_cryptocurrency_pair(
                 Some(quote_rate) => quote_rate,
                 None => {
                     let quote_rate = call_exchanges_impl
-                        .get_cryptocurrency_usdt_rate(&quote_asset, timestamp)
+                        .get_cryptocurrency_usdt_rate(quote_asset, timestamp)
                         .await
                         .map_err(|_| ExchangeRateError::CryptoQuoteAssetNotFound)?;
                     with_cache_mut(|cache| {
@@ -386,7 +386,7 @@ async fn handle_crypto_base_fiat_quote_pair(
 
     if !utils::is_caller_privileged(&caller) {
         let rate_limited = is_rate_limited(num_rates_needed);
-        let already_inflight = is_inflight(&base_asset, timestamp);
+        let already_inflight = is_inflight(base_asset, timestamp);
         let charge_cycles_option = if rate_limited || already_inflight {
             ChargeOption::MinimumFee
         } else {

--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -8,6 +8,7 @@ use crate::{
     call_exchange,
     candid::{Asset, AssetClass, ExchangeRateError, GetExchangeRateRequest, GetExchangeRateResult},
     environment::{CanisterEnvironment, ChargeOption, Environment},
+    inflight::{is_inflight, with_inflight},
     rate_limiting::{is_rate_limited, with_request_counter},
     stablecoin, utils, with_cache_mut, with_forex_rate_store, CallExchangeArgs, CallExchangeError,
     Exchange, MetricCounter, QueriedExchangeRate, DAI, EXCHANGES, LOG_PREFIX, USD, USDC, USDT,
@@ -279,7 +280,9 @@ async fn handle_cryptocurrency_pair(
 
     if !utils::is_caller_privileged(&caller) {
         let rate_limited = is_rate_limited(num_rates_needed);
-        let charge_cycles_option = if rate_limited {
+        let already_inflight =
+            is_inflight(&base_asset, timestamp) || is_inflight(&quote_asset, timestamp);
+        let charge_cycles_option = if rate_limited || already_inflight {
             ChargeOption::MinimumFee
         } else {
             ChargeOption::OutboundRatesNeeded(num_rates_needed)
@@ -287,6 +290,10 @@ async fn handle_cryptocurrency_pair(
         env.charge_cycles(charge_cycles_option)?;
         if rate_limited {
             return Err(ExchangeRateError::RateLimited);
+        }
+
+        if already_inflight {
+            return Err(ExchangeRateError::Pending);
         }
     }
 
@@ -296,39 +303,41 @@ async fn handle_cryptocurrency_pair(
             / maybe_quote_rate.expect("rate should exist"));
     }
 
-    let base_asset = base_asset.clone();
-    let quote_asset = quote_asset.clone();
-    with_request_counter(num_rates_needed, async move {
-        let base_rate = match maybe_base_rate {
-            Some(base_rate) => base_rate,
-            None => {
-                let base_rate = call_exchanges_impl
-                    .get_cryptocurrency_usdt_rate(&base_asset, timestamp)
-                    .await
-                    .map_err(|_| ExchangeRateError::CryptoBaseAssetNotFound)?;
-                with_cache_mut(|cache| {
-                    cache.put((base_asset.symbol.clone(), timestamp), base_rate.clone());
-                });
-                base_rate
-            }
-        };
+    with_inflight(
+        vec![base_asset.symbol.clone(), quote_asset.symbol.clone()],
+        timestamp,
+        with_request_counter(num_rates_needed, async move {
+            let base_rate = match maybe_base_rate {
+                Some(base_rate) => base_rate,
+                None => {
+                    let base_rate = call_exchanges_impl
+                        .get_cryptocurrency_usdt_rate(&base_asset, timestamp)
+                        .await
+                        .map_err(|_| ExchangeRateError::CryptoBaseAssetNotFound)?;
+                    with_cache_mut(|cache| {
+                        cache.put((base_asset.symbol.clone(), timestamp), base_rate.clone());
+                    });
+                    base_rate
+                }
+            };
 
-        let quote_rate = match maybe_quote_rate {
-            Some(quote_rate) => quote_rate,
-            None => {
-                let quote_rate = call_exchanges_impl
-                    .get_cryptocurrency_usdt_rate(&quote_asset, timestamp)
-                    .await
-                    .map_err(|_| ExchangeRateError::CryptoQuoteAssetNotFound)?;
-                with_cache_mut(|cache| {
-                    cache.put((quote_asset.symbol.clone(), timestamp), quote_rate.clone());
-                });
-                quote_rate
-            }
-        };
+            let quote_rate = match maybe_quote_rate {
+                Some(quote_rate) => quote_rate,
+                None => {
+                    let quote_rate = call_exchanges_impl
+                        .get_cryptocurrency_usdt_rate(&quote_asset, timestamp)
+                        .await
+                        .map_err(|_| ExchangeRateError::CryptoQuoteAssetNotFound)?;
+                    with_cache_mut(|cache| {
+                        cache.put((quote_asset.symbol.clone(), timestamp), quote_rate.clone());
+                    });
+                    quote_rate
+                }
+            };
 
-        validate(base_rate / quote_rate)
-    })
+            validate(base_rate / quote_rate)
+        }),
+    )
     .await
 }
 
@@ -377,7 +386,8 @@ async fn handle_crypto_base_fiat_quote_pair(
 
     if !utils::is_caller_privileged(&caller) {
         let rate_limited = is_rate_limited(num_rates_needed);
-        let charge_cycles_option = if rate_limited {
+        let already_inflight = is_inflight(&base_asset, timestamp);
+        let charge_cycles_option = if rate_limited || already_inflight {
             ChargeOption::MinimumFee
         } else {
             ChargeOption::OutboundRatesNeeded(num_rates_needed)
@@ -385,6 +395,10 @@ async fn handle_crypto_base_fiat_quote_pair(
         env.charge_cycles(charge_cycles_option)?;
         if rate_limited {
             return Err(ExchangeRateError::RateLimited);
+        }
+
+        if already_inflight {
+            return Err(ExchangeRateError::Pending);
         }
     }
 
@@ -398,57 +412,61 @@ async fn handle_crypto_base_fiat_quote_pair(
     }
 
     let base_asset = base_asset.clone();
-    with_request_counter(num_rates_needed, async move {
-        // Retrieve the missing stablecoin results. For each rate retrieved, cache it and add it to the
-        // stablecoin rates vector.
-        let stablecoin_results = call_exchanges_impl
-            .get_stablecoin_rates(&missed_stablecoin_symbols, timestamp)
-            .await;
+    with_inflight(
+        vec![base_asset.symbol.clone()],
+        timestamp,
+        with_request_counter(num_rates_needed, async move {
+            // Retrieve the missing stablecoin results. For each rate retrieved, cache it and add it to the
+            // stablecoin rates vector.
+            let stablecoin_results = call_exchanges_impl
+                .get_stablecoin_rates(&missed_stablecoin_symbols, timestamp)
+                .await;
 
-        stablecoin_results
-            .iter()
-            .zip(missed_stablecoin_symbols)
-            .for_each(|(result, symbol)| match result {
-                Ok(rate) => {
-                    stablecoin_rates.push(rate.clone());
-                    with_cache_mut(|cache| {
-                        cache.put((rate.base_asset.symbol.clone(), timestamp), rate.clone());
-                    });
-                }
-                Err(error) => {
-                    ic_cdk::println!(
-                        "{} Error while retrieving {} rates @ {}: {}",
-                        LOG_PREFIX,
-                        symbol,
-                        timestamp,
-                        error
-                    );
-                }
-            });
-
-        let crypto_base_rate = match maybe_crypto_base_rate {
-            Some(base_rate) => base_rate,
-            None => {
-                let base_rate = call_exchanges_impl
-                    .get_cryptocurrency_usdt_rate(&base_asset, timestamp)
-                    .await
-                    .map_err(|_| ExchangeRateError::CryptoBaseAssetNotFound)?;
-                with_cache_mut(|cache| {
-                    cache.put(
-                        (base_rate.base_asset.symbol.clone(), timestamp),
-                        base_rate.clone(),
-                    );
+            stablecoin_results
+                .iter()
+                .zip(missed_stablecoin_symbols)
+                .for_each(|(result, symbol)| match result {
+                    Ok(rate) => {
+                        stablecoin_rates.push(rate.clone());
+                        with_cache_mut(|cache| {
+                            cache.put((rate.base_asset.symbol.clone(), timestamp), rate.clone());
+                        });
+                    }
+                    Err(error) => {
+                        ic_cdk::println!(
+                            "{} Error while retrieving {} rates @ {}: {}",
+                            LOG_PREFIX,
+                            symbol,
+                            timestamp,
+                            error
+                        );
+                    }
                 });
-                base_rate
-            }
-        };
 
-        let stablecoin_rate = stablecoin::get_stablecoin_rate(&stablecoin_rates, &usd_asset())
-            .map_err(ExchangeRateError::from)?;
-        let crypto_usd_base_rate = crypto_base_rate * stablecoin_rate;
+            let crypto_base_rate = match maybe_crypto_base_rate {
+                Some(base_rate) => base_rate,
+                None => {
+                    let base_rate = call_exchanges_impl
+                        .get_cryptocurrency_usdt_rate(&base_asset, timestamp)
+                        .await
+                        .map_err(|_| ExchangeRateError::CryptoBaseAssetNotFound)?;
+                    with_cache_mut(|cache| {
+                        cache.put(
+                            (base_rate.base_asset.symbol.clone(), timestamp),
+                            base_rate.clone(),
+                        );
+                    });
+                    base_rate
+                }
+            };
 
-        validate(crypto_usd_base_rate / forex_rate)
-    })
+            let stablecoin_rate = stablecoin::get_stablecoin_rate(&stablecoin_rates, &usd_asset())
+                .map_err(ExchangeRateError::from)?;
+            let crypto_usd_base_rate = crypto_base_rate * stablecoin_rate;
+
+            validate(crypto_usd_base_rate / forex_rate)
+        }),
+    )
     .await
 }
 

--- a/src/xrc/src/inflight.rs
+++ b/src/xrc/src/inflight.rs
@@ -1,0 +1,62 @@
+use std::{
+    cell::RefCell,
+    collections::{HashMap, HashSet},
+};
+
+use crate::{candid::ExchangeRateError, QueriedExchangeRate};
+
+type InflightCryptoUsdtRequests = HashSet<(String, u64)>;
+
+thread_local! {
+    static INFLIGHT_CRYPTO_USDT_RATE_REQUESTS: RefCell<InflightCryptoUsdtRequests> = RefCell::new(HashSet::new());
+}
+
+fn contains(key: &(String, u64)) -> bool {
+    INFLIGHT_CRYPTO_USDT_RATE_REQUESTS.with(|cell| cell.borrow().contains(key))
+}
+
+fn add(key: (String, u64)) {
+    INFLIGHT_CRYPTO_USDT_RATE_REQUESTS.with(|cell| {
+        cell.borrow_mut().insert(key);
+    });
+}
+
+fn remove(key: &(String, u64)) {
+    INFLIGHT_CRYPTO_USDT_RATE_REQUESTS.with(|cell| {
+        cell.borrow_mut().remove(key);
+    });
+}
+
+pub(crate) async fn with_crypto_exchanges<F>(
+    symbol: String,
+    timestamp: u64,
+    future: F,
+) -> Result<QueriedExchangeRate, ExchangeRateError>
+where
+    F: std::future::Future<Output = Result<QueriedExchangeRate, ExchangeRateError>>,
+{
+    let key = (symbol, timestamp);
+    if contains(&key) {
+        return Err(ExchangeRateError::RateLimited);
+    }
+
+    let _guard = InflightCryptoUsdtRequestsGuard::new(key);
+    future.await
+}
+
+struct InflightCryptoUsdtRequestsGuard {
+    key: (String, u64),
+}
+
+impl InflightCryptoUsdtRequestsGuard {
+    fn new(key: (String, u64)) -> Self {
+        add(key.clone());
+        Self { key }
+    }
+}
+
+impl Drop for InflightCryptoUsdtRequestsGuard {
+    fn drop(&mut self) {
+        remove(&self.key);
+    }
+}

--- a/src/xrc/src/inflight.rs
+++ b/src/xrc/src/inflight.rs
@@ -1,51 +1,49 @@
-use std::{
-    cell::RefCell,
-    collections::{HashMap, HashSet},
-};
+use std::{cell::RefCell, collections::HashSet};
 
 use crate::{
     candid::{Asset, ExchangeRateError},
-    CallExchangeError, QueriedExchangeRate,
+    QueriedExchangeRate,
 };
 
+/// A key contains the symbol and the timestamp.
 type Key = (String, u64);
+///
 type InflightCryptoUsdtRequests = HashSet<Key>;
 
 thread_local! {
+    /// Contains the symbol-timestamp pairs that are currently being requested using HTTP outcalls.
     static INFLIGHT_CRYPTO_USDT_RATE_REQUESTS: RefCell<InflightCryptoUsdtRequests> = RefCell::new(HashSet::new());
 }
 
+/// Checks if the symbol-timestamp pair is in the set.
 fn contains(key: &Key) -> bool {
     INFLIGHT_CRYPTO_USDT_RATE_REQUESTS.with(|cell| cell.borrow().contains(key))
 }
 
-fn contains_any(symbols: &[String], timestamp: u64) -> bool {
-    INFLIGHT_CRYPTO_USDT_RATE_REQUESTS.with(|cell| {
-        let borrowed = cell.borrow();
-        symbols
-            .iter()
-            .any(|symbol| borrowed.contains(&(symbol.clone(), timestamp)))
-    })
-}
-
+/// Adds a symbol-timestamp pair to the set.
 fn add(key: Key) {
     INFLIGHT_CRYPTO_USDT_RATE_REQUESTS.with(|cell| {
         cell.borrow_mut().insert(key);
     });
 }
 
+/// Removes a symbol-timestamp pair from the set.
 fn remove(key: &Key) {
     INFLIGHT_CRYPTO_USDT_RATE_REQUESTS.with(|cell| {
         cell.borrow_mut().remove(key);
     });
 }
 
+/// Provides a simple interface for the rest of the canister to be able to check
+/// if an asset-timestamp pair is in the state.
 pub(crate) fn is_inflight(asset: &Asset, timestamp: u64) -> bool {
     let key = (asset.symbol.clone(), timestamp);
     contains(&key)
 }
 
-pub(crate) async fn with_inflight<F>(
+/// Used to wrap around the HTTP outcalls so that the canister can avoid sending
+/// similar requests to crypto exchanges.
+pub(crate) async fn with_inflight_tracking<F>(
     symbols: Vec<String>,
     timestamp: u64,
     future: F,
@@ -53,20 +51,20 @@ pub(crate) async fn with_inflight<F>(
 where
     F: std::future::Future<Output = Result<QueriedExchangeRate, ExchangeRateError>>,
 {
-    if contains_any(&symbols, timestamp) {
-        return Err(ExchangeRateError::Pending);
-    }
-
-    let _guard = NewInflightCryptoUsdtRequestsGuard::new(symbols, timestamp);
+    // Need to set the guard to maintain the lifetime until the future is complete.
+    let _guard = InflightCryptoUsdtRequestsGuard::new(symbols, timestamp);
     future.await
 }
 
-struct NewInflightCryptoUsdtRequestsGuard {
+/// Guard to ensure that the tracking set adds and removes symbol-timestamp pairs
+/// correctly.
+struct InflightCryptoUsdtRequestsGuard {
     symbols: Vec<String>,
     timestamp: u64,
 }
 
-impl NewInflightCryptoUsdtRequestsGuard {
+impl InflightCryptoUsdtRequestsGuard {
+    /// Adds all symbols paired to a given timestamp to the tracking set.
     fn new(symbols: Vec<String>, timestamp: u64) -> Self {
         for symbol in &symbols {
             add((symbol.clone(), timestamp));
@@ -75,7 +73,8 @@ impl NewInflightCryptoUsdtRequestsGuard {
     }
 }
 
-impl Drop for NewInflightCryptoUsdtRequestsGuard {
+impl Drop for InflightCryptoUsdtRequestsGuard {
+    /// Removes all symbols paired to a given timestamp to the tracking set.
     fn drop(&mut self) {
         for symbol in &self.symbols {
             remove(&(symbol.clone(), self.timestamp));

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -7,7 +7,10 @@
 
 extern crate lru;
 use lru::LruCache;
-use std::num::NonZeroUsize;
+use std::{
+    collections::{BTreeSet, HashSet},
+    num::NonZeroUsize,
+};
 
 mod api;
 /// This module provides the candid types to be used over the wire.
@@ -18,6 +21,7 @@ mod http;
 mod stablecoin;
 
 mod environment;
+mod inflight;
 mod periodic;
 mod rate_limiting;
 /// This module provides types for responding to HTTP requests for metrics.
@@ -105,6 +109,7 @@ thread_local! {
 
     static FOREX_RATE_STORE: RefCell<ForexRateStore> = RefCell::new(ForexRateStore::new());
     static FOREX_RATE_COLLECTOR: RefCell<ForexRatesCollector> = RefCell::new(ForexRatesCollector::new());
+
 
     /// The counter used to determine if a request should be rate limited or not.
     static RATE_LIMITING_REQUEST_COUNTER: Cell<usize> = Cell::new(0);

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -7,10 +7,7 @@
 
 extern crate lru;
 use lru::LruCache;
-use std::{
-    collections::{BTreeSet, HashSet},
-    num::NonZeroUsize,
-};
+use std::num::NonZeroUsize;
 
 mod api;
 /// This module provides the candid types to be used over the wire.
@@ -112,7 +109,6 @@ thread_local! {
 
     static FOREX_RATE_STORE: RefCell<ForexRateStore> = RefCell::new(ForexRateStore::new());
     static FOREX_RATE_COLLECTOR: RefCell<ForexRatesCollector> = RefCell::new(ForexRatesCollector::new());
-
 
     /// The counter used to determine if a request should be rate limited or not.
     static RATE_LIMITING_REQUEST_COUNTER: Cell<usize> = Cell::new(0);

--- a/src/xrc/src/rate_limiting.rs
+++ b/src/xrc/src/rate_limiting.rs
@@ -15,6 +15,11 @@ pub(crate) async fn with_request_counter<F>(
 where
     F: std::future::Future<Output = Result<QueriedExchangeRate, ExchangeRateError>>,
 {
+    // For safety purposes, we should also check here as we do not want misuse of the function.
+    if is_rate_limited(num_rates_needed) {
+        return Err(ExchangeRateError::RateLimited);
+    }
+
     // Need to set the guard to maintain the lifetime until the future is complete.
     let _guard = RateLimitingRequestCounterGuard::new(num_rates_needed);
     future.await

--- a/src/xrc/src/rate_limiting.rs
+++ b/src/xrc/src/rate_limiting.rs
@@ -15,11 +15,6 @@ pub(crate) async fn with_request_counter<F>(
 where
     F: std::future::Future<Output = Result<QueriedExchangeRate, ExchangeRateError>>,
 {
-    // For safety purposes, we should also check here as we do not want misuse of the function.
-    if is_rate_limited(num_rates_needed) {
-        return Err(ExchangeRateError::RateLimited);
-    }
-
     // Need to set the guard to maintain the lifetime until the future is complete.
     let _guard = RateLimitingRequestCounterGuard::new(num_rates_needed);
     future.await


### PR DESCRIPTION
This PR adds the ability to track pending requests. A request is determined as `pending` when one of the assets is currently in process of being retrieved from the exchanges.

For example, the XRC receives a request `X` for `ICP/BTC` at timestamp `100`. While the XRC starts processing request `X`, another request (`Y`) for `BTC/USDT` at timestamp `100` is received. The XRC canister adds the following symbol-timestamp pairs to the tracking set from request `X`: 
`("ICP", 100)` and `("BTC", 100)`. 

While waiting for request `X`'s results, the XRC begins to process request `Y`. As request `Y` contains the symbol-timestamp pair `("BTC", 100)`, request `Y` is determined to be `pending` and the `Pending` error is returned to the user.