### PR TITLE
`chore`: Update the wasm build to enable IPv4 support

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -27,16 +27,14 @@ jobs:
           cache-to: type=gha,scope=cached-stage,mode=max
           outputs: type=cacheonly
           target: builder
-        env:
-          IP_SUPPORT: ipv6
 
   assets:
     needs: builder
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-       include:
-         - BUILD_NAME: "mainnet"
+        include:
+          - BUILD_NAME: "mainnet"
     steps:
       - uses: actions/checkout@v2
       - name: Set up docker buildx
@@ -50,31 +48,29 @@ jobs:
           cache-from: type=gha,scope=cached-stage
           # Exports the artifacts from the final stage
           outputs: ./${{ matrix.BUILD_NAME }}-out
-        env:
-          IP_SUPPORT: ipv6
-      - name: 'Upload ${{ matrix.BUILD_NAME }} wasm module'
+      - name: "Upload ${{ matrix.BUILD_NAME }} wasm module"
         uses: actions/upload-artifact@v2
         with:
           name: Exchange Rate Canister wasm module
           path: ${{ matrix.BUILD_NAME }}-out/xrc.wasm
       - name: "Link the build sha to this commit"
         run: |
-         : Set up git
-         git config user.name "GitHub Actions Bot"
-         git config user.email "<>"
-         : Make a note of the WASM shasum.
-         NOTE="refs/notes/*"
-         SHA="$(sha256sum < "${{ matrix.BUILD_NAME }}-out/xrc.wasm")"
-         echo $SHA
-         git fetch origin "+${NOTE}:${NOTE}"
-         if git notes --ref="${{ matrix.BUILD_NAME }}/wasm-sha" add -m "$SHA"
-         then git push origin "${NOTE}:${NOTE}" || true
-         else echo SHA already set
-         fi
+          : Set up git
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<>"
+          : Make a note of the WASM shasum.
+          NOTE="refs/notes/*"
+          SHA="$(sha256sum < "${{ matrix.BUILD_NAME }}-out/xrc.wasm")"
+          echo $SHA
+          git fetch origin "+${NOTE}:${NOTE}"
+          if git notes --ref="${{ matrix.BUILD_NAME }}/wasm-sha" add -m "$SHA"
+          then git push origin "${NOTE}:${NOTE}" || true
+          else echo SHA already set
+          fi
       - name: "Verify that the WASM module is small enough to deploy"
         run: |
-         wasm_size="$(wc -c < "${{ matrix.BUILD_NAME }}-out/xrc.wasm")"
-         max_size=2097000
-         echo "WASM size:          $wasm_size"
-         echo "Max supported size: $max_size"
-         (( wasm_size <= max_size )) || { echo "The WASM is too large" ; exit 1 ; }
+          wasm_size="$(wc -c < "${{ matrix.BUILD_NAME }}-out/xrc.wasm")"
+          max_size=2097000
+          echo "WASM size:          $wasm_size"
+          echo "Max supported size: $max_size"
+          (( wasm_size <= max_size )) || { echo "The WASM is too large" ; exit 1 ; }


### PR DESCRIPTION
This PR updates the wasm build to turn *on* IPv4 support.