### PR TITLE
`bugfix`: Sanitize requests when logged to avoid possible injection attacks on the dashboard.

### DIFF
--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -21,7 +21,7 @@ use crate::{
     Exchange, MetricCounter, QueriedExchangeRate, DAI, EXCHANGES, LOG_PREFIX, ONE_MINUTE, USD,
     USDC, USDT,
 };
-use crate::{errors, request_log, PRIVILEGED_REQUEST_LOG, NONPRIVILEGED_REQUEST_LOG};
+use crate::{errors, request_log, NONPRIVILEGED_REQUEST_LOG, PRIVILEGED_REQUEST_LOG};
 use async_trait::async_trait;
 use candid::Principal;
 use futures::future::join_all;
@@ -161,9 +161,21 @@ pub async fn get_exchange_rate(request: GetExchangeRateRequest) -> GetExchangeRa
     let result = get_exchange_rate_internal(&env, &call_exchanges_impl, &request).await;
 
     if is_caller_privileged {
-        request_log::log(&PRIVILEGED_REQUEST_LOG, &caller, timestamp, &request, &result);
+        request_log::log(
+            &PRIVILEGED_REQUEST_LOG,
+            &caller,
+            timestamp,
+            &request,
+            &result,
+        );
     } else {
-        request_log::log(&NONPRIVILEGED_REQUEST_LOG, &caller, timestamp, &request, &result);
+        request_log::log(
+            &NONPRIVILEGED_REQUEST_LOG,
+            &caller,
+            timestamp,
+            &request,
+            &result,
+        );
     }
 
     if let Err(ref error) = result {
@@ -400,7 +412,7 @@ impl From<ValidateRequestError> for ExchangeRateError {
     }
 }
 
-/// This function validates a request with the given number of rates needed
+/// This function validates a santized request with the given number of rates needed
 /// in order to complete the request.
 fn validate_request(
     env: &impl Environment,

--- a/src/xrc/src/api/dashboard.rs
+++ b/src/xrc/src/api/dashboard.rs
@@ -1,6 +1,6 @@
 use std::{cell::RefCell, thread::LocalKey};
 
-use ic_xrc_types::GetExchangeRateResult;
+use ic_xrc_types::{Asset, GetExchangeRateResult};
 use serde_bytes::ByteBuf;
 
 use crate::{
@@ -201,11 +201,11 @@ fn render_request_log_entries(log: &'static LocalKey<RefCell<RequestLog>>) -> St
             .iter()
             .map(|entry| {
                 format!(
-                    "<tr><td class='ts-class'>{}</td><td>{}</td><td>{:?}</td><td>{:?}</td><td>{:?}</td>{}</tr>",
+                    "<tr><td class='ts-class'>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{:?}</td>{}</tr>",
                     entry.timestamp,
                     entry.caller,
-                    entry.request.base_asset,
-                    entry.request.quote_asset,
+                    render_asset(&entry.request.base_asset),
+                    render_asset(&entry.request.quote_asset),
                     entry.request.timestamp,
                     render_result(&entry.result)
                 )
@@ -214,6 +214,16 @@ fn render_request_log_entries(log: &'static LocalKey<RefCell<RequestLog>>) -> St
             .join(" ")
     });
     REQUEST_LOG_TABLE.replace("[ROWS]", &rows)
+}
+
+fn render_asset(asset: &Asset) -> String {
+    let symbol = if asset.symbol.chars().all(char::is_alphanumeric) {
+        asset.symbol.clone()
+    } else {
+        "Invalid Symbol".to_string()
+    };
+
+    format!("Symbol: {}<br/>Class: {:?}", symbol, asset.class)
 }
 
 fn render_result(result: &GetExchangeRateResult) -> String {

--- a/src/xrc/src/request_log.rs
+++ b/src/xrc/src/request_log.rs
@@ -3,6 +3,8 @@ use std::{cell::RefCell, collections::VecDeque, thread::LocalKey};
 use candid::Principal;
 use ic_xrc_types::{GetExchangeRateRequest, GetExchangeRateResult};
 
+use crate::utils;
+
 /// A single entry in the log containing the timestamp, caller, request, and
 /// result of the request.
 pub(crate) struct RequestLogEntry {
@@ -40,7 +42,7 @@ impl RequestLog {
         self.entries.push_front(RequestLogEntry {
             timestamp,
             caller: *caller,
-            request: request.clone(),
+            request: utils::sanitize_request(request),
             result: result.clone(),
         });
         if self.entries.len() > self.max_entries {


### PR DESCRIPTION
This PR improves upon the `sanitize_request` function to clean up symbols with invalid characters. This is important as the dashboard could end up rendering the asset symbols as HTML.