### PR TITLE
bugfix: Add a updating forex store guard for safety purposes

### DIFF
--- a/src/xrc/src/periodic.rs
+++ b/src/xrc/src/periodic.rs
@@ -342,4 +342,19 @@ mod test {
         // Saturday, October 22, 2022 12:00:00 UTC
         assert_eq!(get_next_run_timestamp(timestamp), 1666440000);
     }
+
+    #[test]
+    fn updating_forex_store_guard() {
+        // Check state is initialized correctly.
+        assert!(!IS_UPDATING_FOREX_STORE.with(|c| c.get()));
+        // Create the guard and ensure the state has been update to true.
+        let guard = UpdatingForexStoreGuard::new();
+        assert!(IS_UPDATING_FOREX_STORE.with(|c| c.get()));
+
+        // Drop the guard to reset the state.
+        drop(guard);
+
+        // Ensure the flag is reset.
+        assert!(!IS_UPDATING_FOREX_STORE.with(|c| c.get()));
+    }
 }

--- a/src/xrc/src/periodic.rs
+++ b/src/xrc/src/periodic.rs
@@ -31,14 +31,6 @@ fn set_next_run_scheduled_at_timestamp(timestamp: u64) {
     NEXT_RUN_SCHEDULED_AT_TIMESTAMP.with(|cell| cell.set(timestamp));
 }
 
-fn is_updating_forex_store() -> bool {
-    IS_UPDATING_FOREX_STORE.with(|cell| cell.get())
-}
-
-fn set_is_updating_forex_store(is_updating: bool) {
-    IS_UPDATING_FOREX_STORE.with(|cell| cell.set(is_updating))
-}
-
 struct UpdatingForexStoreGuard;
 
 impl UpdatingForexStoreGuard {
@@ -313,7 +305,7 @@ mod test {
     /// an instance running indicated by the [IS_UPDATING_FOREX_STORE] state variable.
     #[test]
     fn forex_store_can_only_be_updated_once_at_a_time() {
-        set_is_updating_forex_store(true);
+        IS_UPDATING_FOREX_STORE.with(|c| c.set(true));
 
         let timestamp = 1666371931;
         let mock_forex_sources = MockForexSourcesImpl::default();


### PR DESCRIPTION
This PR adds a guard to the periodic task for updating the forex store. While we have been extremely careful to dealing with panics, this guard better ensures the state is set properly in case we have missed something.