### PR TITLE
`refactor`: Clean up API code that was duplicated.

### DIFF
--- a/src/xrc/src/environment.rs
+++ b/src/xrc/src/environment.rs
@@ -70,8 +70,6 @@ pub(crate) trait Environment {
 pub(crate) enum ChargeOption {
     /// The minimum fee cost should be used when accepting cycles (XRC_MINIMUM_FEE_COST).
     MinimumFee,
-    /// The base fee cost should be used when accepting cycles (XRC_BASE_CYCLES_COST).
-    BaseCost,
     /// The base fee cost plus the outbound cycles cost (XRC_OUTBOUND_HTTP_CALL_CYCYLES_COST)
     /// multiplied by the defined provided usize. If usize is greater than or equal to 3, 2 is used.
     /// This only occurs if the stablecoin rates are needed.
@@ -83,7 +81,6 @@ pub(crate) enum ChargeOption {
 fn calculate_fee(option: ChargeOption) -> u64 {
     match option {
         ChargeOption::MinimumFee => XRC_MINIMUM_FEE_COST,
-        ChargeOption::BaseCost => XRC_BASE_CYCLES_COST,
         ChargeOption::OutboundRatesNeeded(outbound_rates_needed) => {
             match outbound_rates_needed {
                 // No requests are needed.


### PR DESCRIPTION
This PR cleans up code in the API that was duplicated in the various `handle_*` functions.

* Creates a `validate_request` function to check for future timestamps, rate limiting, already inflight calls, and past timestamps not found in the rate cache.
* Creates a `charge_cycles` function to handle the basic logic the occurs in the `handle_*` functions for charging cycles.
* Adds a the following test: privileged callers cannot make requests containing timestamps in the future.