### PR TITLE
`feat`: Requested timestamps that are too far in the future should be rejected and charged the minimum fee.

### DIFF
--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -5,7 +5,7 @@ mod test;
 pub use metrics::get_metrics;
 
 use crate::cache::ExchangeRateCache;
-use crate::candid::OtherError;
+use crate::errors;
 use crate::{
     call_exchange,
     candid::{Asset, AssetClass, ExchangeRateError, GetExchangeRateRequest, GetExchangeRateResult},
@@ -376,7 +376,7 @@ async fn handle_cryptocurrency_pair(
 
         env.charge_cycles(charge_cycles_option)?;
         if timestamp_is_in_future {
-            return Err(timestamp_is_in_future_error(
+            return Err(errors::timestamp_is_in_future_error(
                 timestamp.value,
                 current_timestamp,
             ));
@@ -507,7 +507,7 @@ async fn handle_crypto_base_fiat_quote_pair(
 
         env.charge_cycles(charge_cycles_option)?;
         if timestamp_is_in_future {
-            return Err(timestamp_is_in_future_error(
+            return Err(errors::timestamp_is_in_future_error(
                 timestamp.value,
                 current_timestamp,
             ));
@@ -604,7 +604,7 @@ fn handle_fiat_pair(
         .map_err(|err| err.into())
         .and_then(validate)
     } else {
-        Err(timestamp_is_in_future_error(
+        Err(errors::timestamp_is_in_future_error(
             requested_timestamp,
             current_timestamp,
         ))
@@ -725,17 +725,4 @@ async fn call_exchange_for_stablecoin(
     } else {
         result
     }
-}
-
-fn timestamp_is_in_future_error(
-    requested_timestamp: u64,
-    current_timestamp: u64,
-) -> ExchangeRateError {
-    ExchangeRateError::Other(OtherError {
-        code: 1,
-        description: format!(
-            "Current IC time is {}. {} is in the future!",
-            current_timestamp, requested_timestamp
-        ),
-    })
 }

--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -360,7 +360,7 @@ async fn handle_cryptocurrency_pair(
 
     if !utils::is_caller_privileged(&caller) {
         let current_timestamp = env.time_secs();
-        let timestamp_is_in_future = timestamp.value > current_timestamp;
+        let timestamp_is_in_future = timestamp.value / 60 > current_timestamp / 60;
         let rate_limited = is_rate_limited(num_rates_needed);
         let already_inflight = is_inflight(&request.base_asset, timestamp.value)
             || is_inflight(&request.quote_asset, timestamp.value);
@@ -492,7 +492,7 @@ async fn handle_crypto_base_fiat_quote_pair(
 
     if !utils::is_caller_privileged(&caller) {
         let current_timestamp = env.time_secs();
-        let timestamp_is_in_future = timestamp.value > current_timestamp;
+        let timestamp_is_in_future = timestamp.value / 60 > current_timestamp / 60;
         let rate_limited = is_rate_limited(num_rates_needed);
         let already_inflight = is_inflight(&request.base_asset, timestamp.value);
         let is_past_minute_not_cached =
@@ -594,7 +594,7 @@ fn handle_fiat_pair(
 ) -> Result<QueriedExchangeRate, ExchangeRateError> {
     let requested_timestamp = utils::get_normalized_timestamp(env, request);
     let current_timestamp = env.time_secs();
-    let result = if requested_timestamp <= current_timestamp {
+    let result = if requested_timestamp / 60 <= current_timestamp / 60 {
         with_forex_rate_store(|store| {
             store.get(
                 requested_timestamp,

--- a/src/xrc/src/api/test.rs
+++ b/src/xrc/src/api/test.rs
@@ -1527,3 +1527,17 @@ fn cached_rate_with_few_collected_rates_is_ignored_for_privileged_canister() {
     // The rate received from exchanges should be returned.
     assert!(matches!(result, Ok(rate) if rate.rate == 4000000000));
 }
+
+mod timestamp_is_in_future {
+
+    use super::*;
+
+    #[test]
+    fn handle_cryptocurrency_pair() {}
+
+    #[test]
+    fn handle_crypto_base_fiat_quote_pair() {}
+
+    #[test]
+    fn handle_fiat_pair() {}
+}

--- a/src/xrc/src/api/test.rs
+++ b/src/xrc/src/api/test.rs
@@ -1530,7 +1530,8 @@ fn cached_rate_with_few_collected_rates_is_ignored_for_privileged_canister() {
 
 mod timestamp_is_in_future {
 
-    use crate::{candid::OtherError, errors::TIMESTAMP_IS_IN_FUTURE_ERROR_CODE, ONE_MINUTE};
+    use crate::{errors::TIMESTAMP_IS_IN_FUTURE_ERROR_CODE, ONE_MINUTE};
+    use ic_xrc_types::OtherError;
 
     use super::*;
 

--- a/src/xrc/src/api/test.rs
+++ b/src/xrc/src/api/test.rs
@@ -1539,7 +1539,7 @@ mod timestamp_is_in_future {
     #[test]
     fn handle_cryptocurrency_pair() {
         let current_timestamp: u64 = 1678752000;
-        let future_timestamp = current_timestamp.saturating_add(2 * ONE_MINUTE);
+        let future_timestamp = current_timestamp.saturating_add(ONE_MINUTE);
         let call_exchanges_impl = TestCallExchangesImpl::builder().build();
         let env = TestEnvironment::builder()
             .with_time_secs(current_timestamp)
@@ -1571,7 +1571,7 @@ mod timestamp_is_in_future {
     #[test]
     fn handle_crypto_base_fiat_quote_pair() {
         let current_timestamp: u64 = 1678752000;
-        let future_timestamp = current_timestamp.saturating_add(2 * ONE_MINUTE);
+        let future_timestamp = current_timestamp.saturating_add(ONE_MINUTE);
         let call_exchanges_impl = TestCallExchangesImpl::builder().build();
         let env = TestEnvironment::builder()
             .with_time_secs(current_timestamp)
@@ -1603,7 +1603,7 @@ mod timestamp_is_in_future {
     #[test]
     fn handle_fiat_pair() {
         let current_timestamp: u64 = 1678752000;
-        let future_timestamp = current_timestamp.saturating_add(2 * ONE_MINUTE);
+        let future_timestamp = current_timestamp.saturating_add(ONE_MINUTE);
         let call_exchanges_impl = TestCallExchangesImpl::builder().build();
         let env = TestEnvironment::builder()
             .with_time_secs(current_timestamp)

--- a/src/xrc/src/errors.rs
+++ b/src/xrc/src/errors.rs
@@ -1,4 +1,4 @@
-use crate::candid::{ExchangeRateError, OtherError};
+use ic_xrc_types::{ExchangeRateError, OtherError};
 
 pub(crate) const TIMESTAMP_IS_IN_FUTURE_ERROR_CODE: u32 = 1;
 

--- a/src/xrc/src/errors.rs
+++ b/src/xrc/src/errors.rs
@@ -1,0 +1,16 @@
+use crate::candid::{ExchangeRateError, OtherError};
+
+pub(crate) const TIMESTAMP_IS_IN_FUTURE_ERROR_CODE: u32 = 1;
+
+pub(crate) fn timestamp_is_in_future_error(
+    requested_timestamp: u64,
+    current_timestamp: u64,
+) -> ExchangeRateError {
+    ExchangeRateError::Other(OtherError {
+        code: TIMESTAMP_IS_IN_FUTURE_ERROR_CODE,
+        description: format!(
+            "Current IC time is {}. {} is in the future!",
+            current_timestamp, requested_timestamp
+        ),
+    })
+}

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -15,6 +15,7 @@ mod http;
 mod stablecoin;
 
 mod environment;
+mod errors;
 mod inflight;
 mod periodic;
 mod rate_limiting;


### PR DESCRIPTION
This PR introduces a future timestamp check for rate requests. If the timestamp is too far in the future, it is rejected and the minimum fee will be charged.