### PR TITLE
refactor: Allow e2e tests to have different response bodies beyond JSON.

### DIFF
--- a/src/xrc-tests/src/container.rs
+++ b/src/xrc-tests/src/container.rs
@@ -21,8 +21,8 @@ pub struct ExchangeResponse {
     pub url: String,
     /// The HTTP status code of the response.
     pub status_code: u16,
-    /// A JSON body that the response may serve.
-    pub maybe_json: Option<serde_json::Value>,
+    /// A body that the response may serve.
+    pub maybe_body: Option<ResponseBody>,
     /// A delay to slow down the response from being delivered.
     pub delay_secs: u64,
 }
@@ -40,7 +40,7 @@ impl Default for ExchangeResponse {
             name: Default::default(),
             url: Default::default(),
             status_code: 200,
-            maybe_json: Default::default(),
+            maybe_body: Default::default(),
             delay_secs: Default::default(),
         }
     }
@@ -77,10 +77,18 @@ impl ExchangeResponseBuilder {
         self
     }
 
-    /// Set the response's JSON body.
-    pub fn json(mut self, json: serde_json::Value) -> Self {
-        self.response.maybe_json = Some(json);
+    pub fn body(mut self, body: ResponseBody) -> Self {
+        self.response.maybe_body = Some(body);
         self
+    }
+
+    /// Set the response's JSON body.
+    pub fn json(self, json: serde_json::Value) -> Self {
+        let body = serde_json::to_vec(&json).expect("Failed to serialize JSON");
+        self.body(ResponseBody {
+            body,
+            type_: ResponseBodyType::Json,
+        })
     }
 
     #[allow(dead_code)]
@@ -187,7 +195,7 @@ impl From<ContainerConfig> for Container {
             let path = url.path().to_string();
             match exchange_responses.get_mut(&host) {
                 Some(c) => c.locations.push(ContainerNginxServerLocationConfig {
-                    maybe_json: response.maybe_json,
+                    maybe_body: response.maybe_body,
                     status_code: response.status_code,
                     path,
                     query_params,
@@ -200,7 +208,7 @@ impl From<ContainerConfig> for Container {
                             name: response.name,
                             host: host_clone,
                             locations: vec![ContainerNginxServerLocationConfig {
-                                maybe_json: response.maybe_json,
+                                maybe_body: response.maybe_body,
                                 path,
                                 status_code: response.status_code,
                                 query_params,
@@ -229,11 +237,45 @@ struct ContainerNginxServerConfig {
     locations: Vec<ContainerNginxServerLocationConfig>,
 }
 
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub enum ResponseBodyType {
+    Json,
+    #[allow(dead_code)]
+    Xml,
+    Empty,
+}
+
+impl core::fmt::Display for ResponseBodyType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ResponseBodyType::Json => write!(f, "json"),
+            ResponseBodyType::Xml => write!(f, "xml"),
+            ResponseBodyType::Empty => write!(f, "txt"),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct ResponseBody {
+    /// Response body as bytes
+    pub body: Vec<u8>,
+    /// Response body type
+    pub type_: ResponseBodyType,
+}
+
+impl Default for ResponseBody {
+    fn default() -> Self {
+        Self {
+            body: Default::default(),
+            type_: ResponseBodyType::Empty,
+        }
+    }
+}
 /// Represents a `location` block in the `server` section of an nginx config.
 #[derive(Debug, Serialize)]
 struct ContainerNginxServerLocationConfig {
-    /// May contain a JSON value. The actual content to be served.
-    maybe_json: Option<serde_json::Value>,
+    /// Maybe contain a response body to be served to the canister.
+    maybe_body: Option<ResponseBody>,
     /// The status code nginx should return to a request.
     status_code: u16,
     /// The path portion of the URL (/a/b/c).

--- a/src/xrc-tests/src/container.rs
+++ b/src/xrc-tests/src/container.rs
@@ -12,6 +12,34 @@ use self::utils::{
     VerifyReplicaIsRunningError,
 };
 
+/// The body contents for an exchange response.
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub enum ResponseBody {
+    /// Signifies that the body is JSON.
+    Json(Vec<u8>),
+    /// Signifies that the body is XML.
+    #[allow(dead_code)]
+    Xml(Vec<u8>),
+    /// Signifies that the body has not been set.
+    Empty,
+}
+
+impl core::fmt::Display for ResponseBody {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ResponseBody::Json(_) => write!(f, "json"),
+            ResponseBody::Xml(_) => write!(f, "xml"),
+            ResponseBody::Empty => write!(f, "empty"),
+        }
+    }
+}
+
+impl Default for ResponseBody {
+    fn default() -> Self {
+        Self::Empty
+    }
+}
+
 /// A response from the `e2e` container's nginx process that is given back to
 /// the `xrc` canister when asking for rates from various exchanges.
 pub struct ExchangeResponse {
@@ -234,29 +262,6 @@ struct ContainerNginxServerConfig {
     locations: Vec<ContainerNginxServerLocationConfig>,
 }
 
-#[derive(Debug, Serialize, PartialEq, Eq)]
-pub enum ResponseBody {
-    Json(Vec<u8>),
-    #[allow(dead_code)]
-    Xml(Vec<u8>),
-    Empty,
-}
-
-impl core::fmt::Display for ResponseBody {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ResponseBody::Json(_) => write!(f, "json"),
-            ResponseBody::Xml(_) => write!(f, "xml"),
-            ResponseBody::Empty => write!(f, "empty"),
-        }
-    }
-}
-
-impl Default for ResponseBody {
-    fn default() -> Self {
-        Self::Empty
-    }
-}
 /// Represents a `location` block in the `server` section of an nginx config.
 #[derive(Debug, Serialize)]
 struct ContainerNginxServerLocationConfig {

--- a/src/xrc-tests/src/container/utils.rs
+++ b/src/xrc-tests/src/container/utils.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 
 use crate::templates;
 
-use super::Container;
+use super::{Container, ResponseBody, ResponseBodyType};
 
 /// Get the working directory which is based off of the `CARGO_MANIFEST_DIR`
 /// environment variable.
@@ -158,9 +158,6 @@ pub enum GenerateExchangeResponsesError {
     /// Used when failing to write a response to the generated content directory.
     #[error("{0}")]
     Io(std::io::Error),
-    /// Used when failing to serialize the JSON values to a pretty string.
-    #[error("{0}")]
-    Serialize(serde_json::Error),
 }
 
 /// This function takes the container's configured responses and dumps the JSON
@@ -174,22 +171,19 @@ where
 {
     for config in container.responses.values() {
         for location in &config.locations {
-            let default = serde_json::json!({});
-
-            let value = match location.maybe_json {
-                Some(ref json) => json,
-                None => &default,
-            };
+            let default = ResponseBody::default();
+            let body = location.maybe_body.as_ref().unwrap_or(&default);
+            if body.type_ == ResponseBodyType::Empty {
+                continue;
+            }
 
             let mut buf = PathBuf::from(path.as_ref());
             buf.push(&config.name);
             buf.push(location.path.trim_start_matches('/'));
             fs::create_dir_all(&buf).map_err(GenerateExchangeResponsesError::Io)?;
 
-            buf.push(format!("{}.json", location.query_params));
-            let contents = serde_json::to_string_pretty(value)
-                .map_err(GenerateExchangeResponsesError::Serialize)?;
-            fs::write(&buf, contents).map_err(GenerateExchangeResponsesError::Io)?;
+            buf.push(format!("{}.{}", location.query_params, body.type_));
+            fs::write(&buf, &body.body).map_err(GenerateExchangeResponsesError::Io)?;
         }
     }
     Ok(())


### PR DESCRIPTION
This PR updates the e2e tests response builder to allow for different content types when responding to the canister HTTP outcalls. The PR was created to start adding forex sources (some sources return XML) to the e2e tests.