### PR TITLE
Adding the TVL canister to the list of privileged canisters

### DIFF
--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -82,7 +82,7 @@ const USD: &str = "USD";
 /// The symbol for the USDT stablecoin.
 const USDT: &str = "USDT";
 
-    /// The symbol for the Dai stablecoin.
+/// The symbol for the Dai stablecoin.
 const DAI: &str = "DAI";
 
 /// The symbol for the USDC stablecoin.

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -67,11 +67,13 @@ pub const XRC_BASE_CYCLES_COST: u64 = 200_000_000;
 /// The amount of cycles charged if a call fails (rate limited, failed to find forex rate in store, etc.).
 pub const XRC_MINIMUM_FEE_COST: u64 = 10_000_000;
 
-const PRIVILEGED_CANISTER_IDS: [Principal; 2] = [
+const PRIVILEGED_CANISTER_IDS: [Principal; 3] = [
     // CMC: rkp4c-7iaaa-aaaaa-aaaca-cai
     Principal::from_slice(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x01, 0x01]),
     // NNS dapp: qoctq-giaaa-aaaaa-aaaea-cai
     Principal::from_slice(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x08, 0x01, 0x01]),
+    // TVL dapp: ewh3f-3qaaa-aaaap-aazjq-cai
+    Principal::from_slice(&[0x00, 0x00, 0x00, 0x00, 0x01, 0xe0, 0x06, 0x53, 0x01, 0x01]),
 ];
 
 /// The currency symbol for the US dollar.
@@ -80,7 +82,7 @@ const USD: &str = "USD";
 /// The symbol for the USDT stablecoin.
 const USDT: &str = "USDT";
 
-/// The symbol for the Dai stablecoin.
+    /// The symbol for the Dai stablecoin.
 const DAI: &str = "DAI";
 
 /// The symbol for the USDC stablecoin.

--- a/src/xrc/src/utils.rs
+++ b/src/xrc/src/utils.rs
@@ -143,6 +143,13 @@ pub(crate) mod test {
     }
 
     #[test]
+    fn tvl_dapp_id_is_correct() {
+        let principal_from_text = Principal::from_text("ewh3f-3qaaa-aaaap-aazjq-cai")
+            .expect("should be a valid textual principal ID");
+        assert!(is_caller_privileged(&principal_from_text));
+    }
+
+    #[test]
     fn sanitize_request_uppercases_the_asset_symbols_and_copies_the_other_properties() {
         let request = GetExchangeRateRequest {
             base_asset: Asset {


### PR DESCRIPTION
The new TVL canister will make use of the exchange rate canister.
Since it is another "system canister", it should be exempt from paying cycles.
This PR adds its canister ID (`ewh3f-3qaaa-aaaap-aazjq-cai`) to the list of privileged canisters.

