### PR TITLE
feat: Add crypto/USDT unit test

### DIFF
--- a/src/xrc/src/api/test.rs
+++ b/src/xrc/src/api/test.rs
@@ -868,7 +868,7 @@ fn get_exchange_rate_will_retrieve_rates_if_inflight_tracking_contains_any_symbo
     assert!(matches!(result, Err(ExchangeRateError::Pending)));
 }
 
-/// This function tests that [get_exchange_rate] can retrieve */USDT rates with one set of outbound
+/// This function tests that [get_exchange_rate] can retrieve crypto/USDT rates with one set of outbound
 /// calls.
 #[test]
 fn get_exchange_rate_can_retrieve_icp_usdt() {

--- a/src/xrc/src/api/test.rs
+++ b/src/xrc/src/api/test.rs
@@ -906,3 +906,42 @@ fn get_exchange_rate_can_retrieve_icp_usdt() {
         1
     );
 }
+
+/// This function tests that [get_exchange_rate] can retrieve USDT/crypto rates with one set of outbound
+/// calls.
+#[test]
+fn get_exchange_rate_can_retrieve_usdt_icp() {
+    let call_exchanges_impl = TestCallExchangesImpl::builder()
+        .with_get_cryptocurrency_usdt_rate_responses(hashmap! {
+            "ICP".to_string() => Ok(icp_queried_exchange_rate_mock())
+        })
+        .build();
+    let env = TestEnvironment::builder()
+        .with_cycles_available(XRC_REQUEST_CYCLES_COST)
+        .with_accepted_cycles(XRC_BASE_CYCLES_COST + XRC_OUTBOUND_HTTP_CALL_CYCLES_COST)
+        .build();
+    let request = GetExchangeRateRequest {
+        base_asset: Asset {
+            symbol: "USDT".to_string(),
+            class: AssetClass::Cryptocurrency,
+        },
+        quote_asset: Asset {
+            symbol: "ICP".to_string(),
+            class: AssetClass::Cryptocurrency,
+        },
+        timestamp: Some(0),
+    };
+
+    let result = get_exchange_rate_internal(&env, &call_exchanges_impl, &request)
+        .now_or_never()
+        .expect("future should complete");
+    assert!(matches!(result, Ok(rate) if rate.quote_asset.symbol == "ICP"));
+    assert_eq!(
+        call_exchanges_impl
+            .get_cryptocurrency_usdt_rate_calls
+            .read()
+            .unwrap()
+            .len(),
+        1
+    );
+}


### PR DESCRIPTION
This PR adds a unit test when a `crypto/USDT` pair is requested. The intended functionality is that the canister will only call for the `crypto/USDT` from the exchanges as `USDT` is the base unit.