### PR TITLE
`feat`: Add `disable-forex-timezone-offset` for system testing purposes

### DIFF
--- a/scripts/build-wasm
+++ b/scripts/build-wasm
@@ -5,6 +5,7 @@ cargo install ic-wasm --version 0.3.0 --root ./target
 
 IP_SUPPORT=${IP_SUPPORT:-}
 DISABLE_FOREX_WEEKEND_CHECK=${DISABLE_FOREX_WEEKEND_CHECK:-}
+DISABLE_FOREX_TIMEZONE_OFFSET=${DISABLE_FOREX_TIMEZONE_OFFSET:-}
 
 if [ -z "${IP_SUPPORT}" ]; then
     IP_SUPPORT="ipv4"
@@ -12,6 +13,10 @@ fi
 
 if [ -z "${DISABLE_FOREX_WEEKEND_CHECK}" ]; then
     DISABLE_FOREX_WEEKEND_CHECK="no"
+fi
+
+if [ -z "${DISABLE_FOREX_TIMEZONE_OFFSET}" ]; then
+    DISABLE_FOREX_TIMEZONE_OFFSET="no"
 fi
 
 FEATURES=()
@@ -25,6 +30,12 @@ if [ "${DISABLE_FOREX_WEEKEND_CHECK}" == "yes" ]; then
     echo "DISABLE_FOREX_WEEKEND_CHECK: $DISABLE_FOREX_WEEKEND_CHECK"
     FEATURES+=('--features' 'disable-forex-weekend-check')
 fi
+
+if [ "${DISABLE_FOREX_TIMEZONE_OFFSET}" == "yes" ]; then
+    echo "DISABLE_FOREX_TIMEZONE: $DISABLE_FOREX_TIMEZONE_OFFSET"
+    FEATURES+=('--features' 'disable-forex-timezone-offset')
+fi
+
 
 cargo build -p xrc --target wasm32-unknown-unknown --release "${FEATURES[@]}"
 

--- a/scripts/e2e-tests
+++ b/scripts/e2e-tests
@@ -26,6 +26,7 @@ done
 # Disable the forex weekend check to allow forex sources to be retrieve during
 # the weekend.
 export DISABLE_FOREX_WEEKEND_CHECK="yes"
+export DISABLE_FOREX_TIMEZONE_OFFSET="yes"
 
 # Build the wasm without needing a canister
 dfx build --check xrc

--- a/src/xrc/Cargo.toml
+++ b/src/xrc/Cargo.toml
@@ -30,3 +30,4 @@ rand = "0.8.5"
 [features]
 ipv4-support = []
 disable-forex-weekend-check = []
+disable-forex-timezone-offset = []

