### PR TITLE
feat: Add `disable-forex-weekend-check` feature flag.

### DIFF
--- a/scripts/build-wasm
+++ b/scripts/build-wasm
@@ -4,17 +4,29 @@ set -euo pipefail
 cargo install ic-wasm --version 0.3.0 --root ./target
 
 IP_SUPPORT=${IP_SUPPORT:-}
+DISABLE_FOREX_WEEKEND_CHECK=${DISABLE_FOREX_WEEKEND_CHECK:-}
 
 if [ -z "${IP_SUPPORT}" ]; then
     IP_SUPPORT="ipv4"
 fi
 
-echo "checking IPv4 support feature flag"
-if [ "${IP_SUPPORT}" == "ipv4" ]; then
-    cargo build -p xrc --target wasm32-unknown-unknown --release --features ipv4-support
-else
-    cargo build -p xrc --target wasm32-unknown-unknown --release
+if [ -z "${DISABLE_FOREX_WEEKEND_CHECK}" ]; then
+    DISABLE_FOREX_WEEKEND_CHECK="no"
 fi
+
+FEATURES=()
+
+if [ "${IP_SUPPORT}" == "ipv4" ]; then
+    echo "IP_SUPPORT: $IP_SUPPORT"
+    FEATURES+=('--features' 'ipv4-support')
+fi
+
+if [ "${DISABLE_FOREX_WEEKEND_CHECK}" == "yes" ]; then
+    echo "DISABLE_FOREX_WEEKEND_CHECK: $DISABLE_FOREX_WEEKEND_CHECK"
+    FEATURES+=('--features' 'disable-forex-weekend-check')
+fi
+
+cargo build -p xrc --target wasm32-unknown-unknown --release ${FEATURES[@]}
 
 ./target/bin/ic-wasm ./target/wasm32-unknown-unknown/release/xrc.wasm \
     -o ./target/wasm32-unknown-unknown/release/xrc.wasm shrink

--- a/scripts/e2e-tests
+++ b/scripts/e2e-tests
@@ -23,6 +23,10 @@ while getopts 'hn:' flag; do
   esac
 done
 
+# Disable the forex weekend check to allow forex sources to be retrieve during
+# the weekend.
+export DISABLE_FOREX_WEEKEND_CHECK="yes"
+
 # Build the wasm without needing a canister
 dfx build --check xrc
 # Build the e2e base image

--- a/src/xrc/Cargo.toml
+++ b/src/xrc/Cargo.toml
@@ -29,3 +29,4 @@ rand = "0.8.5"
 
 [features]
 ipv4-support = []
+disable-forex-weekend-check = []

--- a/src/xrc/src/periodic.rs
+++ b/src/xrc/src/periodic.rs
@@ -63,16 +63,20 @@ impl ForexSources for ForexSourcesImpl {
         Vec<(String, u64, ForexRateMap)>,
         Vec<(String, CallForexError)>,
     ) {
+        let skip_weekend_check = cfg!(feature = "disable-forex-weekend-check");
         let futures_with_times = FOREX_SOURCES.iter().filter_map(|forex| {
             // We always ask for the timestamp of yesterday's date, in the timezone of the source
             let timestamp =
                 ((forex.offset_timestamp_to_timezone(timestamp) - ONE_DAY) / ONE_DAY) * ONE_DAY;
             // Avoid querying on weekends
-            if let Weekday::Sat | Weekday::Sun =
-                NaiveDateTime::from_timestamp(timestamp as i64, 0).weekday()
-            {
-                return None;
+            if !skip_weekend_check {
+                if let Weekday::Sat | Weekday::Sun =
+                    NaiveDateTime::from_timestamp(timestamp as i64, 0).weekday()
+                {
+                    return None;
+                }
             }
+
             // But some sources expect an offset (e.g., today's date for yesterday's rate)
             let timestamp = forex.offset_timestamp_for_query(timestamp);
             if let Some(exclude) = with_forex_rate_collector(|c| c.get_sources(timestamp)) {


### PR DESCRIPTION
This PR adds the `disable-forex-weekend-check` feature flag. This flag is used to skip the check to see if a timestamp is on a Saturday or Sunday when attempting to contact forex sources. This is being introduced in order to add forex sources to the e2e tests. If the e2e tests were to be run on a Saturday or Sunday, the e2e tests using the forex sources mock data would fail.