### PR TITLE
feat: Add dashboard to view most recent requests

### DIFF
--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -21,7 +21,7 @@ use crate::{
     Exchange, MetricCounter, QueriedExchangeRate, DAI, EXCHANGES, LOG_PREFIX, ONE_MINUTE, USD,
     USDC, USDT,
 };
-use crate::{errors, request_log, PRIVILEGED_CANISTER_IDS};
+use crate::{errors, request_log};
 use async_trait::async_trait;
 use candid::Principal;
 use futures::future::join_all;

--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -1,15 +1,17 @@
+mod dashboard;
 mod metrics;
 #[cfg(test)]
 mod test;
 
+pub use dashboard::get_dashboard;
+pub use metrics::get_metrics;
+
 use ic_xrc_types::{
     Asset, AssetClass, ExchangeRateError, GetExchangeRateRequest, GetExchangeRateResult,
 };
-pub use metrics::get_metrics;
 
 use crate::cache::ExchangeRateCache;
 use crate::environment::ChargeCyclesError;
-use crate::errors;
 use crate::{
     call_exchange,
     environment::{CanisterEnvironment, ChargeOption, Environment},
@@ -19,6 +21,7 @@ use crate::{
     Exchange, MetricCounter, QueriedExchangeRate, DAI, EXCHANGES, LOG_PREFIX, ONE_MINUTE, USD,
     USDC, USDT,
 };
+use crate::{errors, request_log, PRIVILEGED_CANISTER_IDS};
 use async_trait::async_trait;
 use candid::Principal;
 use futures::future::join_all;
@@ -155,6 +158,11 @@ pub async fn get_exchange_rate(request: GetExchangeRateRequest) -> GetExchangeRa
     }
 
     let result = get_exchange_rate_internal(&env, &call_exchanges_impl, &request).await;
