### PR TITLE
chore: Move `can_successfully_retrieve_rate` test to separate module

### DIFF
--- a/src/xrc-tests/src/tests.rs
+++ b/src/xrc-tests/src/tests.rs
@@ -1,3 +1,5 @@
+mod can_successfully_retrieve_rate;
+
 use std::time::Instant;
 
 use serde_json::json;
@@ -66,62 +68,6 @@ fn build_response(
         .url(exchange.get_url(&asset.symbol, &usdt_asset().symbol, timestamp))
         .json(json)
         .build()
-}
-
-/// This test is used to confirm that the exchange rate canister can receive
-/// a request to the `get_exchange_rate` endpoint and successfully return a
-/// computed rate for the provided assets.
-#[ignore]
-#[test]
-fn can_successfully_retrieve_rate() {
-    let timestamp = 1614596340;
-    let request = GetExchangeRateRequest {
-        timestamp: Some(timestamp),
-        quote_asset: Asset {
-            symbol: "BTC".to_string(),
-            class: AssetClass::Cryptocurrency,
-        },
-        base_asset: Asset {
-            symbol: "ICP".to_string(),
-            class: AssetClass::Cryptocurrency,
-        },
-    };
-
-    let responses = EXCHANGES
-        .iter()
-        .flat_map(|exchange| {
-            let json = get_sample_json_for_exchange(exchange);
-            [
-                build_response(exchange, &request.base_asset, timestamp, json.clone()),
-                build_response(exchange, &request.quote_asset, timestamp, json),
-            ]
-        })
-        .collect::<Vec<_>>();
-
-    let container = Container::builder()
-        .name("can_successfully_retrieve_rate")
-        .exchange_responses(responses)
-        .build();
-
-    let request_ = request.clone();
-    let exchange_rate_result = run_scenario(container, |container: &Container| {
-        Ok(container
-            .call_canister::<_, GetExchangeRateResult>("get_exchange_rate", request_)
-            .expect("Failed to call canister for rates"))
-    })
-    .expect("Scenario failed");
-
-    let exchange_rate =
-        exchange_rate_result.expect("Failed to retrieve an exchange rate from the canister.");
-    assert_eq!(exchange_rate.base_asset, request.base_asset);
-    assert_eq!(exchange_rate.quote_asset, request.quote_asset);
-    assert_eq!(exchange_rate.timestamp, timestamp);
-    assert_eq!(exchange_rate.metadata.base_asset_num_queried_sources, 6);
-    assert_eq!(exchange_rate.metadata.base_asset_num_received_rates, 6);
-    assert_eq!(exchange_rate.metadata.quote_asset_num_queried_sources, 6);
-    assert_eq!(exchange_rate.metadata.quote_asset_num_received_rates, 6);
-    assert_eq!(exchange_rate.metadata.standard_deviation, 50499737);
-    assert_eq!(exchange_rate.rate, 999999986);
 }
 
 /// This test is used to confirm that the exchange rate canister's cache is

--- a/src/xrc-tests/src/tests/can_successfully_retrieve_rate.rs
+++ b/src/xrc-tests/src/tests/can_successfully_retrieve_rate.rs
@@ -1,0 +1,65 @@
+use xrc::{
+    candid::{Asset, AssetClass, GetExchangeRateRequest, GetExchangeRateResult},
+    EXCHANGES,
+};
+
+use crate::{
+    container::{run_scenario, Container},
+    tests::{build_response, get_sample_json_for_exchange},
+};
+
+/// This test is used to confirm that the exchange rate canister can receive
+/// a request to the `get_exchange_rate` endpoint and successfully return a
+/// computed rate for the provided assets.
+#[ignore]
+#[test]
+fn can_successfully_retrieve_rate() {
+    let timestamp = 1614596340;
+    let request = GetExchangeRateRequest {
+        timestamp: Some(timestamp),
+        quote_asset: Asset {
+            symbol: "BTC".to_string(),
+            class: AssetClass::Cryptocurrency,
+        },
+        base_asset: Asset {
+            symbol: "ICP".to_string(),
+            class: AssetClass::Cryptocurrency,
+        },
+    };
+
+    let responses = EXCHANGES
+        .iter()
+        .flat_map(|exchange| {
+            let json = get_sample_json_for_exchange(exchange);
+            [
+                build_response(exchange, &request.base_asset, timestamp, json.clone()),
+                build_response(exchange, &request.quote_asset, timestamp, json),
+            ]
+        })
+        .collect::<Vec<_>>();
+
+    let container = Container::builder()
+        .name("can_successfully_retrieve_rate")
+        .exchange_responses(responses)
+        .build();
+
+    let request_ = request.clone();
+    let exchange_rate_result = run_scenario(container, |container: &Container| {
+        Ok(container
+            .call_canister::<_, GetExchangeRateResult>("get_exchange_rate", request_)
+            .expect("Failed to call canister for rates"))
+    })
+    .expect("Scenario failed");
+
+    let exchange_rate =
+        exchange_rate_result.expect("Failed to retrieve an exchange rate from the canister.");
+    assert_eq!(exchange_rate.base_asset, request.base_asset);
+    assert_eq!(exchange_rate.quote_asset, request.quote_asset);
+    assert_eq!(exchange_rate.timestamp, timestamp);
+    assert_eq!(exchange_rate.metadata.base_asset_num_queried_sources, 6);
+    assert_eq!(exchange_rate.metadata.base_asset_num_received_rates, 6);
+    assert_eq!(exchange_rate.metadata.quote_asset_num_queried_sources, 6);
+    assert_eq!(exchange_rate.metadata.quote_asset_num_received_rates, 6);
+    assert_eq!(exchange_rate.metadata.standard_deviation, 50499737);
+    assert_eq!(exchange_rate.rate, 999999986);
+}


### PR DESCRIPTION
This PR moves the `can_successfully_retrieve_rate` test to a separate module. As we add additional `e2e` tests, the singular `tests` module will become quite cluttered. This is the first PR to address that.