### PR TITLE
`bugfix`: Central Bank of Bosnia Herzegovina added rates on a Saturday

### DIFF
--- a/src/xrc/src/forex.rs
+++ b/src/xrc/src/forex.rs
@@ -71,7 +71,7 @@ const MAX_DAYS_TO_GO_BACK: u64 = 4;
 macro_rules! forex {
     ($($name:ident),*) => {
         /// Enum that contains all of the possible forex sources.
-        #[derive(PartialEq)]
+        #[derive(Debug, PartialEq)]
         pub enum Forex {
             $(
                 #[allow(missing_docs)]
@@ -81,7 +81,7 @@ macro_rules! forex {
         }
 
         $(
-            #[derive(PartialEq)]
+            #[derive(Debug, PartialEq)]
             pub struct $name;
         )*
 
@@ -212,6 +212,7 @@ macro_rules! forex {
 
 forex! { MonetaryAuthorityOfSingapore, CentralBankOfMyanmar, CentralBankOfBosniaHerzegovina, EuropeanCentralBank, BankOfCanada, CentralBankOfUzbekistan }
 
+#[derive(Debug)]
 pub struct ForexContextArgs {
     pub timestamp: u64,
 }

--- a/src/xrc/src/periodic.rs
+++ b/src/xrc/src/periodic.rs
@@ -402,7 +402,7 @@ mod test {
     fn check_forex_status_weekend() {
         let forex = FOREX_SOURCES.get(0).expect("Singapore expected"); // Singapore
         assert!(matches!(
-            check_forex_status(forex, 1680220800),
+            check_forex_status(forex, 1680372000),
             Err(ForexStatusError::Weekend)
         ));
     }

--- a/src/xrc/src/periodic.rs
+++ b/src/xrc/src/periodic.rs
@@ -145,6 +145,8 @@ fn check_forex_status(forex: &Forex, timestamp: u64) -> Result<(), ForexStatusEr
     Ok(())
 }
 
+/// Helper function that builds out the timestamps and context args when
+/// calling each forex.
 fn get_forexes_with_timestamps_and_context(
     timestamp: u64,
 ) -> Vec<(&'static Forex, u64, ForexContextArgs)> {
@@ -432,6 +434,38 @@ mod test {
 
     #[test]
     fn successfully_get_forexes_with_timestamps_and_context() {
-        assert!(false);
+        let timestamp = 1680220800;
+        let forexes_with_timestamps_and_context =
+            get_forexes_with_timestamps_and_context(timestamp);
+        // Currently, 3. Once ipv4 flag is removed, 5. Bank of Cananda's offset will filter it out.
+        assert_eq!(forexes_with_timestamps_and_context.len(), 3);
+
+        assert!(matches!(
+            forexes_with_timestamps_and_context[0].0,
+            Forex::MonetaryAuthorityOfSingapore(_)
+        ));
+        assert_eq!(forexes_with_timestamps_and_context[0].1, 1680134400);
+        assert_eq!(
+            forexes_with_timestamps_and_context[1].2.timestamp,
+            1680134400
+        );
+        assert!(matches!(
+            forexes_with_timestamps_and_context[1].0,
+            Forex::CentralBankOfMyanmar(_)
+        ));
+        assert_eq!(forexes_with_timestamps_and_context[1].1, 1680134400);
+        assert_eq!(
+            forexes_with_timestamps_and_context[1].2.timestamp,
+            1680134400
+        );
+        assert!(matches!(
+            forexes_with_timestamps_and_context[2].0,
+            Forex::CentralBankOfBosniaHerzegovina(_)
+        ));
+        assert_eq!(forexes_with_timestamps_and_context[2].1, 1680134400);
+        assert_eq!(
+            forexes_with_timestamps_and_context[2].2.timestamp,
+            1680220800
+        );
     }
 }

--- a/src/xrc/src/periodic.rs
+++ b/src/xrc/src/periodic.rs
@@ -390,6 +390,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(not(feature = "ipv4-support"))]
     fn check_forex_status_ipv4_not_supported() {
         let forex = FOREX_SOURCES.get(3).expect("ECB expected"); // European Central Bank
         assert!(matches!(
@@ -433,11 +434,12 @@ mod test {
     }
 
     #[test]
+    #[cfg(not(feature = "ipv4-support"))]
     fn successfully_get_forexes_with_timestamps_and_context() {
         let timestamp = 1680220800;
         let forexes_with_timestamps_and_context =
             get_forexes_with_timestamps_and_context(timestamp);
-        // Currently, 3. Once ipv4 flag is removed, 5. Bank of Cananda's offset will filter it out.
+        // Currently, 3. Once ipv4 flag is removed, 6.
         assert_eq!(forexes_with_timestamps_and_context.len(), 3);
 
         assert!(matches!(
@@ -466,6 +468,73 @@ mod test {
         assert_eq!(
             forexes_with_timestamps_and_context[2].2.timestamp,
             1680220800
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "ipv4-support")]
+    fn successfully_get_forexes_with_timestamps_and_context() {
+        let timestamp = 1680220800;
+        let forexes_with_timestamps_and_context =
+            get_forexes_with_timestamps_and_context(timestamp);
+        assert_eq!(forexes_with_timestamps_and_context.len(), 6);
+
+        assert!(matches!(
+            forexes_with_timestamps_and_context[0].0,
+            Forex::MonetaryAuthorityOfSingapore(_)
+        ));
+        assert_eq!(forexes_with_timestamps_and_context[0].1, 1680134400);
+        assert_eq!(
+            forexes_with_timestamps_and_context[1].2.timestamp,
+            1680134400
+        );
+        assert!(matches!(
+            forexes_with_timestamps_and_context[1].0,
+            Forex::CentralBankOfMyanmar(_)
+        ));
+        assert_eq!(forexes_with_timestamps_and_context[1].1, 1680134400);
+        assert_eq!(
+            forexes_with_timestamps_and_context[1].2.timestamp,
+            1680134400
+        );
+        assert!(matches!(
+            forexes_with_timestamps_and_context[2].0,
+            Forex::CentralBankOfBosniaHerzegovina(_)
+        ));
+        assert_eq!(forexes_with_timestamps_and_context[2].1, 1680134400);
+        assert_eq!(
+            forexes_with_timestamps_and_context[2].2.timestamp,
+            1680220800
+        );
+
+        assert!(matches!(
+            forexes_with_timestamps_and_context[3].0,
+            Forex::EuropeanCentralBank(_)
+        ));
+        assert_eq!(forexes_with_timestamps_and_context[3].1, 1680134400);
+        assert_eq!(
+            forexes_with_timestamps_and_context[3].2.timestamp,
+            1680134400
+        );
+
+        assert!(matches!(
+            forexes_with_timestamps_and_context[4].0,
+            Forex::BankOfCanada(_)
+        ));
+        assert_eq!(forexes_with_timestamps_and_context[4].1, 1680048000);
+        assert_eq!(
+            forexes_with_timestamps_and_context[4].2.timestamp,
+            1680048000
+        );
+
+        assert!(matches!(
+            forexes_with_timestamps_and_context[5].0,
+            Forex::CentralBankOfUzbekistan(_)
+        ));
+        assert_eq!(forexes_with_timestamps_and_context[5].1, 1680134400);
+        assert_eq!(
+            forexes_with_timestamps_and_context[5].2.timestamp,
+            1680134400
         );
     }
 }


### PR DESCRIPTION
This PR fixes a bug that caused the Central Bank of Bosnia Herzegovina to be added on a Saturday. The bug came from the query timestamp (B.H. needs to use +1 day to get the rates for the prior day) being returned as the timestamp that the rates should be assigned to.