### PR TITLE
Fix EOD offset computation

### DIFF
--- a/src/xrc/src/forex.rs
+++ b/src/xrc/src/forex.rs
@@ -276,6 +276,27 @@ impl ForexRateStore {
         }
     }
 
+    fn shift_to_latest_source_eod(requested_timestamp: u64, current_timestamp: u64) -> u64 {
+        // We avoid fetching rates for today if today is not over for any of the sources we use.
+        // Therefore, if the current time means the day is not over for the source at the western-most timezone,
+        // we use the normalized timestamp for yesterday.
+        let max_shift_hours = FOREX_SOURCES
+            .iter()
+            .map(|src| src.get_utc_offset())
+            .min()
+            .unwrap_or((TIMEZONE_AOE_SHIFT_HOURS as i16) * -1) as i64;
+
+        let shift_to_latest_source_eod =
+            (SECONDS_PER_DAY as i64 + (max_shift_hours * SECONDS_PER_HOUR as i64)) as u64;
+        let requested_day_end_on_all_sources =
+            requested_timestamp.saturating_add(shift_to_latest_source_eod);
+        if current_timestamp < requested_day_end_on_all_sources {
+            requested_timestamp.saturating_sub(SECONDS_PER_DAY)
+        } else {
+            requested_timestamp
+        }
+    }
+
     /// Returns the exchange rate for the given two forex assets and a given timestamp, or None if a rate cannot be found.
     pub(crate) fn get(
         &self,
@@ -288,23 +309,8 @@ impl ForexRateStore {
         let mut requested_timestamp = (requested_timestamp / SECONDS_PER_DAY) * SECONDS_PER_DAY;
 
         if !cfg!(feature = "disable-forex-timezone-offset") {
-            // We avoid fetching rates for today if today is not over for any of the sources we use.
-            // Therefore, if the current time means the day is not over for the source at the western-most timezone,
-            // we use the normalized timestamp for yesterday.
-            let max_shift_hours = FOREX_SOURCES
-                .iter()
-                .map(|src| src.get_utc_offset())
-                .min()
-                .unwrap_or((TIMEZONE_AOE_SHIFT_HOURS as i16) * -1)
-                as i64;
-
-            let shift_to_latest_source_eod =
-                (SECONDS_PER_DAY as i64 + (max_shift_hours * SECONDS_PER_HOUR as i64)) as u64;
-            let requested_day_end_on_all_sources =
-                requested_timestamp.saturating_add(shift_to_latest_source_eod);
-            if current_timestamp < requested_day_end_on_all_sources {
-                requested_timestamp = requested_timestamp.saturating_sub(SECONDS_PER_DAY);
-            }
+            requested_timestamp =
+                Self::shift_to_latest_source_eod(requested_timestamp, current_timestamp);
         }
 
         let base_asset = base_asset.to_uppercase();
@@ -2145,5 +2151,23 @@ mod test {
         let available_forex_sources_count =
             FOREX_SOURCES.iter().filter(|e| e.is_available()).count();
         assert_eq!(available_forex_sources_count, 6);
+    }
+
+    #[test]
+    fn correct_shift_to_latest_source_eod() {
+        // Let the current time be day 2, noon UTC
+        let current_timestamp = SECONDS_PER_DAY * 2 + SECONDS_PER_DAY / 2;
+        // Try the timestamp of the beginning of day 2 UTC
+        // Expect a shift to day 1
+        let requested_timestamp = SECONDS_PER_DAY * 2;
+        let shifted =
+            ForexRateStore::shift_to_latest_source_eod(requested_timestamp, current_timestamp);
+        assert_eq!(shifted, SECONDS_PER_DAY);
+        // Try the timestamp of the beginning of day 1
+        // Expect no shift
+        let requested_timestamp = SECONDS_PER_DAY;
+        let shifted =
+            ForexRateStore::shift_to_latest_source_eod(requested_timestamp, current_timestamp);
+        assert_eq!(shifted, requested_timestamp);
     }
 }

--- a/src/xrc/src/forex.rs
+++ b/src/xrc/src/forex.rs
@@ -284,7 +284,7 @@ impl ForexRateStore {
             .iter()
             .map(|src| src.get_utc_offset())
             .min()
-            .unwrap_or((TIMEZONE_AOE_SHIFT_HOURS as i16) * -1) as i64;
+            .unwrap_or(-(TIMEZONE_AOE_SHIFT_HOURS as i16)) as i64;
 
         let shift_to_latest_source_eod =
             (SECONDS_PER_DAY as i64 + (max_shift_hours * SECONDS_PER_HOUR as i64)) as u64;
@@ -2163,7 +2163,7 @@ mod test {
         let shifted =
             ForexRateStore::shift_to_latest_source_eod(requested_timestamp, current_timestamp);
         assert_eq!(shifted, SECONDS_PER_DAY);
-        // Try the timestamp of the beginning of day 1
+        // Try the timestamp of the beginning of day 1 UTC
         // Expect no shift
         let requested_timestamp = SECONDS_PER_DAY;
         let shifted =


### PR DESCRIPTION
The computation for end-of-day used `max` instead of `min` (as `get_utc_offset` returns a negative number for western sources). Fixing this raised a problem in type casting as we were casting a potentially negative value to `u64`.