### PR TITLE
feat: Update the monitor canister to contain a sampling schedule.

### DIFF
--- a/src/monitor-canister/monitor-canister.did
+++ b/src/monitor-canister/monitor-canister.did
@@ -33,6 +33,8 @@ type ExchangeRate = record {
 type ExchangeRateError = variant {
     // Returned when the canister receives a call from the anonymous principal.
     AnonymousPrincipalNotAllowed: null;
+    /// Returned when the canister is in process of retrieving a rate from an exchange.
+    Pending: null;
     // Returned when the base asset rates are not found from the exchanges HTTP outcalls.
     CryptoBaseAssetNotFound: null;
     // Returned when the quote asset rates are not found from the exchanges HTTP outcalls.

--- a/src/monitor-canister/src/periodic.rs
+++ b/src/monitor-canister/src/periodic.rs
@@ -12,7 +12,12 @@ use crate::{
     Environment,
 };
 
+/// How many entries to retrieve per interval.
 const SAMPLE_SIZE: usize = 1000;
+/// The order of the intervals. Each entry is the number of minutes that
+/// pass between each sampling.
+///
+/// Starts with sampling every minute then ends on sampling every 10 minutes.
 const SAMPLE_SCHEDULE: &[u64; 4] = &[1, 3, 5, 10];
 
 const ONE_MINUTE_SECONDS: u64 = 60;

--- a/src/monitor-canister/src/periodic.rs
+++ b/src/monitor-canister/src/periodic.rs
@@ -1,6 +1,5 @@
 use async_trait::async_trait;
 use candid::encode_one;
-use chrono::{TimeZone, Timelike};
 use ic_cdk::export::Principal;
 use std::cell::Cell;
 use xrc::candid::{Asset, AssetClass, GetExchangeRateRequest, GetExchangeRateResult};

--- a/src/monitor-canister/src/periodic.rs
+++ b/src/monitor-canister/src/periodic.rs
@@ -11,6 +11,9 @@ use crate::{
     Environment,
 };
 
+const SAMPLE_SIZE: usize = 1000;
+const SAMPLE_SCHEDULE: &[u64; 4] = &[1, 3, 5, 10];
+
 const ONE_MINUTE_SECONDS: u64 = 60;
 const NANOS_PER_SEC: u64 = 1_000_000_000;
 
@@ -77,6 +80,12 @@ impl Xrc for XrcImpl {
 }
 
 pub(crate) fn beat(env: &impl Environment) {
+    let entries_len = with_entries(|entries| entries.len());
+    let all_samples_collected = entries_len >= SAMPLE_SIZE * SAMPLE_SCHEDULE.len();
+    if all_samples_collected {
+        return;
+    }
+
     let now_secs = ((env.time() / NANOS_PER_SEC) / 60) * 60;
     let xrc_impl = XrcImpl::new();
     ic_cdk::spawn(call_xrc(xrc_impl, now_secs))
@@ -107,8 +116,14 @@ async fn call_xrc(xrc_impl: impl Xrc, now_secs: u64) {
 
     set_is_calling_xrc(true);
 
-    // Request the rate from one minute ago (this is done to ensure we do actually receive some rates).
-    let one_minute_ago_secs = now_secs.saturating_sub(ONE_MINUTE_SECONDS);
+    // Request the rate from one minute ago * the current sample schedule value (this is done to ensure we do actually receive some rates).
+    let entries_len = with_entries(|entries| entries.len());
+    let index = entries_len / SAMPLE_SIZE;
+    if index >= SAMPLE_SCHEDULE.len() {
+        return;
+    }
+
+    let one_minute_ago_secs = now_secs.saturating_sub(ONE_MINUTE_SECONDS * SAMPLE_SCHEDULE[index]);
     let request = make_get_exchange_rate_request(one_minute_ago_secs);
 
     let call_result = xrc_impl.get_exchange_rate(request.clone()).await;

--- a/src/monitor-canister/src/periodic.rs
+++ b/src/monitor-canister/src/periodic.rs
@@ -12,7 +12,7 @@ use crate::{
     Environment,
 };
 
-const SAMPLE_SIZE: usize = 1;
+const SAMPLE_SIZE: usize = 1000;
 const SAMPLE_SCHEDULE: &[u64; 4] = &[1, 3, 5, 10];
 
 const ONE_MINUTE_SECONDS: u64 = 60;


### PR DESCRIPTION
This PR adds a sampling schedule to the monitor canister. For each entry in the schedule, the monitor canister will collect `1_000` entries.

The current schedule is set as follows:
1. Every 1 minute
2. Every 3 minutes
3. Every 5 minutes
4. Every 10 minutes