### PR TITLE
feat: Allow e2e-tests to take arguments so one test can be ran easily

### DIFF
--- a/scripts/e2e-tests
+++ b/scripts/e2e-tests
@@ -5,6 +5,22 @@
 # Builds the wasm locally, the e2e base image, moves the wasm to the
 # appropriate location, and runs the tests
 
+name=''
+
+help() {
+  echo "Usage: ..."
+}
+
+while getopts 'hn:' flag; do
+  case "${flag}" in
+    n) name="${OPTARG}" ;;
+    h) help
+       exit 1 ;;
+    *) help
+       exit 1 ;;
+  esac
+done
+
 # Build the wasm without needing a canister
 dfx build --check xrc
 # Build the e2e base image
@@ -13,4 +29,4 @@ docker-compose -f src/xrc-tests/docker/docker-compose.yml build base
 mkdir -p src/xrc-tests/gen/canister
 cp target/wasm32-unknown-unknown/release/xrc.wasm src/xrc-tests/gen/canister
 # Run the system tests
-cargo test --tests --package xrc-tests -- --ignored --show-output
+cargo test --tests --package xrc-tests -- --ignored --show-output $name

--- a/scripts/e2e-tests
+++ b/scripts/e2e-tests
@@ -8,7 +8,9 @@
 name=''
 
 help() {
-  echo "Usage: ..."
+  echo "Usage:"
+  echo "    To run all tests:       ./scripts/e2e-tests"
+  echo "    To run a singular test: ./scripts/e2e-tests -n test_name_here"
 }
 
 while getopts 'hn:' flag; do


### PR DESCRIPTION
This PR adds the ability to `./scripts/e2e-tests` to run a singular test. During development of new `e2e` tests, it is generally painful to run a singular test. This is addressed by giving the option to add a flag (`n`) to provide a name of the test that a user wants to run.

Example: `./scripts/e2e-tests -n test_name_here`