--- a/src/xrc/src/forex.rs
+++ b/src/xrc/src/forex.rs
@@ -165,6 +165,9 @@ macro_rules! forex {
 
             /// This method invokes the forex's [IsForex::offset_timestamp_to_timezone] function.
             pub fn offset_timestamp_to_timezone(&self, timestamp: u64) -> u64 {
+                if cfg!(feature = "disable-forex-weekend-check") {
+                    return timestamp;
+                }
                 match self {
                     $(Forex::$name(forex) => forex.offset_timestamp_to_timezone(timestamp)),*,
                 }
@@ -172,6 +175,9 @@ macro_rules! forex {
 
             /// This method invokes the forex's [IsForex::offset_timestamp_for_query] function.
             pub fn offset_timestamp_for_query(&self, timestamp: u64) -> u64 {
+                if cfg!(feature = "disable-forex-weekend-check") {
+                    return timestamp;
+                }
                 match self {
                     $(Forex::$name(forex) => forex.offset_timestamp_for_query(timestamp)),*,
                 }
@@ -199,6 +205,7 @@ macro_rules! forex {
 
 forex! { MonetaryAuthorityOfSingapore, CentralBankOfMyanmar, CentralBankOfBosniaHerzegovina, BankOfIsrael, EuropeanCentralBank, BankOfCanada, CentralBankOfUzbekistan }
 
+#[derive(Debug)]
 pub struct ForexContextArgs {
     pub timestamp: u64,
 }

--- a/src/xrc/src/forex.rs
+++ b/src/xrc/src/forex.rs
@@ -205,7 +205,6 @@ macro_rules! forex {
 
 forex! { MonetaryAuthorityOfSingapore, CentralBankOfMyanmar, CentralBankOfBosniaHerzegovina, BankOfIsrael, EuropeanCentralBank, BankOfCanada, CentralBankOfUzbekistan }
 
-#[derive(Debug)]
 pub struct ForexContextArgs {
     pub timestamp: u64,
 }

--- a/src/xrc/src/forex.rs
+++ b/src/xrc/src/forex.rs
@@ -165,7 +165,7 @@ macro_rules! forex {
 
             /// This method invokes the forex's [IsForex::offset_timestamp_to_timezone] function.
             pub fn offset_timestamp_to_timezone(&self, timestamp: u64) -> u64 {
-                if cfg!(feature = "disable-forex-weekend-check") {
+                if cfg!(feature = "disable-forex-timezone-offset") {
                     return timestamp;
                 }
                 match self {
@@ -175,7 +175,7 @@ macro_rules! forex {
 
             /// This method invokes the forex's [IsForex::offset_timestamp_for_query] function.
             pub fn offset_timestamp_for_query(&self, timestamp: u64) -> u64 {
-                if cfg!(feature = "disable-forex-weekend-check") {
+                if cfg!(feature = "disable-forex-timezone-offset") {
                     return timestamp;
                 }
                 match self {

--- a/src/xrc/src/forex.rs
+++ b/src/xrc/src/forex.rs
@@ -281,11 +281,13 @@ impl ForexRateStore {
 
         // If today's date is requested, and the day is not over anywhere on Earth, use yesterday's date
         // Get the normalized timestamp for yesterday.
-        let yesterday = (current_timestamp as i64 + TIMEZONE_AOE_SHIFT_SECONDS) as u64
-            / SECONDS_PER_DAY
-            * SECONDS_PER_DAY;
-        if timestamp > SECONDS_PER_DAY && yesterday == timestamp {
-            timestamp -= SECONDS_PER_DAY;
+        if !cfg!(feature = "disable-forex-timezone-offset") {
+            let yesterday = (current_timestamp as i64 + TIMEZONE_AOE_SHIFT_SECONDS) as u64
+                / SECONDS_PER_DAY
+                * SECONDS_PER_DAY;
+            if timestamp > SECONDS_PER_DAY && yesterday == timestamp {
+                timestamp -= SECONDS_PER_DAY;
+            }
         }
 
         let base_asset = base_asset.to_uppercase();

--- a/src/xrc/src/forex.rs
+++ b/src/xrc/src/forex.rs
@@ -279,9 +279,9 @@ impl ForexRateStore {
         // Normalize timestamp to the beginning of the day.
         let mut timestamp = (requested_timestamp / SECONDS_PER_DAY) * SECONDS_PER_DAY;
 
-        // If today's date is requested, and the day is not over anywhere on Earth, use yesterday's date
-        // Get the normalized timestamp for yesterday.
         if !cfg!(feature = "disable-forex-timezone-offset") {
+            // If today's date is requested, and the day is not over anywhere on Earth, use yesterday's date
+            // Get the normalized timestamp for yesterday.
             let yesterday = (current_timestamp as i64 + TIMEZONE_AOE_SHIFT_SECONDS) as u64
                 / SECONDS_PER_DAY
                 * SECONDS_PER_DAY;


### PR DESCRIPTION
This PR adds a feature flag to disable the forex timezone offset. This causes issues in determining what values will be used when creating system tests that expect hand built responses.