### PR TITLE
`refactor`: Refactor handle functions to take in the entire request

### DIFF
--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -174,65 +174,11 @@ async fn get_exchange_rate_internal(
     }
 
     let sanitized_request = utils::sanitize_request(request);
-    let timestamp = utils::get_normalized_timestamp(env, &sanitized_request);
-
     // Route the call based on the provided asset types.
-    let result = match (
-        &sanitized_request.base_asset.class,
-        &sanitized_request.quote_asset.class,
-    ) {
-        (AssetClass::Cryptocurrency, AssetClass::Cryptocurrency) => {
-            handle_cryptocurrency_pair(
-                env,
-                call_exchanges_impl,
-                &sanitized_request.base_asset,
-                &sanitized_request.quote_asset,
-                timestamp,
-            )
-            .await
-        }
-        (AssetClass::Cryptocurrency, AssetClass::FiatCurrency) => {
-            handle_crypto_base_fiat_quote_pair(
-                env,
-                call_exchanges_impl,
-                &sanitized_request.base_asset,
-                &sanitized_request.quote_asset,
-                timestamp,
-            )
-            .await
-            .map_err(|err| match err {
-                ExchangeRateError::ForexBaseAssetNotFound => {
-                    ExchangeRateError::ForexQuoteAssetNotFound
-                }
-                _ => err,
-            })
-        }
-        (AssetClass::FiatCurrency, AssetClass::Cryptocurrency) => {
-            handle_crypto_base_fiat_quote_pair(
-                env,
-                call_exchanges_impl,
-                &sanitized_request.quote_asset,
-                &sanitized_request.base_asset,
-                timestamp,
-            )
-            .await
-            .map(|r| r.inverted())
-            .map_err(|err| match err {
-                ExchangeRateError::CryptoBaseAssetNotFound => {
-                    ExchangeRateError::CryptoQuoteAssetNotFound
-                }
-                _ => err,
-            })
-        }
-        (AssetClass::FiatCurrency, AssetClass::FiatCurrency) => handle_fiat_pair(
-            env,
-            &sanitized_request.base_asset,
-            &sanitized_request.quote_asset,
-            timestamp,
-        ),
-    };
+    let result = route_request(env, call_exchanges_impl, request).await;
 
     if let Err(ref error) = result {
+        let timestamp = utils::get_normalized_timestamp(env, &sanitized_request);
         ic_cdk::println!(
             "{} Timestamp: {} Request: {:?} Error: {:?}",
             LOG_PREFIX,
@@ -244,6 +190,42 @@ async fn get_exchange_rate_internal(
 
     // If the result is successful, convert from a `QueriedExchangeRate` to `candid::ExchangeRate`.
     result.map(|r| r.into())
+}
+
+async fn route_request(
+    env: &impl Environment,
+    call_exchanges_impl: &impl CallExchanges,
+    request: &GetExchangeRateRequest,
+) -> Result<QueriedExchangeRate, ExchangeRateError> {
+    match (&request.base_asset.class, &request.quote_asset.class) {
+        (AssetClass::Cryptocurrency, AssetClass::Cryptocurrency) => {
+            handle_cryptocurrency_pair(env, call_exchanges_impl, request).await
+        }
+        (AssetClass::Cryptocurrency, AssetClass::FiatCurrency) => {
+            handle_crypto_base_fiat_quote_pair(env, call_exchanges_impl, request)
+                .await
+                .map_err(|err| match err {
+                    ExchangeRateError::ForexBaseAssetNotFound => {
+                        ExchangeRateError::ForexQuoteAssetNotFound
+                    }
+                    _ => err,
+                })
+        }
+        (AssetClass::FiatCurrency, AssetClass::Cryptocurrency) => {
+            handle_crypto_base_fiat_quote_pair(env, call_exchanges_impl, request)
+                .await
+                .map(|r| r.inverted())
+                .map_err(|err| match err {
+                    ExchangeRateError::ForexBaseAssetNotFound => {
+                        ExchangeRateError::ForexQuoteAssetNotFound
+                    }
+                    _ => err,
+                })
+        }
+        (AssetClass::FiatCurrency, AssetClass::FiatCurrency) => {
+            handle_fiat_pair(env, request).await
+        }
+    }
 }
 
 /// The function validates the rates in the [QueriedExchangeRate] struct.
@@ -258,14 +240,14 @@ fn validate(rate: QueriedExchangeRate) -> Result<QueriedExchangeRate, ExchangeRa
 async fn handle_cryptocurrency_pair(
     env: &impl Environment,
     call_exchanges_impl: &impl CallExchanges,
-    base_asset: &Asset,
-    quote_asset: &Asset,
-    timestamp: u64,
+    request: &GetExchangeRateRequest,
 ) -> Result<QueriedExchangeRate, ExchangeRateError> {
+    let timestamp = utils::get_normalized_timestamp(env, &request);
+
     let caller = env.caller();
     let (maybe_base_rate, maybe_quote_rate) = with_cache_mut(|cache| {
-        let maybe_base_rate = cache.get(&base_asset.symbol, timestamp);
-        let maybe_quote_rate = cache.get(&quote_asset.symbol, timestamp);
+        let maybe_base_rate = cache.get(&request.base_asset.symbol, timestamp);
+        let maybe_quote_rate = cache.get(&request.quote_asset.symbol, timestamp);
         (maybe_base_rate, maybe_quote_rate)
     });
 
@@ -280,8 +262,8 @@ async fn handle_cryptocurrency_pair(
 
     if !utils::is_caller_privileged(&caller) {
         let rate_limited = is_rate_limited(num_rates_needed);
-        let already_inflight =
-            is_inflight(base_asset, timestamp) || is_inflight(quote_asset, timestamp);
+        let already_inflight = is_inflight(&request.base_asset, timestamp)
+            || is_inflight(&request.quote_asset, timestamp);
         let charge_cycles_option = if rate_limited || already_inflight {
             ChargeOption::MinimumFee
         } else {
@@ -304,14 +286,17 @@ async fn handle_cryptocurrency_pair(
     }
 
     with_inflight_tracking(
-        vec![base_asset.symbol.clone(), quote_asset.symbol.clone()],
+        vec![
+            request.base_asset.symbol.clone(),
+            request.quote_asset.symbol.clone(),
+        ],
         timestamp,
         with_request_counter(num_rates_needed, async move {
             let base_rate = match maybe_base_rate {
                 Some(base_rate) => base_rate,
                 None => {
                     let base_rate = call_exchanges_impl
-                        .get_cryptocurrency_usdt_rate(base_asset, timestamp)
+                        .get_cryptocurrency_usdt_rate(&request.base_asset, timestamp)
                         .await
                         .map_err(|_| ExchangeRateError::CryptoBaseAssetNotFound)?;
                     with_cache_mut(|cache| {
@@ -325,7 +310,7 @@ async fn handle_cryptocurrency_pair(
                 Some(quote_rate) => quote_rate,
                 None => {
                     let quote_rate = call_exchanges_impl
-                        .get_cryptocurrency_usdt_rate(quote_asset, timestamp)
+                        .get_cryptocurrency_usdt_rate(&request.quote_asset, timestamp)
                         .await
                         .map_err(|_| ExchangeRateError::CryptoQuoteAssetNotFound)?;
                     with_cache_mut(|cache| {
@@ -344,15 +329,19 @@ async fn handle_cryptocurrency_pair(
 async fn handle_crypto_base_fiat_quote_pair(
     env: &impl Environment,
     call_exchanges_impl: &impl CallExchanges,
-    base_asset: &Asset,
-    quote_asset: &Asset,
-    timestamp: u64,
+    request: &GetExchangeRateRequest,
 ) -> Result<QueriedExchangeRate, ExchangeRateError> {
+    let timestamp = utils::get_normalized_timestamp(env, &request);
     let caller = env.caller();
     let current_timestamp = env.time_secs();
 
     let forex_rate_result = with_forex_rate_store(|store| {
-        store.get(timestamp, current_timestamp, &quote_asset.symbol, USD)
+        store.get(
+            timestamp,
+            current_timestamp,
+            &request.quote_asset.symbol,
+            USD,
+        )
     })
     .map_err(ExchangeRateError::from);
     let forex_rate = match forex_rate_result {
@@ -363,7 +352,8 @@ async fn handle_crypto_base_fiat_quote_pair(
         }
     };
 
-    let maybe_crypto_base_rate = with_cache_mut(|cache| cache.get(&base_asset.symbol, timestamp));
+    let maybe_crypto_base_rate =
+        with_cache_mut(|cache| cache.get(&request.base_asset.symbol, timestamp));
     let mut num_rates_needed: usize = 0;
     if maybe_crypto_base_rate.is_none() {
         num_rates_needed = num_rates_needed.saturating_add(1);
@@ -385,7 +375,7 @@ async fn handle_crypto_base_fiat_quote_pair(
 
     if !utils::is_caller_privileged(&caller) {
         let rate_limited = is_rate_limited(num_rates_needed);
-        let already_inflight = is_inflight(base_asset, timestamp);
+        let already_inflight = is_inflight(&request.base_asset, timestamp);
         let charge_cycles_option = if rate_limited || already_inflight {
             ChargeOption::MinimumFee
         } else {
@@ -410,9 +400,8 @@ async fn handle_crypto_base_fiat_quote_pair(
         return Ok(crypto_usd_base_rate / forex_rate);
     }
 
-    let base_asset = base_asset.clone();
     with_inflight_tracking(
-        vec![base_asset.symbol.clone()],
+        vec![request.base_asset.symbol.clone()],
         timestamp,
         with_request_counter(num_rates_needed, async move {
             // Retrieve the missing stablecoin results. For each rate retrieved, cache it and add it to the
@@ -446,7 +435,7 @@ async fn handle_crypto_base_fiat_quote_pair(
                 Some(base_rate) => base_rate,
                 None => {
                     let base_rate = call_exchanges_impl
-                        .get_cryptocurrency_usdt_rate(&base_asset, timestamp)
+                        .get_cryptocurrency_usdt_rate(&request.base_asset, timestamp)
                         .await
                         .map_err(|_| ExchangeRateError::CryptoBaseAssetNotFound)?;
                     with_cache_mut(|cache| {
@@ -466,19 +455,18 @@ async fn handle_crypto_base_fiat_quote_pair(
     .await
 }
 
-fn handle_fiat_pair(
+async fn handle_fiat_pair(
     env: &impl Environment,
-    base_asset: &Asset,
-    quote_asset: &Asset,
-    timestamp: u64,
+    request: &GetExchangeRateRequest,
 ) -> Result<QueriedExchangeRate, ExchangeRateError> {
+    let timestamp = utils::get_normalized_timestamp(env, &request);
     let current_timestamp = env.time_secs();
     let result = with_forex_rate_store(|store| {
         store.get(
             timestamp,
             current_timestamp,
-            &base_asset.symbol,
-            &quote_asset.symbol,
+            &request.base_asset.symbol,
+            &request.quote_asset.symbol,
         )
     })
     .map_err(|err| err.into())

--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -242,7 +242,7 @@ async fn handle_cryptocurrency_pair(
     call_exchanges_impl: &impl CallExchanges,
     request: &GetExchangeRateRequest,
 ) -> Result<QueriedExchangeRate, ExchangeRateError> {
-    let timestamp = utils::get_normalized_timestamp(env, &request);
+    let timestamp = utils::get_normalized_timestamp(env, request);
 
     let caller = env.caller();
     let (maybe_base_rate, maybe_quote_rate) = with_cache_mut(|cache| {
@@ -331,7 +331,7 @@ async fn handle_crypto_base_fiat_quote_pair(
     call_exchanges_impl: &impl CallExchanges,
     request: &GetExchangeRateRequest,
 ) -> Result<QueriedExchangeRate, ExchangeRateError> {
-    let timestamp = utils::get_normalized_timestamp(env, &request);
+    let timestamp = utils::get_normalized_timestamp(env, request);
     let caller = env.caller();
     let current_timestamp = env.time_secs();
 
@@ -459,7 +459,7 @@ async fn handle_fiat_pair(
     env: &impl Environment,
     request: &GetExchangeRateRequest,
 ) -> Result<QueriedExchangeRate, ExchangeRateError> {
-    let timestamp = utils::get_normalized_timestamp(env, &request);
+    let timestamp = utils::get_normalized_timestamp(env, request);
     let current_timestamp = env.time_secs();
     let result = with_forex_rate_store(|store| {
         store.get(

--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -222,9 +222,7 @@ async fn route_request(
                     _ => err,
                 })
         }
-        (AssetClass::FiatCurrency, AssetClass::FiatCurrency) => {
-            handle_fiat_pair(env, request).await
-        }
+        (AssetClass::FiatCurrency, AssetClass::FiatCurrency) => handle_fiat_pair(env, request),
     }
 }
 
@@ -455,7 +453,7 @@ async fn handle_crypto_base_fiat_quote_pair(
     .await
 }
 
-async fn handle_fiat_pair(
+fn handle_fiat_pair(
     env: &impl Environment,
     request: &GetExchangeRateRequest,
 ) -> Result<QueriedExchangeRate, ExchangeRateError> {


### PR DESCRIPTION
This PR cleans up the following:

* Moves the `get_normalized_timestamp` call to inside each handle function.
* Moves the `match` statement to a `route_request` function for readability.
* Passes a reference of the request into each handle function instead of separate parameters.

This work is done in preparation for the new `timestamp = null` feature.