### PR TITLE
`bugfix`: Increase `max response bytes` for newly added forex sources

### DIFF
--- a/src/xrc/src/forex/georgia.rs
+++ b/src/xrc/src/forex/georgia.rs
@@ -112,7 +112,7 @@ mod test {
     #[test]
     fn max_response_bytes() {
         let forex = Forex::CentralBankOfGeorgia(CentralBankOfGeorgia);
-        assert_eq!(forex.max_response_bytes(), 30 * ONE_KIB);
+        assert_eq!(forex.max_response_bytes(), 100 * ONE_KIB);
     }
 
     #[test]

--- a/src/xrc/src/forex/georgia.rs
+++ b/src/xrc/src/forex/georgia.rs
@@ -79,7 +79,7 @@ impl IsForex for CentralBankOfGeorgia {
     }
 
     fn max_response_bytes(&self) -> u64 {
-        ONE_KIB * 30
+        ONE_KIB * 100
     }
 }
 

--- a/src/xrc/src/forex/italy.rs
+++ b/src/xrc/src/forex/italy.rs
@@ -94,7 +94,7 @@ impl IsForex for BankOfItaly {
     }
 
     fn max_response_bytes(&self) -> u64 {
-        ONE_KIB * 30
+        ONE_KIB * 100
     }
 }
 

--- a/src/xrc/src/forex/italy.rs
+++ b/src/xrc/src/forex/italy.rs
@@ -127,7 +127,7 @@ mod test {
     #[test]
     fn max_response_bytes() {
         let forex = Forex::BankOfItaly(BankOfItaly);
-        assert_eq!(forex.max_response_bytes(), 30 * ONE_KIB);
+        assert_eq!(forex.max_response_bytes(), 100 * ONE_KIB);
     }
 
     #[test]

--- a/src/xrc/src/forex/nepal.rs
+++ b/src/xrc/src/forex/nepal.rs
@@ -141,7 +141,7 @@ mod test {
     #[test]
     fn max_response_bytes() {
         let forex = Forex::CentralBankOfNepal(CentralBankOfNepal);
-        assert_eq!(forex.max_response_bytes(), 30 * ONE_KIB);
+        assert_eq!(forex.max_response_bytes(), 100 * ONE_KIB);
     }
 
     #[test]

--- a/src/xrc/src/forex/nepal.rs
+++ b/src/xrc/src/forex/nepal.rs
@@ -108,7 +108,7 @@ impl IsForex for CentralBankOfNepal {
     }
 
     fn max_response_bytes(&self) -> u64 {
-        ONE_KIB * 30
+        ONE_KIB * 100
     }
 }
 

--- a/src/xrc/src/forex/switzerland.rs
+++ b/src/xrc/src/forex/switzerland.rs
@@ -81,7 +81,7 @@ impl IsForex for SwissFederalOfficeForCustoms {
     }
 
     fn max_response_bytes(&self) -> u64 {
-        500 * ONE_KIB
+        1000 * ONE_KIB
     }
 
     fn supports_ipv6(&self) -> bool {

--- a/src/xrc/src/forex/switzerland.rs
+++ b/src/xrc/src/forex/switzerland.rs
@@ -119,7 +119,7 @@ mod test {
     #[test]
     fn max_response_bytes() {
         let forex = Forex::SwissFederalOfficeForCustoms(SwissFederalOfficeForCustoms);
-        assert_eq!(forex.max_response_bytes(), 500 * ONE_KIB);
+        assert_eq!(forex.max_response_bytes(), 750 * ONE_KIB);
     }
 
     /// The function tests if the [SwissFederalOfficeForCustoms] struct returns the correct forex rate.

--- a/src/xrc/src/forex/switzerland.rs
+++ b/src/xrc/src/forex/switzerland.rs
@@ -119,7 +119,7 @@ mod test {
     #[test]
     fn max_response_bytes() {
         let forex = Forex::SwissFederalOfficeForCustoms(SwissFederalOfficeForCustoms);
-        assert_eq!(forex.max_response_bytes(), 750 * ONE_KIB);
+        assert_eq!(forex.max_response_bytes(), 1000 * ONE_KIB);
     }
 
     /// The function tests if the [SwissFederalOfficeForCustoms] struct returns the correct forex rate.


### PR DESCRIPTION
This is a simple PR to increase the max response bytes to a higher limit for the most recently added forex sources. Some of the responses are much larger than expected.