+
+    if is_caller_privileged {
+        let timestamp = env.time_secs();
+        request_log::log(&caller, timestamp, &request, &result);
+    }
 
     if let Err(ref error) = result {
         MetricCounter::ErrorsReturned.increment();

--- a/src/xrc/src/api/dashboard.rs
+++ b/src/xrc/src/api/dashboard.rs
@@ -4,9 +4,115 @@ use ic_xrc_types::GetExchangeRateResult;
 use serde_bytes::ByteBuf;
 
 use crate::{
-    forex::FOREX_SOURCES, request_log::RequestLog, types::HttpResponse, DECIMALS, EXCHANGES,
-    FOREX_RATE_COLLECTOR, PRIVILEGED_CANISTER_IDS, PRIVILEGED_REQUEST_LOG, RATE_UNIT, NONPRIVILEGED_REQUEST_LOG,
+    forex::{ForexRatesCollector, FOREX_SOURCES},
+    request_log::RequestLog,
+    types::HttpResponse,
+    DECIMALS, EXCHANGES, FOREX_RATE_COLLECTOR, NONPRIVILEGED_REQUEST_LOG, PRIVILEGED_CANISTER_IDS,
+    PRIVILEGED_REQUEST_LOG, RATE_UNIT,
 };
+
+const DOCUMENT: &str = r#"
+<!DOCTYPE html>
+<html lang=\"en\">
+    <head>
+        <title>Exchange Rate Canister Dashboard</title>
+        <style>
+            table {
+                border: solid;
+                text-align: left;
+                width: 100%;
+                border-width: thin;
+            }
+            h3 {
+                font-variant: small-caps;
+                margin-top: 30px;
+                margin-bottom: 5px;
+            }
+            table.forex tr th:first-child {
+                width: 25%;
+            }
+            table td, table th {
+                padding: 5px;
+            }
+            table table { font-size: small; }
+            tbody tr:nth-child(odd) { background-color: #eeeeee; }
+        </style>
+        <script>
+            document.addEventListener("DOMContentLoaded", function() {
+                var tds = document.querySelectorAll(".ts-class");
+                for (var i = 0; i < tds.length; i++) {
+                    var td = tds[i];
+                    var timestamp = td.textContent * 1000;
+                    var date = new Date(timestamp);
+                    var options = {
+                        year: 'numeric',
+                        month: 'short',
+                        day: 'numeric',
+                        hour: 'numeric',
+                        minute: 'numeric',
+                        second: 'numeric'
+                    };
+                    td.title = td.textContent;
+                    td.textContent = date.toGMTString(undefined, options);
+                }
+            });
+        </script>
+    </head>
+    <body>
+        <h3>Metadata</h3>
+        [METADATA]
+        [FOREX_COLLECTOR_STATE]
+        <h3>Requests from Privileged Canisters</h3>
+        [PRIVILEGED_LOGS]
+        <h3>Requests from Other Canisters</h3>
+        [NONPRIVILEGED_LOGS]
+    </body>
+</html>
+"#;
+
+const REQUEST_LOG_TABLE: &str = r#"
+<table>
+    <thead>
+        <tr>
+            <th>Timestamp</th>
+            <th>Canister ID</th>
+            <th>Base Asset</th>
+            <th>Quote Asset</th>
+            <th>Request Timestamp</th>
+            <th>Error (if occurred)</th>
+            <th>Rate</th>
+            <th>Base Asset Received Rates</th>
+            <th>Quote Asset Received Rates</th>
+            <th>Std dev</th>
+            <th>Forex Timestamp</th>
+        </tr>
+    </thead>
+    <tbody>[ROWS]</tbody>
+</table>
+"#;
+
+const METADATA_TABLE: &str = r#"
+<table>
+    <tr>
+        <th>Decimals</th>
+        <td>[DECIMALS]</td>
+    </tr>
+    <tr>
+        <th># of Crypto Exchanges</th>
+        <td>[EXCHANGES_NUM]</td>
+    </tr>
+    <tr>
+        <th># of Forex Sources</th>
+        <td>[FOREX_SOURCES_NUM]</td>
+    </tr>
+    <tr>
+        <th>Privileged Canister IDs</th>
+        <td>
+            <table>[PRIVILEGED_CANISTER_IDS]</table>
+        </td>
+    </tr>
+</table>
+"#;
 
 pub fn get_dashboard() -> HttpResponse {
     let body = render();
@@ -18,127 +124,74 @@ pub fn get_dashboard() -> HttpResponse {
 }
 
 fn render() -> Vec<u8> {
-    let html = format!(
-        "
-        <!DOCTYPE html>
-        <html lang=\"en\">
-            <head>
-                <title>Exchange Rate Canister Dashboard</title>
-                <style>
-                    table {{
-                        border: solid;
-                        text-align: left;
-                        width: 100%;
-                        border-width: thin;
-                    }}
-                    h3 {{
-                        font-variant: small-caps;
-                        margin-top: 30px;
-                        margin-bottom: 5px;
-                    }}
-                    table.forex tr th:first-child {{
-                        width: 25%;
-                    }}
-                    table td, table th {{
-                        padding: 5px;
-                    }}
-                    table table {{ font-size: small; }}
-                    tbody tr:nth-child(odd) {{ background-color: #eeeeee; }}
-                </style>
-                <script>
-                    document.addEventListener(\"DOMContentLoaded\", function() {{
-                        var tds = document.querySelectorAll(\".ts-class\");
-                        for (var i = 0; i < tds.length; i++) {{
-                        var td = tds[i];
-                        var timestamp = td.textContent * 1000;
-                        var date = new Date(timestamp);
-                        var options = {{
-                            year: 'numeric',
-                            month: 'short',
-                            day: 'numeric',
-                            hour: 'numeric',
-                            minute: 'numeric',
-                            second: 'numeric'
-                        }};
-                        td.title = td.textContent;
-                        td.textContent = date.toGMTString(undefined, options);
-                        }}
-                    }});
-                </script>
-            </head>
-            <body>
-                <h3>Metadata</h3>
-                {}
-                {}
-                <h3>Requests from Privileged Canisters</h3>
-                {}
-                <h3>Requests from Other Canisters</h3>
-                {}
-            </body>
-        </html>",
-        render_metadata(),
-        render_forex_collector(),
-        render_request_log_entries(&PRIVILEGED_REQUEST_LOG),
-        render_request_log_entries(&NONPRIVILEGED_REQUEST_LOG)
-    );
+    let html = DOCUMENT
+        .replace("[METADATA]", &render_metadata())
+        .replace("[FOREX_COLLECTOR_STATE]", &render_forex_collectors())
+        .replace(
+            "[PRIVILEGED_LOGS]",
+            &render_request_log_entries(&PRIVILEGED_REQUEST_LOG),
+        )
+        .replace(
+            "[NONPRIVILEGED_LOGS]",
+            &render_request_log_entries(&NONPRIVILEGED_REQUEST_LOG),
+        );
     html.into_bytes()
 }
 
 fn render_metadata() -> String {
-    format!(
-        "<table>
-        <tr>
-            <th>Decimals</th>
-            <td>{}</td>
-        </tr>
-        <tr>
-            <th># of Crypto Exchanges</th>
-            <td>{}</td>
-        </tr>
-        <tr>
-            <th># of Forex Sources</th>
-            <td>{}</td>
-        </tr>
-        <tr>
-            <th>Privileged Canister IDs</th>
-            <td>
-                <table>{}</table>
-            </td>
-        </tr>
-    </table>",
-        DECIMALS,
-        EXCHANGES.iter().filter(|e| e.is_available()).count(),
-        FOREX_SOURCES.iter().filter(|s| s.is_available()).count(),
-        PRIVILEGED_CANISTER_IDS
-            .iter()
-            .map(|id| format!("<tr><td><code>{}</code></td></tr>", id))
-            .collect::<Vec<_>>()
-            .join("")
-    )
+    METADATA_TABLE
+        .replace("[DECIMALS]", &DECIMALS.to_string())
+        .replace(
+            "[EXCHANGES_NUM]",
+            &EXCHANGES
+                .iter()
+                .filter(|e| e.is_available())
+                .count()
+                .to_string(),
+        )
+        .replace(
+            "[FOREX_SOURCES_NUM]",
+            &FOREX_SOURCES
+                .iter()
+                .filter(|s| s.is_available())
+                .count()
+                .to_string(),
+        )
+        .replace(
+            "[PRIVILEGED_CANISTER_IDS]",
+            &PRIVILEGED_CANISTER_IDS
+                .iter()
+                .map(|id| format!("<tr><td><code>{}</code></td></tr>", id))
+                .collect::<Vec<_>>()
+                .join(""),
+        )
 }
 
-fn render_forex_collector() -> String {
+fn render_forex_collectors() -> String {
     FOREX_RATE_COLLECTOR.with(|cell| {
         let collector = cell.borrow();
         collector
             .get_timestamps()
             .iter()
-            .map(|timestamp| {
-                format!(
-                    "<h3>Forex Collection for <span class='ts-class'>{}</span></h3>
-                    <table class='forex'>
-                        <tr><th>Sources</th><td>{}</td></tr>
-                    </table>",
-                    timestamp,
-                    collector
-                        .get_sources(*timestamp)
-                        .unwrap_or_default()
-                        .join(", ")
-                )
-            })
+            .map(|timestamp| render_forex_collector(&collector, *timestamp))
             .collect::<Vec<_>>()
             .join("")
     })
+}
+
+fn render_forex_collector(collector: &ForexRatesCollector, timestamp: u64) -> String {
+    let title = format!(
+        "<h3>Forex Collection for <span class='ts-class'>{}</span></h3>",
+        timestamp
+    );
+    let table = format!(
+        "<table class='forex'><tr><th>Sources</th><td>{}</td></tr></table>",
+        collector
+            .get_sources(timestamp)
+            .unwrap_or_default()
+            .join(", ")
+    );
+    format!("{}{}", title, table)
 }
 
 fn render_request_log_entries(log: &'static LocalKey<RefCell<RequestLog>>) -> String {
@@ -148,14 +201,7 @@ fn render_request_log_entries(log: &'static LocalKey<RefCell<RequestLog>>) -> St
             .iter()
             .map(|entry| {
                 format!(
-                    "<tr>
-                    <td class='ts-class'>{}</td>
-                    <td>{}</td>
-                    <td>{:?}</td>
-                    <td>{:?}</td>
-                    <td>{:?}</td>
-                    {}
-                </tr>",
+                    "<tr><td class='ts-class'>{}</td><td>{}</td><td>{:?}</td><td>{:?}</td><td>{:?}</td>{}</tr>",
                     entry.timestamp,
                     entry.caller,
                     entry.request.base_asset,
@@ -167,40 +213,13 @@ fn render_request_log_entries(log: &'static LocalKey<RefCell<RequestLog>>) -> St
             .collect::<Vec<String>>()
             .join(" ")
     });
-    format!(
-        "                <table>
-                    <thead>
-                        <tr>
-                            <th>Timestamp</th>
-                            <th>Canister ID</th>
-                            <th>Base Asset</th>
-                            <th>Quote Asset</th>
-                            <th>Request Timestamp</th>
-                            <th>Error (if occurred)</th>
-                            <th>Rate</th>
-                            <th>Base Asset Received Rates</th>
-                            <th>Quote Asset Received Rates</th>
-                            <th>Std dev</th>
-                            <th>Forex Timestamp</th>
-                        </tr>
-                    </thead>
-                    <tbody>{}</tbody>
-                </table>",
-        rows
-    )
+    REQUEST_LOG_TABLE.replace("[ROWS]", &rows)
 }
 
 fn render_result(result: &GetExchangeRateResult) -> String {
     match result {
         Ok(rate) => format!(
-            "
-            <td></td>
-            <td>{}</td>
-            <td>{}</td>
-            <td>{}</td>
-            <td>{}</td>
-            <td>{}</td>
-        ",
+            "<td></td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td>",
             format_scaled_value(rate.rate),
             rate.metadata.base_asset_num_received_rates,
             rate.metadata.quote_asset_num_received_rates,
@@ -212,12 +231,7 @@ fn render_result(result: &GetExchangeRateResult) -> String {
         ),
         Err(error) => {
             format!(
-                "<td>{:?}</td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>",
+                "<td>{:?}</td><td></td><td></td><td></td><td></td><td></td>",
                 error
             )
         }

--- a/src/xrc/src/api/dashboard.rs
+++ b/src/xrc/src/api/dashboard.rs
@@ -1,0 +1,219 @@
+use ic_xrc_types::GetExchangeRateResult;
+use serde_bytes::ByteBuf;
+
+use crate::{
+    forex::FOREX_SOURCES, types::HttpResponse, DECIMALS, EXCHANGES, FOREX_RATE_COLLECTOR,
+    PRIVILEGED_CANISTER_IDS, PRIVILEGED_REQUEST_LOG, RATE_UNIT,
+};
+
+pub fn get_dashboard() -> HttpResponse {
+    let body = render();
+    HttpResponse {
+        status_code: 200,
+        headers: vec![],
+        body: ByteBuf::from(body),
+    }
+}
+
+fn render() -> Vec<u8> {
+    let html = format!(
+        "
+        <!DOCTYPE html>
+        <html lang=\"en\">
+            <head>
+                <title>Exchange Rate Canister Dashboard</title>
+                <style>
+                    table {{
+                        border: solid;
+                        text-align: left;
+                        width: 100%;
+                        border-width: thin;
+                    }}
+                    h3 {{
+                        font-variant: small-caps;
+                        margin-top: 30px;
+                        margin-bottom: 5px;
+                    }}
+                    table.forex tr th:first-child {{
+                        width: 25%;
+                    }}
+                    table td, table th {{
+                        padding: 5px;
+                    }}
+                    table table {{ font-size: small; }}
+                    tbody tr:nth-child(odd) {{ background-color: #eeeeee; }}
+                </style>
+                <script>
+                    document.addEventListener(\"DOMContentLoaded\", function() {{
+                        var tds = document.querySelectorAll(\".ts-class\");
+                        for (var i = 0; i < tds.length; i++) {{
+                        var td = tds[i];
+                        var timestamp = td.textContent * 1000;
+                        var date = new Date(timestamp);
+                        var options = {{
+                            year: 'numeric',
+                            month: 'short',
+                            day: 'numeric',
+                            hour: 'numeric',
+                            minute: 'numeric',
+                            second: 'numeric'
+                        }};
+                        td.title = td.textContent;
+                        td.textContent = date.toGMTString(undefined, options);
+                        }}
+                    }});
+                </script>
+            </head>
+            <body>
+                <h3>Metadata</h3>
+                {}
+                {}
+                <h3>Requests from Privileged Canisters</h3>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Timestamp</th>
+                            <th>Canister ID</th>
+                            <th>Base Asset</th>
+                            <th>Quote Asset</th>
+                            <th>Request Timestamp</th>
+                            <th>Error (if occurred)</th>
+                            <th>Rate</th>
+                            <th>Base Asset Received Rates</th>
+                            <th>Quote Asset Received Rates</th>
+                            <th>Std dev</th>
+                            <th>Forex Timestamp</th>
+                        </tr>
+                    </thead>
+                    <tbody>{}</tbody>
+                </table>
+            </body>
+        </html>",
+        render_metadata(),
+        render_forex_collector(),
+        render_request_log_entries()
+    );
+    html.into_bytes()
+}
+
+fn render_metadata() -> String {
+    format!(
+        "<table>
+        <tr>
+            <th>Decimals</th>
+            <td>{}</td>
+        </tr>
+        <tr>
+            <th># of Crypto Exchanges</th>
+            <td>{}</td>
+        </tr>
+        <tr>
+            <th># of Forex Sources</th>
+            <td>{}</td>
+        </tr>
+        <tr>
+            <th>Privileged Canister IDs</th>
+            <td>
+                <table>{}</table>
+            </td>
+        </tr>
+    </table>",
+        DECIMALS,
+        EXCHANGES.iter().filter(|e| e.is_available()).count(),
+        FOREX_SOURCES.iter().filter(|s| s.is_available()).count(),
+        PRIVILEGED_CANISTER_IDS
+            .iter()
+            .map(|id| format!("<tr><td><code>{}</code></td></tr>", id))
+            .collect::<Vec<_>>()
+            .join("")
+    )
+}
+
+fn render_forex_collector() -> String {
+    FOREX_RATE_COLLECTOR.with(|cell| {
+        let collector = cell.borrow();
+        collector
+            .get_timestamps()
+            .iter()
+            .map(|timestamp| {
+                format!(
+                    "<h3>Forex Collection for <span class='ts-class'>{}</span></h3>
+                    <table class='forex'>
+                        <tr><th>Sources</th><td>{}</td></tr>
+                    </table>",
+                    timestamp,
+                    collector.get_sources(*timestamp).unwrap_or_default().join(", ")
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("")
+    })
+}
+
+fn render_request_log_entries() -> String {
+    PRIVILEGED_REQUEST_LOG.with(|cell| {
+        cell.borrow()
+            .entries()
+            .iter()
+            .map(|entry| {
+                format!(
+                    "<tr>
+                    <td class='ts-class'>{}</td>
+                    <td>{}</td>
+                    <td>{:?}</td>
+                    <td>{:?}</td>
+                    <td>{:?}</td>
+                    {}
+                </tr>",
+                    entry.timestamp,
+                    entry.caller,
+                    entry.request.base_asset,
+                    entry.request.quote_asset,
+                    entry.request.timestamp,
+                    render_result(&entry.result)
+                )
+            })
+            .collect::<Vec<String>>()
+            .join(" ")
+    })
+}
+
+fn render_result(result: &GetExchangeRateResult) -> String {
+    match result {
+        Ok(rate) => format!(
+            "
+            <td></td>
+            <td>{}</td>
+            <td>{}</td>
+            <td>{}</td>
+            <td>{}</td>
+            <td>{}</td>
+        ",
+            format_scaled_value(rate.rate),
+            rate.metadata.base_asset_num_received_rates,
+            rate.metadata.quote_asset_num_received_rates,
+            format_scaled_value(rate.metadata.standard_deviation),
+            rate.metadata
+                .forex_timestamp
+                .map(|t| t.to_string())
+                .unwrap_or("None".to_string())
+        ),
+        Err(error) => {
+            format!(
+                "<td>{:?}</td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td></td>",
+                error
+            )
+        }
+    }
+}
+
+fn format_scaled_value(value: u64) -> String {
+    let fractional = value % RATE_UNIT;
+    let whole = value / RATE_UNIT;
+    format!("{}.{:0width$}", whole, fractional, width = DECIMALS as usize)
+}

--- a/src/xrc/src/api/dashboard.rs
+++ b/src/xrc/src/api/dashboard.rs
@@ -227,7 +227,7 @@ fn render_result(result: &GetExchangeRateResult) -> String {
             rate.metadata
                 .forex_timestamp
                 .map(|t| t.to_string())
-                .unwrap_or("None".to_string())
+                .unwrap_or_else(|| "None".to_string())
         ),
         Err(error) => {
             format!(

--- a/src/xrc/src/forex.rs
+++ b/src/xrc/src/forex.rs
@@ -571,6 +571,10 @@ impl ForexRatesCollector {
         }
     }
 
+    pub(crate) fn get_timestamps(&self) -> Vec<u64>  {
+        self.days.iter().map(|day| day.timestamp).collect()
+    }
+
     /// Updates the collected rates with a new set of rates. The provided timestamp must exist in the collector or be newer than the existing ones. The function returns true if the collector has been updated, or false if the timestamp is too old.
     pub(crate) fn update(&mut self, source: String, timestamp: u64, rates: ForexRateMap) -> bool {
         let timestamp = (timestamp / SECONDS_PER_DAY) * SECONDS_PER_DAY;

--- a/src/xrc/src/forex.rs
+++ b/src/xrc/src/forex.rs
@@ -571,7 +571,8 @@ impl ForexRatesCollector {
         }
     }
 
-    pub(crate) fn get_timestamps(&self) -> Vec<u64>  {
+    /// Returns the timestamps that are currently sitting in the forex rates collector.
+    pub(crate) fn get_timestamps(&self) -> Vec<u64> {
         self.days.iter().map(|day| day.timestamp).collect()
     }
 

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -20,6 +20,7 @@ mod rate_limiting;
 /// This module provides types for responding to HTTP requests for metrics.
 pub mod types;
 mod utils;
+mod request_log;
 
 use ::candid::{CandidType, Deserialize};
 use cache::ExchangeRateCache;
@@ -28,6 +29,7 @@ use ic_cdk::{
     export::candid::Principal,
 };
 use ic_xrc_types::{Asset, ExchangeRate, ExchangeRateMetadata};
+use request_log::RequestLog;
 use serde_bytes::ByteBuf;
 
 use crate::forex::ForexRateStore;
@@ -97,8 +99,11 @@ const RATE_UNIT: u64 = 10u64.saturating_pow(DECIMALS);
 /// Used for setting the max response bytes for the exchanges and forexes.
 const ONE_KIB: u64 = 1_024;
 
-// 1 minute in seconds
+/// 1 minute in seconds
 const ONE_MINUTE: u64 = 60;
+
+/// Maximum number of entries in the request log.
+const MAX_REQUEST_LOG_ENTRIES: usize = 100;
 
 thread_local! {
     // The exchange rate cache.
@@ -107,6 +112,9 @@ thread_local! {
 
     static FOREX_RATE_STORE: RefCell<ForexRateStore> = RefCell::new(ForexRateStore::new());
     static FOREX_RATE_COLLECTOR: RefCell<ForexRatesCollector> = RefCell::new(ForexRatesCollector::new());
+
+    /// A simple structure to collect privileged canister requests and responses.
+    static PRIVILEGED_REQUEST_LOG: RefCell<RequestLog> = RefCell::new(RequestLog::new(MAX_REQUEST_LOG_ENTRIES));
 
     /// The counter used to determine if a request should be rate limited or not.
     static RATE_LIMITING_REQUEST_COUNTER: Cell<usize> = Cell::new(0);
@@ -746,6 +754,7 @@ pub fn transform_forex_http_response(args: TransformArgs) -> HttpResponse {
 pub fn http_request(req: types::HttpRequest) -> types::HttpResponse {
     let parts: Vec<&str> = req.url.split('?').collect();
     match parts[0] {
+        "/dashboard" => api::get_dashboard(),
         "/metrics" => api::get_metrics(),
         _ => types::HttpResponse {
             status_code: 404,

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -17,10 +17,10 @@ mod errors;
 mod inflight;
 mod periodic;
 mod rate_limiting;
+mod request_log;
 /// This module provides types for responding to HTTP requests for metrics.
 pub mod types;
 mod utils;
-mod request_log;
 
 use ::candid::{CandidType, Deserialize};
 use cache::ExchangeRateCache;
@@ -102,8 +102,11 @@ const ONE_KIB: u64 = 1_024;
 /// 1 minute in seconds
 const ONE_MINUTE: u64 = 60;
 
-/// Maximum number of entries in the request log.
-const MAX_REQUEST_LOG_ENTRIES: usize = 100;
+/// Maximum number of entries in the privileged request log.
+const MAX_PRIVILEGED_REQUEST_LOG_ENTRIES: usize = 100;
+
+/// Maximum number of entries in the non-privileged request log.
+const MAX_NONPRIVILEGED_REQUEST_LOG_ENTRIES: usize = 50;
 
 thread_local! {
     // The exchange rate cache.
@@ -114,7 +117,9 @@ thread_local! {
     static FOREX_RATE_COLLECTOR: RefCell<ForexRatesCollector> = RefCell::new(ForexRatesCollector::new());
 
     /// A simple structure to collect privileged canister requests and responses.
-    static PRIVILEGED_REQUEST_LOG: RefCell<RequestLog> = RefCell::new(RequestLog::new(MAX_REQUEST_LOG_ENTRIES));
+    static PRIVILEGED_REQUEST_LOG: RefCell<RequestLog> = RefCell::new(RequestLog::new(MAX_PRIVILEGED_REQUEST_LOG_ENTRIES));
+    /// A simple structure to collect non-privileged canister requests and responses.
+    static NONPRIVILEGED_REQUEST_LOG: RefCell<RequestLog> = RefCell::new(RequestLog::new(MAX_NONPRIVILEGED_REQUEST_LOG_ENTRIES));
 
     /// The counter used to determine if a request should be rate limited or not.
     static RATE_LIMITING_REQUEST_COUNTER: Cell<usize> = Cell::new(0);

--- a/src/xrc/src/request_log.rs
+++ b/src/xrc/src/request_log.rs
@@ -32,14 +32,14 @@ impl RequestLog {
         request: &GetExchangeRateRequest,
         result: &GetExchangeRateResult,
     ) {
-        self.entries.push_back(RequestLogEntry {
+        self.entries.push_front(RequestLogEntry {
             timestamp,
             caller: caller.clone(),
             request: request.clone(),
             result: result.clone(),
         });
         if self.entries.len() > self.max_entries {
-            self.entries.pop_front();
+            self.entries.pop_back();
         }
     }
 

--- a/src/xrc/src/request_log.rs
+++ b/src/xrc/src/request_log.rs
@@ -3,6 +3,8 @@ use std::{cell::RefCell, collections::VecDeque, thread::LocalKey};
 use candid::Principal;
 use ic_xrc_types::{GetExchangeRateRequest, GetExchangeRateResult};
 
+/// A single entry in the log containing the timestamp, caller, request, and
+/// result of the request.
 pub(crate) struct RequestLogEntry {
     pub timestamp: u64,
     pub caller: Principal,
@@ -10,12 +12,15 @@ pub(crate) struct RequestLogEntry {
     pub result: GetExchangeRateResult,
 }
 
+/// Data structure that contains the most recent requests and results.
 pub(crate) struct RequestLog {
     entries: VecDeque<RequestLogEntry>,
+    /// Max number of entries the log should contain.
     max_entries: usize,
 }
 
 impl RequestLog {
+    /// Create a new log for recording requests.
     pub(crate) fn new(max_entries: usize) -> Self {
         Self {
             entries: VecDeque::new(),
@@ -23,6 +28,8 @@ impl RequestLog {
         }
     }
 
+    /// Writes the provided parameters into a new log entry and if the log
+    /// has more entries than `max_entries`, it prunes off the oldest.
     pub fn log(
         &mut self,
         caller: &Principal,
@@ -41,11 +48,13 @@ impl RequestLog {
         }
     }
 
+    /// Returns a reference to the internal log entries for read purposes.
     pub fn entries(&self) -> &VecDeque<RequestLogEntry> {
         &self.entries
     }
 }
 
+/// A simple helper to quickly log to a global state request log.
 pub(crate) fn log(
     safe_log: &'static LocalKey<RefCell<RequestLog>>,
     caller: &Principal,

--- a/src/xrc/src/request_log.rs
+++ b/src/xrc/src/request_log.rs
@@ -1,9 +1,7 @@
-use std::{collections::VecDeque, thread::LocalKey, cell::RefCell};
+use std::{cell::RefCell, collections::VecDeque, thread::LocalKey};
 
 use candid::Principal;
 use ic_xrc_types::{GetExchangeRateRequest, GetExchangeRateResult};
-
-use crate::PRIVILEGED_REQUEST_LOG;
 
 pub(crate) struct RequestLogEntry {
     pub timestamp: u64,
@@ -34,7 +32,7 @@ impl RequestLog {
     ) {
         self.entries.push_front(RequestLogEntry {
             timestamp,
-            caller: caller.clone(),
+            caller: *caller,
             request: request.clone(),
             result: result.clone(),
         });

--- a/src/xrc/src/request_log.rs
+++ b/src/xrc/src/request_log.rs
@@ -1,0 +1,60 @@
+use std::collections::VecDeque;
+
+use candid::Principal;
+use ic_xrc_types::{GetExchangeRateRequest, GetExchangeRateResult};
+
+use crate::PRIVILEGED_REQUEST_LOG;
+
+pub(crate) struct RequestLogEntry {
+    pub timestamp: u64,
+    pub caller: Principal,
+    pub request: GetExchangeRateRequest,
+    pub result: GetExchangeRateResult,
+}
+
+pub(crate) struct RequestLog {
+    entries: VecDeque<RequestLogEntry>,
+    max_entries: usize,
+}
+
+impl RequestLog {
+    pub(crate) fn new(max_entries: usize) -> Self {
+        Self {
+            entries: VecDeque::new(),
+            max_entries,
+        }
+    }
+
+    pub fn log(
+        &mut self,
+        caller: &Principal,
+        timestamp: u64,
+        request: &GetExchangeRateRequest,
+        result: &GetExchangeRateResult,
+    ) {
+        self.entries.push_back(RequestLogEntry {
+            timestamp,
+            caller: caller.clone(),
+            request: request.clone(),
+            result: result.clone(),
+        });
+        if self.entries.len() > self.max_entries {
+            self.entries.pop_front();
+        }
+    }
+
+    pub fn entries(&self) -> &VecDeque<RequestLogEntry> {
+        &self.entries
+    }
+}
+
+pub(crate) fn log(
+    caller: &Principal,
+    timestamp: u64,
+    request: &GetExchangeRateRequest,
+    result: &GetExchangeRateResult,
+) {
+    PRIVILEGED_REQUEST_LOG.with(|cell| {
+        cell.borrow_mut().log(caller, timestamp, request, result);
+    });
+}

--- a/src/xrc/src/request_log.rs
+++ b/src/xrc/src/request_log.rs
@@ -1,4 +1,4 @@
-use std::collections::VecDeque;
+use std::{collections::VecDeque, thread::LocalKey, cell::RefCell};
 
 use candid::Principal;
 use ic_xrc_types::{GetExchangeRateRequest, GetExchangeRateResult};
@@ -49,12 +49,13 @@ impl RequestLog {
 }
 
 pub(crate) fn log(
+    safe_log: &'static LocalKey<RefCell<RequestLog>>,
     caller: &Principal,
     timestamp: u64,
     request: &GetExchangeRateRequest,
     result: &GetExchangeRateResult,
 ) {
-    PRIVILEGED_REQUEST_LOG.with(|cell| {
+    safe_log.with(|cell| {
         cell.borrow_mut().log(caller, timestamp, request, result);
     });
 }


### PR DESCRIPTION
This PR adds a dashboard to the canister. This will give us a better view into how the XRC is being used.

* A metadata table to see the following:
  * Decimals
  * Number of exchanges available
  * Number of forex sources available
  * List of the privileged canister IDs
* Tables with information on the active forex collectors:
  * Sources that have been collected
* Tables containing requests and responses including the timestamp and caller