### PR TITLE
`bugfix`: Check the division when inverting the rate to avoid division by zero errors.

### DIFF
--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -687,8 +687,11 @@ async fn call_exchange_for_stablecoin(
 
     // Some stablecoin pairs are the inverse (USDT/DAI) of what is desired (DAI/USDT).
     // To ensure USDT is the quote asset, the rate is inverted.
+    // If the rate is zero, the rate will be rejected as it will fail to invert.
     if invert {
-        result.map(utils::invert_rate)
+        result.and_then(|rate| {
+            utils::checked_invert_rate(rate).ok_or(CallExchangeError::NoRatesFound)
+        })
     } else {
         result
     }

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -279,7 +279,9 @@ impl std::ops::Mul for QueriedExchangeRate {
                     .saturating_mul(other_value)
                     .saturating_div(RATE_UNIT as u128) as u64;
 
-                rates.push(rate);
+                if rate > 0 {
+                    rates.push(rate);
+                }
             }
         }
         rates.sort();
@@ -984,5 +986,66 @@ mod test {
         // If one value is arbitrarily small, the rate is still valid.
         modified_rate.rates[length - 1] = 1_020_300_000;
         assert!(modified_rate.is_valid());
+    }
+
+    #[test]
+    fn zeroes_are_filtered_out_when_queried_exchange_rate_is_inverted() {
+        let (mut a_b_rate, c_b_rate) = get_rates(
+            ("A".to_string(), "B".to_string()),
+            ("C".to_string(), "B".to_string()),
+        );
+        a_b_rate.rates = vec![0, 10_900_000, 12_300_000];
+
+        let a_c_rate = QueriedExchangeRate {
+            base_asset: Asset {
+                symbol: "A".to_string(),
+                class: AssetClass::Cryptocurrency,
+            },
+            quote_asset: Asset {
+                symbol: "C".to_string(),
+                class: AssetClass::Cryptocurrency,
+            },
+            timestamp: 1661523960,
+            rates: vec![
+                10_683_132, 10_898_910, 10_989_010, 11_036_857, 12_055_277, 12_298_770, 12_400_443,
+                12_454_434,
+            ],
+            base_asset_num_queried_sources: 3,
+            base_asset_num_received_rates: 3,
+            quote_asset_num_queried_sources: 4,
+            quote_asset_num_received_rates: 4,
+            forex_timestamp: None,
+        };
+
+        assert_eq!(a_c_rate, a_b_rate / c_b_rate);
+
+        let (a_b_rate, mut c_b_rate) = get_rates(
+            ("A".to_string(), "B".to_string()),
+            ("C".to_string(), "B".to_string()),
+        );
+        c_b_rate.rates = vec![0, 991_900_000, 1_000_100_000, 1_020_300_000];
+
+        let a_c_rate = QueriedExchangeRate {
+            base_asset: Asset {
+                symbol: "A".to_string(),
+                class: AssetClass::Cryptocurrency,
+            },
+            quote_asset: Asset {
+                symbol: "C".to_string(),
+                class: AssetClass::Cryptocurrency,
+            },
+            timestamp: 1661523960,
+            rates: vec![
+                8_624_914, 8_799_120, 8_871_862, 10_683_132, 10_898_910, 10_989_010, 12_055_277,
+                12_298_770, 12_400_443,
+            ],
+            base_asset_num_queried_sources: 3,
+            base_asset_num_received_rates: 3,
+            quote_asset_num_queried_sources: 4,
+            quote_asset_num_received_rates: 4,
+            forex_timestamp: None,
+        };
+
+        assert_eq!(a_c_rate, a_b_rate / c_b_rate);
     }
 }

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -278,10 +278,7 @@ impl std::ops::Mul for QueriedExchangeRate {
                 let rate = own_value
                     .saturating_mul(other_value)
                     .saturating_div(RATE_UNIT as u128) as u64;
-
-                if rate > 0 {
-                    rates.push(rate);
-                }
+                rates.push(rate);
             }
         }
         rates.sort();

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -380,7 +380,7 @@ impl QueriedExchangeRate {
         let mut inverted_rates: Vec<_> = self
             .rates
             .iter()
-            .map(|rate| utils::invert_rate(*rate))
+            .filter_map(|rate| utils::checked_invert_rate(*rate))
             .collect();
         inverted_rates.sort();
         Self {

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -987,35 +987,6 @@ mod test {
 
     #[test]
     fn zeroes_are_filtered_out_when_queried_exchange_rate_is_inverted() {
-        let (mut a_b_rate, c_b_rate) = get_rates(
-            ("A".to_string(), "B".to_string()),
-            ("C".to_string(), "B".to_string()),
-        );
-        a_b_rate.rates = vec![0, 10_900_000, 12_300_000];
-
-        let a_c_rate = QueriedExchangeRate {
-            base_asset: Asset {
-                symbol: "A".to_string(),
-                class: AssetClass::Cryptocurrency,
-            },
-            quote_asset: Asset {
-                symbol: "C".to_string(),
-                class: AssetClass::Cryptocurrency,
-            },
-            timestamp: 1661523960,
-            rates: vec![
-                10_683_132, 10_898_910, 10_989_010, 11_036_857, 12_055_277, 12_298_770, 12_400_443,
-                12_454_434,
-            ],
-            base_asset_num_queried_sources: 3,
-            base_asset_num_received_rates: 3,
-            quote_asset_num_queried_sources: 4,
-            quote_asset_num_received_rates: 4,
-            forex_timestamp: None,
-        };
-
-        assert_eq!(a_c_rate, a_b_rate / c_b_rate);
-
         let (a_b_rate, mut c_b_rate) = get_rates(
             ("A".to_string(), "B".to_string()),
             ("C".to_string(), "B".to_string()),

--- a/src/xrc/src/stablecoin.rs
+++ b/src/xrc/src/stablecoin.rs
@@ -268,7 +268,8 @@ mod test {
 
         let stablecoin_rate = get_stablecoin_rate(&rates, &target);
         // The expected rate is the inverse of the median rate.
-        let expected_rate = utils::invert_rate(median_rate);
+        let expected_rate =
+            utils::checked_invert_rate(median_rate).expect("should be able to invert the rate");
         assert!(matches!(stablecoin_rate, Ok(rate) if rate.rates[0] == expected_rate));
     }
 

--- a/src/xrc/src/utils.rs
+++ b/src/xrc/src/utils.rs
@@ -109,9 +109,9 @@ pub(crate) fn is_caller_privileged(caller: &Principal) -> bool {
     PRIVILEGED_CANISTER_IDS.contains(caller)
 }
 
-/// Inverts a given rate.
-pub(crate) fn invert_rate(rate: u64) -> u64 {
-    (RATE_UNIT * RATE_UNIT) / rate
+/// Inverts a given rate. If the rate cannot be inverted, return None.
+pub(crate) fn checked_invert_rate(rate: u64) -> Option<u64> {
+    (RATE_UNIT * RATE_UNIT).checked_div(rate)
 }
 
 /// Checks if the canister is supporting IPv4 exchanges and forex sources.


### PR DESCRIPTION
This PR resolves the discovered possibility of division by zero errors while inverting a rate. This is accomplished by updating the division in `utils::invert_rate` (renamed to `utils::checked_invert_rate`) to `checked_div` and returning the result.

* When used to invert a `QueriedExchangeRate`, the failed results are filtered out using `filter_map`.
* When inverting a stablecoin rate, if the rate fails to be inverted, a `CallExchangeError::NoRateFound` is returned.