### PR TITLE
Changing the behavior when no timestamp is provided in a request

### DIFF
--- a/src/xrc/src/utils.rs
+++ b/src/xrc/src/utils.rs
@@ -68,13 +68,14 @@ pub(crate) fn standard_deviation(rates: &[u64]) -> u64 {
 }
 
 /// Pulls the timestamp from a rate request. If the timestamp is not set,
-/// pulls the latest IC time and normalizes the timestamp to the most recent
-/// minute.
+/// pulls the latest IC time and normalizes the timestamp by setting it to the
+/// start of the most recent minute if 30 seconds or more have already passed. Otherwise,
+/// the timestamp is set to the start of the previous minute.
 pub(crate) fn get_normalized_timestamp(
     env: &impl Environment,
     request: &GetExchangeRateRequest,
 ) -> u64 {
-    (request.timestamp.unwrap_or_else(|| env.time_secs()) / 60) * 60
+    (request.timestamp.unwrap_or_else(|| env.time_secs() - 30) / 60) * 60
 }
 
 /// Sanitizes a [GetExchangeRateRequest] to clean up the following:

--- a/src/xrc/src/utils.rs
+++ b/src/xrc/src/utils.rs
@@ -75,7 +75,7 @@ pub(crate) fn get_normalized_timestamp(
     env: &impl Environment,
     request: &GetExchangeRateRequest,
 ) -> u64 {
-    (request.timestamp.unwrap_or_else(|| env.time_secs() - 30) / 60) * 60
+    (request.timestamp.unwrap_or_else(|| env.time_secs().saturating_sub(30)) / 60) * 60
 }
 
 /// Sanitizes a [GetExchangeRateRequest] to clean up the following:


### PR DESCRIPTION
Currently, if a request doesn't specify a timestamp, the start of the most recent minute is used as the timestamp.
Since it takes some time for exchanges to offer data for the current minute, this approach results in many failed calls.

This PR changes the behavior: The start of the current minute is only used if at least 30 seconds have passed. Otherwise, the start of the previous minute is used.