### PR TITLE
`bugfix`: Raise Okx max response bytes

### DIFF
--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -191,8 +191,9 @@ async fn get_exchange_rate_internal(
     if let Err(ref error) = result {
         let timestamp = utils::get_normalized_timestamp(env, &sanitized_request);
         ic_cdk::println!(
-            "{} Timestamp: {} Request: {:?} Error: {:?}",
+            "{} Caller: {} Timestamp: {} Request: {:?} Error: {:?}",
             LOG_PREFIX,
+            caller,
             timestamp,
             sanitized_request,
             error

--- a/src/xrc/src/exchanges.rs
+++ b/src/xrc/src/exchanges.rs
@@ -741,7 +741,7 @@ mod test {
         let exchange = Exchange::KuCoin(KuCoin);
         assert_eq!(exchange.max_response_bytes(), 2 * ONE_KIB);
         let exchange = Exchange::Okx(Okx);
-        assert_eq!(exchange.max_response_bytes(), ONE_KIB);
+        assert_eq!(exchange.max_response_bytes(), 2 * ONE_KIB);
         let exchange = Exchange::GateIo(GateIo);
         assert_eq!(exchange.max_response_bytes(), ONE_KIB);
         let exchange = Exchange::Mexc(Mexc);

--- a/src/xrc/src/exchanges.rs
+++ b/src/xrc/src/exchanges.rs
@@ -390,6 +390,10 @@ impl IsExchange for Okx {
     fn supports_ipv6(&self) -> bool {
         true
     }
+
+    fn max_response_bytes(&self) -> u64 {
+        2 * ONE_KIB
+    }
 }
 
 /// Gate.io


### PR DESCRIPTION
This PR should resolve the issue with the Okx exchange receiving the following error: `Http body exceeds size limit of 212 bytes`.

In addition, this adds the caller to the log statements.