### PR TITLE
`feature`: If timestamp = null and the request is inflight, use the previous minute in hopes to return a rate.

### DIFF
--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -235,12 +235,13 @@ fn validate(rate: QueriedExchangeRate) -> Result<QueriedExchangeRate, ExchangeRa
     }
 }
 
-#[derive(PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 enum TimestampType {
     Current,
     Previous,
 }
 
+#[derive(Debug)]
 struct Timestamp {
     value: u64,
     r#type: TimestampType,
@@ -304,10 +305,15 @@ async fn handle_cryptocurrency_pair(
     }
 
     if !utils::is_caller_privileged(&caller) {
+        println!("{:#?}", timestamp);
         let rate_limited = is_rate_limited(num_rates_needed);
         let already_inflight = is_request_already_inflight(request, timestamp.value);
         let is_previous_minute_with_rates_needed =
             timestamp.r#type == TimestampType::Previous && num_rates_needed > 0;
+        println!(
+            "is_previous_minutes_with_rates_needed: {}",
+            is_previous_minute_with_rates_needed
+        );
         let charge_cycles_option =
             if rate_limited || already_inflight || is_previous_minute_with_rates_needed {
                 ChargeOption::MinimumFee

--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -273,7 +273,7 @@ impl NormalizedTimestamp {
 /// If the request contains a timestamp, the function returns the normalized requested timestamp.
 /// If the request's timestamp is null, the function returns the current timestamp if no assets are found
 /// to be inflight; otherwise, the normalized timestamp from one minute ago.
-fn get_normalized_timestamp_for_crypto_assets(
+fn get_normalized_timestamp(
     env: &impl Environment,
     request: &GetExchangeRateRequest,
 ) -> NormalizedTimestamp {
@@ -294,7 +294,7 @@ async fn handle_cryptocurrency_pair(
     call_exchanges_impl: &impl CallExchanges,
     request: &GetExchangeRateRequest,
 ) -> Result<QueriedExchangeRate, ExchangeRateError> {
-    let timestamp = get_normalized_timestamp_for_crypto_assets(env, request);
+    let timestamp = get_normalized_timestamp(env, request);
 
     let caller = env.caller();
     let (maybe_base_rate, maybe_quote_rate) = with_cache_mut(|cache| {
@@ -387,7 +387,7 @@ async fn handle_crypto_base_fiat_quote_pair(
     call_exchanges_impl: &impl CallExchanges,
     request: &GetExchangeRateRequest,
 ) -> Result<QueriedExchangeRate, ExchangeRateError> {
-    let timestamp = get_normalized_timestamp_for_crypto_assets(env, request);
+    let timestamp = get_normalized_timestamp(env, request);
     let caller = env.caller();
 
     let forex_rate_result = with_forex_rate_store(|store| {

--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -305,15 +305,10 @@ async fn handle_cryptocurrency_pair(
     }
 
     if !utils::is_caller_privileged(&caller) {
-        println!("{:#?}", timestamp);
         let rate_limited = is_rate_limited(num_rates_needed);
         let already_inflight = is_request_already_inflight(request, timestamp.value);
         let is_previous_minute_with_rates_needed =
             timestamp.r#type == TimestampType::Previous && num_rates_needed > 0;
-        println!(
-            "is_previous_minutes_with_rates_needed: {}",
-            is_previous_minute_with_rates_needed
-        );
         let charge_cycles_option =
             if rate_limited || already_inflight || is_previous_minute_with_rates_needed {
                 ChargeOption::MinimumFee

--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -174,65 +174,11 @@ async fn get_exchange_rate_internal(
     }
 
     let sanitized_request = utils::sanitize_request(request);
-    let timestamp = utils::get_normalized_timestamp(env, &sanitized_request);
-
     // Route the call based on the provided asset types.
-    let result = match (
-        &sanitized_request.base_asset.class,
-        &sanitized_request.quote_asset.class,
-    ) {
-        (AssetClass::Cryptocurrency, AssetClass::Cryptocurrency) => {
-            handle_cryptocurrency_pair(
-                env,
-                call_exchanges_impl,
-                &sanitized_request.base_asset,
-                &sanitized_request.quote_asset,
-                timestamp,
-            )
-            .await
-        }
-        (AssetClass::Cryptocurrency, AssetClass::FiatCurrency) => {
-            handle_crypto_base_fiat_quote_pair(
-                env,
-                call_exchanges_impl,
-                &sanitized_request.base_asset,
-                &sanitized_request.quote_asset,
-                timestamp,
-            )
-            .await
-            .map_err(|err| match err {
-                ExchangeRateError::ForexBaseAssetNotFound => {
-                    ExchangeRateError::ForexQuoteAssetNotFound
-                }
-                _ => err,
-            })
-        }
-        (AssetClass::FiatCurrency, AssetClass::Cryptocurrency) => {
-            handle_crypto_base_fiat_quote_pair(
-                env,
-                call_exchanges_impl,
-                &sanitized_request.quote_asset,
-                &sanitized_request.base_asset,
-                timestamp,
-            )
-            .await
-            .map(|r| r.inverted())
-            .map_err(|err| match err {
-                ExchangeRateError::CryptoBaseAssetNotFound => {
-                    ExchangeRateError::CryptoQuoteAssetNotFound
-                }
-                _ => err,
-            })
-        }
-        (AssetClass::FiatCurrency, AssetClass::FiatCurrency) => handle_fiat_pair(
-            env,
-            &sanitized_request.base_asset,
-            &sanitized_request.quote_asset,
-            timestamp,
-        ),
-    };
+    let result = route_request(env, call_exchanges_impl, request).await;
 
     if let Err(ref error) = result {
+        let timestamp = utils::get_normalized_timestamp(env, &sanitized_request);
         ic_cdk::println!(
             "{} Timestamp: {} Request: {:?} Error: {:?}",
             LOG_PREFIX,
@@ -244,6 +190,42 @@ async fn get_exchange_rate_internal(
 
     // If the result is successful, convert from a `QueriedExchangeRate` to `candid::ExchangeRate`.
     result.map(|r| r.into())
+}
+
+async fn route_request(
+    env: &impl Environment,
+    call_exchanges_impl: &impl CallExchanges,
+    request: &GetExchangeRateRequest,
+) -> Result<QueriedExchangeRate, ExchangeRateError> {
+    match (&request.base_asset.class, &request.quote_asset.class) {
+        (AssetClass::Cryptocurrency, AssetClass::Cryptocurrency) => {
+            handle_cryptocurrency_pair(env, call_exchanges_impl, request).await
+        }
+        (AssetClass::Cryptocurrency, AssetClass::FiatCurrency) => {
+            handle_crypto_base_fiat_quote_pair(env, call_exchanges_impl, request)
+                .await
+                .map_err(|err| match err {
+                    ExchangeRateError::ForexBaseAssetNotFound => {
+                        ExchangeRateError::ForexQuoteAssetNotFound
+                    }
+                    _ => err,
+                })
+        }
+        (AssetClass::FiatCurrency, AssetClass::Cryptocurrency) => {
+            handle_crypto_base_fiat_quote_pair(env, call_exchanges_impl, request)
+                .await
+                .map(|r| r.inverted())
+                .map_err(|err| match err {
+                    ExchangeRateError::ForexBaseAssetNotFound => {
+                        ExchangeRateError::ForexQuoteAssetNotFound
+                    }
+                    _ => err,
+                })
+        }
+        (AssetClass::FiatCurrency, AssetClass::FiatCurrency) => {
+            handle_fiat_pair(env, request).await
+        }
+    }
 }
 
 /// The function validates the rates in the [QueriedExchangeRate] struct.
@@ -258,14 +240,14 @@ fn validate(rate: QueriedExchangeRate) -> Result<QueriedExchangeRate, ExchangeRa
 async fn handle_cryptocurrency_pair(
     env: &impl Environment,
     call_exchanges_impl: &impl CallExchanges,
-    base_asset: &Asset,
-    quote_asset: &Asset,
-    timestamp: u64,
+    request: &GetExchangeRateRequest,
 ) -> Result<QueriedExchangeRate, ExchangeRateError> {
+    let timestamp = utils::get_normalized_timestamp(env, &request);
+
     let caller = env.caller();
     let (maybe_base_rate, maybe_quote_rate) = with_cache_mut(|cache| {
-        let maybe_base_rate = cache.get(&base_asset.symbol, timestamp);
-        let maybe_quote_rate = cache.get(&quote_asset.symbol, timestamp);
+        let maybe_base_rate = cache.get(&request.base_asset.symbol, timestamp);
+        let maybe_quote_rate = cache.get(&request.quote_asset.symbol, timestamp);
         (maybe_base_rate, maybe_quote_rate)
     });
 
@@ -280,8 +262,8 @@ async fn handle_cryptocurrency_pair(
 
     if !utils::is_caller_privileged(&caller) {
         let rate_limited = is_rate_limited(num_rates_needed);
-        let already_inflight =
-            is_inflight(base_asset, timestamp) || is_inflight(quote_asset, timestamp);
+        let already_inflight = is_inflight(&request.base_asset, timestamp)
+            || is_inflight(&request.quote_asset, timestamp);
         let charge_cycles_option = if rate_limited || already_inflight {
             ChargeOption::MinimumFee
         } else {
@@ -304,14 +286,17 @@ async fn handle_cryptocurrency_pair(
     }
 
     with_inflight_tracking(
-        vec![base_asset.symbol.clone(), quote_asset.symbol.clone()],
+        vec![
+            request.base_asset.symbol.clone(),
+            request.quote_asset.symbol.clone(),
+        ],
         timestamp,
         with_request_counter(num_rates_needed, async move {
             let base_rate = match maybe_base_rate {
                 Some(base_rate) => base_rate,
                 None => {
                     let base_rate = call_exchanges_impl
-                        .get_cryptocurrency_usdt_rate(base_asset, timestamp)
+                        .get_cryptocurrency_usdt_rate(&request.base_asset, timestamp)
                         .await
                         .map_err(|_| ExchangeRateError::CryptoBaseAssetNotFound)?;
                     with_cache_mut(|cache| {
@@ -325,7 +310,7 @@ async fn handle_cryptocurrency_pair(
                 Some(quote_rate) => quote_rate,
                 None => {
                     let quote_rate = call_exchanges_impl
-                        .get_cryptocurrency_usdt_rate(quote_asset, timestamp)
+                        .get_cryptocurrency_usdt_rate(&request.quote_asset, timestamp)
                         .await
                         .map_err(|_| ExchangeRateError::CryptoQuoteAssetNotFound)?;
                     with_cache_mut(|cache| {
@@ -344,15 +329,19 @@ async fn handle_cryptocurrency_pair(
 async fn handle_crypto_base_fiat_quote_pair(
     env: &impl Environment,
     call_exchanges_impl: &impl CallExchanges,
-    base_asset: &Asset,
-    quote_asset: &Asset,
-    timestamp: u64,
+    request: &GetExchangeRateRequest,
 ) -> Result<QueriedExchangeRate, ExchangeRateError> {
+    let timestamp = utils::get_normalized_timestamp(env, &request);
     let caller = env.caller();
     let current_timestamp = env.time_secs();
 
     let forex_rate_result = with_forex_rate_store(|store| {
-        store.get(timestamp, current_timestamp, &quote_asset.symbol, USD)
+        store.get(
+            timestamp,
+            current_timestamp,
+            &request.quote_asset.symbol,
+            USD,
+        )
     })
     .map_err(ExchangeRateError::from);
     let forex_rate = match forex_rate_result {
@@ -363,7 +352,8 @@ async fn handle_crypto_base_fiat_quote_pair(
         }
     };
 
-    let maybe_crypto_base_rate = with_cache_mut(|cache| cache.get(&base_asset.symbol, timestamp));
+    let maybe_crypto_base_rate =
+        with_cache_mut(|cache| cache.get(&request.base_asset.symbol, timestamp));
     let mut num_rates_needed: usize = 0;
     if maybe_crypto_base_rate.is_none() {
         num_rates_needed = num_rates_needed.saturating_add(1);
@@ -385,7 +375,7 @@ async fn handle_crypto_base_fiat_quote_pair(
 
     if !utils::is_caller_privileged(&caller) {
         let rate_limited = is_rate_limited(num_rates_needed);
-        let already_inflight = is_inflight(base_asset, timestamp);
+        let already_inflight = is_inflight(&request.base_asset, timestamp);
         let charge_cycles_option = if rate_limited || already_inflight {
             ChargeOption::MinimumFee
         } else {
@@ -410,9 +400,8 @@ async fn handle_crypto_base_fiat_quote_pair(
         return Ok(crypto_usd_base_rate / forex_rate);
     }
 
-    let base_asset = base_asset.clone();
     with_inflight_tracking(
-        vec![base_asset.symbol.clone()],
+        vec![request.base_asset.symbol.clone()],
         timestamp,
         with_request_counter(num_rates_needed, async move {
             // Retrieve the missing stablecoin results. For each rate retrieved, cache it and add it to the
@@ -446,7 +435,7 @@ async fn handle_crypto_base_fiat_quote_pair(
                 Some(base_rate) => base_rate,
                 None => {
                     let base_rate = call_exchanges_impl
-                        .get_cryptocurrency_usdt_rate(&base_asset, timestamp)
+                        .get_cryptocurrency_usdt_rate(&request.base_asset, timestamp)
                         .await
                         .map_err(|_| ExchangeRateError::CryptoBaseAssetNotFound)?;
                     with_cache_mut(|cache| {
@@ -466,19 +455,18 @@ async fn handle_crypto_base_fiat_quote_pair(
     .await
 }
 
-fn handle_fiat_pair(
+async fn handle_fiat_pair(
     env: &impl Environment,
-    base_asset: &Asset,
-    quote_asset: &Asset,
-    timestamp: u64,
+    request: &GetExchangeRateRequest,
 ) -> Result<QueriedExchangeRate, ExchangeRateError> {
+    let timestamp = utils::get_normalized_timestamp(env, &request);
     let current_timestamp = env.time_secs();
     let result = with_forex_rate_store(|store| {
         store.get(
             timestamp,
             current_timestamp,
-            &base_asset.symbol,
-            &quote_asset.symbol,
+            &request.base_asset.symbol,
+            &request.quote_asset.symbol,
         )
     })
     .map_err(|err| err.into())

--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -242,7 +242,7 @@ async fn handle_cryptocurrency_pair(
     call_exchanges_impl: &impl CallExchanges,
     request: &GetExchangeRateRequest,
 ) -> Result<QueriedExchangeRate, ExchangeRateError> {
-    let timestamp = utils::get_normalized_timestamp(env, &request);
+    let timestamp = utils::get_normalized_timestamp(env, request);
 
     let caller = env.caller();
     let (maybe_base_rate, maybe_quote_rate) = with_cache_mut(|cache| {
@@ -331,7 +331,7 @@ async fn handle_crypto_base_fiat_quote_pair(
     call_exchanges_impl: &impl CallExchanges,
     request: &GetExchangeRateRequest,
 ) -> Result<QueriedExchangeRate, ExchangeRateError> {
-    let timestamp = utils::get_normalized_timestamp(env, &request);
+    let timestamp = utils::get_normalized_timestamp(env, request);
     let caller = env.caller();
     let current_timestamp = env.time_secs();
 
@@ -459,7 +459,7 @@ async fn handle_fiat_pair(
     env: &impl Environment,
     request: &GetExchangeRateRequest,
 ) -> Result<QueriedExchangeRate, ExchangeRateError> {
-    let timestamp = utils::get_normalized_timestamp(env, &request);
+    let timestamp = utils::get_normalized_timestamp(env, request);
     let current_timestamp = env.time_secs();
     let result = with_forex_rate_store(|store| {
         store.get(

--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -222,9 +222,7 @@ async fn route_request(
                     _ => err,
                 })
         }
-        (AssetClass::FiatCurrency, AssetClass::FiatCurrency) => {
-            handle_fiat_pair(env, request).await
-        }
+        (AssetClass::FiatCurrency, AssetClass::FiatCurrency) => handle_fiat_pair(env, request),
     }
 }
 
@@ -455,7 +453,7 @@ async fn handle_crypto_base_fiat_quote_pair(
     .await
 }
 
-async fn handle_fiat_pair(
+fn handle_fiat_pair(
     env: &impl Environment,
     request: &GetExchangeRateRequest,
 ) -> Result<QueriedExchangeRate, ExchangeRateError> {

--- a/src/xrc/src/api/test.rs
+++ b/src/xrc/src/api/test.rs
@@ -1099,6 +1099,7 @@ mod uses_previous_minute_when_timestamp_is_null_if_request_would_be_pending {
 
     /// This function tests that [get_exchange_rate] will return a rate for a crypto/fiat pair when:
     /// * timestamp is null
+    /// * there is a pending lookup for the crypto asset for the current minute
     /// * the crypto asset with the previous minute IS in the cache
     /// * the stablecoins are in the cache
     #[test]

--- a/src/xrc/src/api/test.rs
+++ b/src/xrc/src/api/test.rs
@@ -1059,7 +1059,7 @@ mod uses_previous_minute_when_timestamp_is_null_if_request_would_be_pending {
         let result = get_exchange_rate_internal(&env, &call_exchanges_impl, &request)
             .now_or_never()
             .expect("future should complete");
-        assert!(matches!(result, Ok(_)));
+        assert!(matches!(result, Ok(rate) if rate.timestamp == 0));
     }
 
     /// This function tests that [get_exchange_rate] will return pending for a crypto pair when:
@@ -1131,7 +1131,7 @@ mod uses_previous_minute_when_timestamp_is_null_if_request_would_be_pending {
         let result = get_exchange_rate_internal(&env, &call_exchanges_impl, &request)
             .now_or_never()
             .expect("future should complete");
-        assert!(matches!(result, Ok(_)));
+        assert!(matches!(result, Ok(rate) if rate.timestamp == 0));
     }
 
     /// This function tests that [get_exchange_rate] will return pending for a crypto/fiat pair when:

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -98,6 +98,9 @@ const RATE_UNIT: u64 = 10u64.saturating_pow(DECIMALS);
 /// Used for setting the max response bytes for the exchanges and forexes.
 const ONE_KIB: u64 = 1_024;
 
+// 1 minute in seconds
+const ONE_MINUTE: u64 = 60;
+
 thread_local! {
     // The exchange rate cache.
     static EXCHANGE_RATE_CACHE: RefCell<ExchangeRateCache> = RefCell::new(

--- a/src/xrc/src/periodic.rs
+++ b/src/xrc/src/periodic.rs
@@ -8,7 +8,7 @@ use crate::{
     call_forex,
     forex::{ForexContextArgs, ForexRateMap, FOREX_SOURCES},
     with_forex_rate_collector, with_forex_rate_collector_mut, with_forex_rate_store_mut,
-    CallForexError, LOG_PREFIX,
+    CallForexError, LOG_PREFIX, ONE_MINUTE,
 };
 
 thread_local! {
@@ -16,8 +16,6 @@ thread_local! {
     static IS_UPDATING_FOREX_STORE: Cell<bool> = Cell::new(false);
 }
 
-// 1 minute in seconds
-const ONE_MINUTE: u64 = 60;
 // 1 hour in seconds
 const ONE_HOUR: u64 = 60 * ONE_MINUTE;
 // 6 hours in seconds


### PR DESCRIPTION
This PR implements the following:

1. If the request contains a timestamp = null, the XRC will get the current normalized timestamp. 
2. If the requested assets with the current normalized timestamp are considered to be inflight, the XRC then goes back 1 additional minute (labeled internally as a past normalized timestamp).
3. If requested assets with the past normalized timestamp *are not* in the cache, the minimum fee is charged and the caller receives a pending error.
4. If requested assets with the past normalized timestamp *are* in the cache, the base cost fee is charged and the caller receives the requested rate.