### PR TITLE
New going back policy for forex rate retrieval

### DIFF
--- a/src/xrc-tests/docker/base.Dockerfile
+++ b/src/xrc-tests/docker/base.Dockerfile
@@ -1,7 +1,7 @@
-FROM golang:1.11.2 AS minica
+FROM golang:1.20 AS minica
 
 RUN apt-get update && apt-get install -y git
-RUN go get github.com/jsha/minica
+RUN go install github.com/jsha/minica@latest
 
 FROM ubuntu:20.04 
 

--- a/src/xrc/src/api/test.rs
+++ b/src/xrc/src/api/test.rs
@@ -587,6 +587,25 @@ fn get_exchange_rate_for_crypto_non_usd_pair() {
                             quote_asset_num_queried_sources: 4,
                             quote_asset_num_received_rates: 4,
                             forex_timestamp: Some(0),
+                        },
+                    // It is necessary to have a CXDR rate with at least 4 sources for the rate store to return a result
+                    "CXDR".to_string() =>
+                        QueriedExchangeRate {
+                            base_asset: Asset {
+                                symbol: "CXDR".to_string(),
+                                class: AssetClass::FiatCurrency,
+                            },
+                            quote_asset: Asset {
+                                symbol: USD.to_string(),
+                                class: AssetClass::FiatCurrency,
+                            },
+                            timestamp: 0,
+                            rates: vec![800_000_000],
+                            base_asset_num_queried_sources: 4,
+                            base_asset_num_received_rates: 4,
+                            quote_asset_num_queried_sources: 4,
+                            quote_asset_num_received_rates: 4,
+                            forex_timestamp: Some(0),
                         }
             },
         );
@@ -668,6 +687,25 @@ fn get_exchange_rate_for_non_usd_crypto_pair() {
                             quote_asset_num_queried_sources: 4,
                             quote_asset_num_received_rates: 4,
                             forex_timestamp: Some(0),
+                        },
+                    // It is necessary to have a CXDR rate with at least 4 sources for the rate store to return a result
+                    "CXDR".to_string() =>
+                        QueriedExchangeRate {
+                            base_asset: Asset {
+                                symbol: "CXDR".to_string(),
+                                class: AssetClass::FiatCurrency,
+                            },
+                            quote_asset: Asset {
+                                symbol: USD.to_string(),
+                                class: AssetClass::FiatCurrency,
+                            },
+                            timestamp: 0,
+                            rates: vec![800_000_000],
+                            base_asset_num_queried_sources: 4,
+                            base_asset_num_received_rates: 4,
+                            quote_asset_num_queried_sources: 4,
+                            quote_asset_num_received_rates: 4,
+                            forex_timestamp: Some(0),
                         }
             },
         );
@@ -736,6 +774,25 @@ fn get_exchange_rate_for_non_usd_crypto_pair_crypto_asset_not_found() {
                         QueriedExchangeRate {
                             base_asset: Asset {
                                 symbol: "EUR".to_string(),
+                                class: AssetClass::FiatCurrency,
+                            },
+                            quote_asset: Asset {
+                                symbol: USD.to_string(),
+                                class: AssetClass::FiatCurrency,
+                            },
+                            timestamp: 0,
+                            rates: vec![800_000_000],
+                            base_asset_num_queried_sources: 4,
+                            base_asset_num_received_rates: 4,
+                            quote_asset_num_queried_sources: 4,
+                            quote_asset_num_received_rates: 4,
+                            forex_timestamp: Some(0),
+                        },
+                    // It is necessary to have a CXDR rate with at least 4 sources for the rate store to return a result
+                    "CXDR".to_string() =>
+                        QueriedExchangeRate {
+                            base_asset: Asset {
+                                symbol: "CXDR".to_string(),
                                 class: AssetClass::FiatCurrency,
                             },
                             quote_asset: Asset {
@@ -847,6 +904,25 @@ fn get_exchange_rate_for_fiat_eur_usd_pair() {
                             quote_asset_num_queried_sources: 4,
                             quote_asset_num_received_rates: 4,
                             forex_timestamp: Some(0),
+                        },
+                    // It is necessary to have a CXDR rate with at least 4 sources for the rate store to return a result
+                    "CXDR".to_string() =>
+                        QueriedExchangeRate {
+                            base_asset: Asset {
+                                symbol: "CXDR".to_string(),
+                                class: AssetClass::FiatCurrency,
+                            },
+                            quote_asset: Asset {
+                                symbol: USD.to_string(),
+                                class: AssetClass::FiatCurrency,
+                            },
+                            timestamp: 0,
+                            rates: vec![800_000_000],
+                            base_asset_num_queried_sources: 4,
+                            base_asset_num_received_rates: 4,
+                            quote_asset_num_queried_sources: 4,
+                            quote_asset_num_received_rates: 4,
+                            forex_timestamp: Some(0),
                         }
             },
         );
@@ -890,6 +966,25 @@ fn get_exchange_rate_for_fiat_with_unknown_symbol() {
                         QueriedExchangeRate {
                             base_asset: Asset {
                                 symbol: "EUR".to_string(),
+                                class: AssetClass::FiatCurrency,
+                            },
+                            quote_asset: Asset {
+                                symbol: USD.to_string(),
+                                class: AssetClass::FiatCurrency,
+                            },
+                            timestamp: 0,
+                            rates: vec![800_000_000],
+                            base_asset_num_queried_sources: 4,
+                            base_asset_num_received_rates: 4,
+                            quote_asset_num_queried_sources: 4,
+                            quote_asset_num_received_rates: 4,
+                            forex_timestamp: Some(0),
+                        },
+                    // It is necessary to have a CXDR rate with at least 4 sources for the rate store to return a result
+                    "CXDR".to_string() =>
+                        QueriedExchangeRate {
+                            base_asset: Asset {
+                                symbol: "CXDR".to_string(),
                                 class: AssetClass::FiatCurrency,
                             },
                             quote_asset: Asset {
@@ -953,6 +1048,25 @@ fn get_exchange_rate_for_fiat_with_unknown_timestamp() {
                                 class: AssetClass::FiatCurrency,
                             },
                             timestamp: 86_400,
+                            rates: vec![800_000_000],
+                            base_asset_num_queried_sources: 4,
+                            base_asset_num_received_rates: 4,
+                            quote_asset_num_queried_sources: 4,
+                            quote_asset_num_received_rates: 4,
+                            forex_timestamp: Some(0),
+                        },
+                    // It is necessary to have a CXDR rate with at least 4 sources for the rate store to return a result
+                    "CXDR".to_string() =>
+                        QueriedExchangeRate {
+                            base_asset: Asset {
+                                symbol: "CXDR".to_string(),
+                                class: AssetClass::FiatCurrency,
+                            },
+                            quote_asset: Asset {
+                                symbol: USD.to_string(),
+                                class: AssetClass::FiatCurrency,
+                            },
+                            timestamp: 0,
                             rates: vec![800_000_000],
                             base_asset_num_queried_sources: 4,
                             base_asset_num_received_rates: 4,

--- a/src/xrc/src/api/test.rs
+++ b/src/xrc/src/api/test.rs
@@ -11,12 +11,12 @@ use crate::{
     inflight::test::set_inflight_tracking,
     rate_limiting::test::{set_request_counter, REQUEST_COUNTER_TRIGGER_RATE_LIMIT},
     with_cache_mut, with_forex_rate_store_mut, CallExchangeError, QueriedExchangeRate, DAI,
-    EXCHANGES, PRIVILEGED_CANISTER_IDS, RATE_UNIT, USD, USDC, XRC_BASE_CYCLES_COST,
+    EXCHANGES, PRIVILEGED_CANISTER_IDS, RATE_UNIT, USDC, XRC_BASE_CYCLES_COST,
     XRC_IMMEDIATE_REFUND_CYCLES, XRC_MINIMUM_FEE_COST, XRC_OUTBOUND_HTTP_CALL_CYCLES_COST,
     XRC_REQUEST_CYCLES_COST,
 };
 
-use super::{get_exchange_rate_internal, CallExchanges};
+use super::{get_exchange_rate_internal, usd_asset, CallExchanges};
 
 fn test_cxdr_rate() -> QueriedExchangeRate {
     QueriedExchangeRate::new(
@@ -24,10 +24,7 @@ fn test_cxdr_rate() -> QueriedExchangeRate {
             symbol: COMPUTED_XDR_SYMBOL.to_string(),
             class: AssetClass::FiatCurrency,
         },
-        Asset {
-            symbol: USD.to_string(),
-            class: AssetClass::FiatCurrency,
-        },
+        usd_asset(),
         0,
         &[800_000_000, 800_000_000, 800_000_000, 800_000_000],
         4,
@@ -493,10 +490,7 @@ fn get_exchange_rate_for_crypto_usd_pair() {
             symbol: "ICP".to_string(),
             class: AssetClass::Cryptocurrency,
         },
-        quote_asset: Asset {
-            symbol: USD.to_string(),
-            class: AssetClass::FiatCurrency,
-        },
+        quote_asset: usd_asset(),
         timestamp: Some(0),
     };
     let result = get_exchange_rate_internal(&env, &call_exchanges_impl, &request)
@@ -548,10 +542,7 @@ fn get_exchange_rate_for_usd_crypto_pair() {
             symbol: "ICP".to_string(),
             class: AssetClass::Cryptocurrency,
         },
-        base_asset: Asset {
-            symbol: USD.to_string(),
-            class: AssetClass::FiatCurrency,
-        },
+        base_asset: usd_asset(),
         timestamp: Some(0),
     };
 
@@ -590,23 +581,18 @@ fn get_exchange_rate_for_crypto_non_usd_pair() {
             0,
             hashmap! {
                     "EUR".to_string() =>
-                        QueriedExchangeRate {
-                            base_asset: Asset {
+                        QueriedExchangeRate::new(
+                            Asset {
                                 symbol: "EUR".to_string(),
                                 class: AssetClass::FiatCurrency,
                             },
-                            quote_asset: Asset {
-                                symbol: USD.to_string(),
-                                class: AssetClass::FiatCurrency,
-                            },
-                            timestamp: 0,
-                            rates: vec![800_000_000],
-                            base_asset_num_queried_sources: 4,
-                            base_asset_num_received_rates: 4,
-                            quote_asset_num_queried_sources: 4,
-                            quote_asset_num_received_rates: 4,
-                            forex_timestamp: Some(0),
-                        },
+                            usd_asset(),
+                            0,
+                            &[800_000_000, 800_000_000, 800_000_000, 800_000_000],
+                            4,
+                            4,
+                            Some(0),
+                        ),
                     // It is necessary to have a CXDR rate with at least 4 sources for the rate store to return a result
                     COMPUTED_XDR_SYMBOL.to_string() => test_cxdr_rate(),
             },
@@ -673,23 +659,18 @@ fn get_exchange_rate_for_non_usd_crypto_pair() {
             0,
             hashmap! {
                     "EUR".to_string() =>
-                        QueriedExchangeRate {
-                            base_asset: Asset {
+                        QueriedExchangeRate::new(
+                            Asset {
                                 symbol: "EUR".to_string(),
                                 class: AssetClass::FiatCurrency,
                             },
-                            quote_asset: Asset {
-                                symbol: USD.to_string(),
-                                class: AssetClass::FiatCurrency,
-                            },
-                            timestamp: 0,
-                            rates: vec![800_000_000],
-                            base_asset_num_queried_sources: 4,
-                            base_asset_num_received_rates: 4,
-                            quote_asset_num_queried_sources: 4,
-                            quote_asset_num_received_rates: 4,
-                            forex_timestamp: Some(0),
-                        },
+                            usd_asset(),
+                            0,
+                            &[800_000_000, 800_000_000, 800_000_000, 800_000_000],
+                            4,
+                            4,
+                            Some(0),
+                        ),
                     // It is necessary to have a CXDR rate with at least 4 sources for the rate store to return a result
                     COMPUTED_XDR_SYMBOL.to_string() => test_cxdr_rate(),
             },
@@ -756,23 +737,18 @@ fn get_exchange_rate_for_non_usd_crypto_pair_crypto_asset_not_found() {
             0,
             hashmap! {
                     "EUR".to_string() =>
-                        QueriedExchangeRate {
-                            base_asset: Asset {
+                        QueriedExchangeRate::new(
+                            Asset {
                                 symbol: "EUR".to_string(),
                                 class: AssetClass::FiatCurrency,
                             },
-                            quote_asset: Asset {
-                                symbol: USD.to_string(),
-                                class: AssetClass::FiatCurrency,
-                            },
-                            timestamp: 0,
-                            rates: vec![800_000_000],
-                            base_asset_num_queried_sources: 4,
-                            base_asset_num_received_rates: 4,
-                            quote_asset_num_queried_sources: 4,
-                            quote_asset_num_received_rates: 4,
-                            forex_timestamp: Some(0),
-                        },
+                            usd_asset(),
+                            0,
+                            &[800_000_000, 800_000_000, 800_000_000, 800_000_000],
+                            4,
+                            4,
+                            Some(0),
+                        ),
                     // It is necessary to have a CXDR rate with at least 4 sources for the rate store to return a result
                     COMPUTED_XDR_SYMBOL.to_string() => test_cxdr_rate(),
             },
@@ -856,23 +832,18 @@ fn get_exchange_rate_for_fiat_eur_usd_pair() {
             0,
             hashmap! {
                     "EUR".to_string() =>
-                        QueriedExchangeRate {
-                            base_asset: Asset {
+                        QueriedExchangeRate::new(
+                            Asset {
                                 symbol: "EUR".to_string(),
                                 class: AssetClass::FiatCurrency,
                             },
-                            quote_asset: Asset {
-                                symbol: USD.to_string(),
-                                class: AssetClass::FiatCurrency,
-                            },
-                            timestamp: 0,
-                            rates: vec![800_000_000],
-                            base_asset_num_queried_sources: 4,
-                            base_asset_num_received_rates: 4,
-                            quote_asset_num_queried_sources: 4,
-                            quote_asset_num_received_rates: 4,
-                            forex_timestamp: Some(0),
-                        },
+                            usd_asset(),
+                            0,
+                            &[800_000_000, 800_000_000, 800_000_000, 800_000_000],
+                            4,
+                            4,
+                            Some(0),
+                        ),
                     // It is necessary to have a CXDR rate with at least 4 sources for the rate store to return a result
                     COMPUTED_XDR_SYMBOL.to_string() => test_cxdr_rate(),
             },
@@ -884,10 +855,7 @@ fn get_exchange_rate_for_fiat_eur_usd_pair() {
             symbol: "EUR".to_string(),
             class: AssetClass::FiatCurrency,
         },
-        quote_asset: Asset {
-            symbol: USD.to_string(),
-            class: AssetClass::FiatCurrency,
-        },
+        quote_asset: usd_asset(),
         timestamp: Some(0),
     };
     let result = get_exchange_rate_internal(&env, &call_exchanges_impl, &request)
@@ -914,23 +882,18 @@ fn get_exchange_rate_for_fiat_with_unknown_symbol() {
             0,
             hashmap! {
                     "EUR".to_string() =>
-                        QueriedExchangeRate {
-                            base_asset: Asset {
+                        QueriedExchangeRate::new(
+                            Asset {
                                 symbol: "EUR".to_string(),
                                 class: AssetClass::FiatCurrency,
                             },
-                            quote_asset: Asset {
-                                symbol: USD.to_string(),
-                                class: AssetClass::FiatCurrency,
-                            },
-                            timestamp: 0,
-                            rates: vec![800_000_000],
-                            base_asset_num_queried_sources: 4,
-                            base_asset_num_received_rates: 4,
-                            quote_asset_num_queried_sources: 4,
-                            quote_asset_num_received_rates: 4,
-                            forex_timestamp: Some(0),
-                        },
+                            usd_asset(),
+                            0,
+                            &[800_000_000, 800_000_000, 800_000_000, 800_000_000],
+                            4,
+                            4,
+                            Some(0),
+                        ),
                     // It is necessary to have a CXDR rate with at least 4 sources for the rate store to return a result
                     COMPUTED_XDR_SYMBOL.to_string() => test_cxdr_rate(),
             },
@@ -942,10 +905,7 @@ fn get_exchange_rate_for_fiat_with_unknown_symbol() {
             symbol: "RTY".to_string(),
             class: AssetClass::FiatCurrency,
         },
-        quote_asset: Asset {
-            symbol: USD.to_string(),
-            class: AssetClass::FiatCurrency,
-        },
+        quote_asset: usd_asset(),
         timestamp: Some(0),
     };
     let result = get_exchange_rate_internal(&env, &call_exchanges_impl, &request)
@@ -972,23 +932,18 @@ fn get_exchange_rate_for_fiat_with_unknown_timestamp() {
             86_400,
             hashmap! {
                     "EUR".to_string() =>
-                        QueriedExchangeRate {
-                            base_asset: Asset {
+                        QueriedExchangeRate::new(
+                            Asset {
                                 symbol: "EUR".to_string(),
                                 class: AssetClass::FiatCurrency,
                             },
-                            quote_asset: Asset {
-                                symbol: USD.to_string(),
-                                class: AssetClass::FiatCurrency,
-                            },
-                            timestamp: 86_400,
-                            rates: vec![800_000_000],
-                            base_asset_num_queried_sources: 4,
-                            base_asset_num_received_rates: 4,
-                            quote_asset_num_queried_sources: 4,
-                            quote_asset_num_received_rates: 4,
-                            forex_timestamp: Some(0),
-                        },
+                            usd_asset(),
+                            86_400,
+                            &[800_000_000, 800_000_000, 800_000_000, 800_000_000],
+                            4,
+                            4,
+                            Some(0),
+                        ),
                     // It is necessary to have a CXDR rate with at least 4 sources for the rate store to return a result
                     COMPUTED_XDR_SYMBOL.to_string() => test_cxdr_rate(),
             },
@@ -1000,10 +955,7 @@ fn get_exchange_rate_for_fiat_with_unknown_timestamp() {
             symbol: "EUR".to_string(),
             class: AssetClass::FiatCurrency,
         },
-        quote_asset: Asset {
-            symbol: USD.to_string(),
-            class: AssetClass::FiatCurrency,
-        },
+        quote_asset: usd_asset(),
         timestamp: Some(0),
     };
     let result = get_exchange_rate_internal(&env, &call_exchanges_impl, &request)
@@ -1255,10 +1207,7 @@ mod privileged_callers_can_bypass_pending {
                 symbol: "ICP".to_string(),
                 class: AssetClass::Cryptocurrency,
             },
-            quote_asset: Asset {
-                symbol: USD.to_string(),
-                class: AssetClass::FiatCurrency,
-            },
+            quote_asset: usd_asset(),
             timestamp: Some(0),
         };
 
@@ -1370,10 +1319,7 @@ mod uses_previous_minute_when_timestamp_is_null_if_request_would_be_pending {
                 symbol: "ICP".to_string(),
                 class: AssetClass::Cryptocurrency,
             },
-            quote_asset: Asset {
-                symbol: USD.to_string(),
-                class: AssetClass::FiatCurrency,
-            },
+            quote_asset: usd_asset(),
             timestamp: None,
         };
 
@@ -1404,10 +1350,7 @@ mod uses_previous_minute_when_timestamp_is_null_if_request_would_be_pending {
                 symbol: "ICP".to_string(),
                 class: AssetClass::Cryptocurrency,
             },
-            quote_asset: Asset {
-                symbol: USD.to_string(),
-                class: AssetClass::FiatCurrency,
-            },
+            quote_asset: usd_asset(),
             timestamp: None,
         };
 
@@ -1439,10 +1382,7 @@ mod uses_previous_minute_when_timestamp_is_null_if_request_would_be_pending {
                 symbol: "ICP".to_string(),
                 class: AssetClass::Cryptocurrency,
             },
-            quote_asset: Asset {
-                symbol: USD.to_string(),
-                class: AssetClass::FiatCurrency,
-            },
+            quote_asset: usd_asset(),
             timestamp: None,
         };
 
@@ -1615,10 +1555,7 @@ mod timestamp_is_in_future {
                 symbol: "ICP".to_string(),
                 class: AssetClass::Cryptocurrency,
             },
-            quote_asset: Asset {
-                symbol: USD.to_string(),
-                class: AssetClass::FiatCurrency,
-            },
+            quote_asset: usd_asset(),
             timestamp: Some(future_timestamp),
         };
 
@@ -1647,10 +1584,7 @@ mod timestamp_is_in_future {
                 symbol: "EUR".to_string(),
                 class: AssetClass::FiatCurrency,
             },
-            quote_asset: Asset {
-                symbol: USD.to_string(),
-                class: AssetClass::FiatCurrency,
-            },
+            quote_asset: usd_asset(),
             timestamp: Some(future_timestamp),
         };
 
@@ -1782,10 +1716,7 @@ mod request_contains_invalid_symbols {
                 symbol: "-)]}:@[!]+.;!#_-&$,;{%$@&;=]?%".to_string(),
                 class: AssetClass::Cryptocurrency,
             },
-            quote_asset: Asset {
-                symbol: USD.to_string(),
-                class: AssetClass::FiatCurrency,
-            },
+            quote_asset: usd_asset(),
             timestamp: Some(current_timestamp),
         };
 
@@ -1875,10 +1806,7 @@ mod request_contains_invalid_symbols {
             .with_accepted_cycles(XRC_MINIMUM_FEE_COST)
             .build();
         let request = GetExchangeRateRequest {
-            base_asset: Asset {
-                symbol: USD.to_string(),
-                class: AssetClass::FiatCurrency,
-            },
+            base_asset: usd_asset(),
             quote_asset: Asset {
                 symbol: "@!!!@&%!$&#@*$&=$&=@".to_string(),
                 class: AssetClass::Cryptocurrency,
@@ -1911,10 +1839,7 @@ mod request_contains_invalid_symbols {
                 symbol: "+!!*%$#%%&=&*$!%%=%#".to_string(),
                 class: AssetClass::FiatCurrency,
             },
-            quote_asset: Asset {
-                symbol: USD.to_string(),
-                class: AssetClass::FiatCurrency,
-            },
+            quote_asset: usd_asset(),
             timestamp: Some(current_timestamp),
         };
 
@@ -1939,10 +1864,7 @@ mod request_contains_invalid_symbols {
             .with_accepted_cycles(XRC_MINIMUM_FEE_COST)
             .build();
         let request = GetExchangeRateRequest {
-            base_asset: Asset {
-                symbol: USD.to_string(),
-                class: AssetClass::FiatCurrency,
-            },
+            base_asset: usd_asset(),
             quote_asset: Asset {
                 symbol: "<>".to_string(),
                 class: AssetClass::FiatCurrency,

--- a/src/xrc/src/api/test.rs
+++ b/src/xrc/src/api/test.rs
@@ -29,7 +29,7 @@ fn test_cxdr_rate() -> QueriedExchangeRate {
             class: AssetClass::FiatCurrency,
         },
         0,
-        &vec![800_000_000, 800_000_000, 800_000_000, 800_000_000],
+        &[800_000_000, 800_000_000, 800_000_000, 800_000_000],
         4,
         4,
         Some(0),

--- a/src/xrc/src/api/test.rs
+++ b/src/xrc/src/api/test.rs
@@ -7,6 +7,7 @@ use maplit::hashmap;
 
 use crate::{
     environment::test::TestEnvironment,
+    forex::COMPUTED_XDR_SYMBOL,
     inflight::test::set_inflight_tracking,
     rate_limiting::test::{set_request_counter, REQUEST_COUNTER_TRIGGER_RATE_LIMIT},
     with_cache_mut, with_forex_rate_store_mut, CallExchangeError, QueriedExchangeRate, DAI,
@@ -16,6 +17,24 @@ use crate::{
 };
 
 use super::{get_exchange_rate_internal, CallExchanges};
+
+fn test_cxdr_rate() -> QueriedExchangeRate {
+    QueriedExchangeRate::new(
+        Asset {
+            symbol: COMPUTED_XDR_SYMBOL.to_string(),
+            class: AssetClass::FiatCurrency,
+        },
+        Asset {
+            symbol: USD.to_string(),
+            class: AssetClass::FiatCurrency,
+        },
+        0,
+        &vec![800_000_000, 800_000_000, 800_000_000, 800_000_000],
+        4,
+        4,
+        Some(0),
+    )
+}
 
 /// Used to simulate HTTP outcalls from the canister for testing purposes.
 #[derive(Default)]
@@ -589,24 +608,7 @@ fn get_exchange_rate_for_crypto_non_usd_pair() {
                             forex_timestamp: Some(0),
                         },
                     // It is necessary to have a CXDR rate with at least 4 sources for the rate store to return a result
-                    "CXDR".to_string() =>
-                        QueriedExchangeRate {
-                            base_asset: Asset {
-                                symbol: "CXDR".to_string(),
-                                class: AssetClass::FiatCurrency,
-                            },
-                            quote_asset: Asset {
-                                symbol: USD.to_string(),
-                                class: AssetClass::FiatCurrency,
-                            },
-                            timestamp: 0,
-                            rates: vec![800_000_000],
-                            base_asset_num_queried_sources: 4,
-                            base_asset_num_received_rates: 4,
-                            quote_asset_num_queried_sources: 4,
-                            quote_asset_num_received_rates: 4,
-                            forex_timestamp: Some(0),
-                        }
+                    COMPUTED_XDR_SYMBOL.to_string() => test_cxdr_rate(),
             },
         );
     });
@@ -689,24 +691,7 @@ fn get_exchange_rate_for_non_usd_crypto_pair() {
                             forex_timestamp: Some(0),
                         },
                     // It is necessary to have a CXDR rate with at least 4 sources for the rate store to return a result
-                    "CXDR".to_string() =>
-                        QueriedExchangeRate {
-                            base_asset: Asset {
-                                symbol: "CXDR".to_string(),
-                                class: AssetClass::FiatCurrency,
-                            },
-                            quote_asset: Asset {
-                                symbol: USD.to_string(),
-                                class: AssetClass::FiatCurrency,
-                            },
-                            timestamp: 0,
-                            rates: vec![800_000_000],
-                            base_asset_num_queried_sources: 4,
-                            base_asset_num_received_rates: 4,
-                            quote_asset_num_queried_sources: 4,
-                            quote_asset_num_received_rates: 4,
-                            forex_timestamp: Some(0),
-                        }
+                    COMPUTED_XDR_SYMBOL.to_string() => test_cxdr_rate(),
             },
         );
     });
@@ -789,24 +774,7 @@ fn get_exchange_rate_for_non_usd_crypto_pair_crypto_asset_not_found() {
                             forex_timestamp: Some(0),
                         },
                     // It is necessary to have a CXDR rate with at least 4 sources for the rate store to return a result
-                    "CXDR".to_string() =>
-                        QueriedExchangeRate {
-                            base_asset: Asset {
-                                symbol: "CXDR".to_string(),
-                                class: AssetClass::FiatCurrency,
-                            },
-                            quote_asset: Asset {
-                                symbol: USD.to_string(),
-                                class: AssetClass::FiatCurrency,
-                            },
-                            timestamp: 0,
-                            rates: vec![800_000_000],
-                            base_asset_num_queried_sources: 4,
-                            base_asset_num_received_rates: 4,
-                            quote_asset_num_queried_sources: 4,
-                            quote_asset_num_received_rates: 4,
-                            forex_timestamp: Some(0),
-                        }
+                    COMPUTED_XDR_SYMBOL.to_string() => test_cxdr_rate(),
             },
         );
     });
@@ -906,24 +874,7 @@ fn get_exchange_rate_for_fiat_eur_usd_pair() {
                             forex_timestamp: Some(0),
                         },
                     // It is necessary to have a CXDR rate with at least 4 sources for the rate store to return a result
-                    "CXDR".to_string() =>
-                        QueriedExchangeRate {
-                            base_asset: Asset {
-                                symbol: "CXDR".to_string(),
-                                class: AssetClass::FiatCurrency,
-                            },
-                            quote_asset: Asset {
-                                symbol: USD.to_string(),
-                                class: AssetClass::FiatCurrency,
-                            },
-                            timestamp: 0,
-                            rates: vec![800_000_000],
-                            base_asset_num_queried_sources: 4,
-                            base_asset_num_received_rates: 4,
-                            quote_asset_num_queried_sources: 4,
-                            quote_asset_num_received_rates: 4,
-                            forex_timestamp: Some(0),
-                        }
+                    COMPUTED_XDR_SYMBOL.to_string() => test_cxdr_rate(),
             },
         );
     });
@@ -981,24 +932,7 @@ fn get_exchange_rate_for_fiat_with_unknown_symbol() {
                             forex_timestamp: Some(0),
                         },
                     // It is necessary to have a CXDR rate with at least 4 sources for the rate store to return a result
-                    "CXDR".to_string() =>
-                        QueriedExchangeRate {
-                            base_asset: Asset {
-                                symbol: "CXDR".to_string(),
-                                class: AssetClass::FiatCurrency,
-                            },
-                            quote_asset: Asset {
-                                symbol: USD.to_string(),
-                                class: AssetClass::FiatCurrency,
-                            },
-                            timestamp: 0,
-                            rates: vec![800_000_000],
-                            base_asset_num_queried_sources: 4,
-                            base_asset_num_received_rates: 4,
-                            quote_asset_num_queried_sources: 4,
-                            quote_asset_num_received_rates: 4,
-                            forex_timestamp: Some(0),
-                        }
+                    COMPUTED_XDR_SYMBOL.to_string() => test_cxdr_rate(),
             },
         );
     });
@@ -1056,24 +990,7 @@ fn get_exchange_rate_for_fiat_with_unknown_timestamp() {
                             forex_timestamp: Some(0),
                         },
                     // It is necessary to have a CXDR rate with at least 4 sources for the rate store to return a result
-                    "CXDR".to_string() =>
-                        QueriedExchangeRate {
-                            base_asset: Asset {
-                                symbol: "CXDR".to_string(),
-                                class: AssetClass::FiatCurrency,
-                            },
-                            quote_asset: Asset {
-                                symbol: USD.to_string(),
-                                class: AssetClass::FiatCurrency,
-                            },
-                            timestamp: 0,
-                            rates: vec![800_000_000],
-                            base_asset_num_queried_sources: 4,
-                            base_asset_num_received_rates: 4,
-                            quote_asset_num_queried_sources: 4,
-                            quote_asset_num_received_rates: 4,
-                            forex_timestamp: Some(0),
-                        }
+                    COMPUTED_XDR_SYMBOL.to_string() => test_cxdr_rate(),
             },
         );
     });

--- a/src/xrc/src/forex/italy.rs
+++ b/src/xrc/src/forex/italy.rs
@@ -136,7 +136,6 @@ mod test {
         let query_response = load_file("test-data/forex/bank-of-italy.json");
         let timestamp: u64 = 1656374400;
         let extracted_rates = forex.extract_rate(&query_response, timestamp);
-        println!(">>> {:?}", &extracted_rates);
         assert!(matches!(extracted_rates, Ok(ref rates) if rates["EUR"] == 1_056_100_000));
         assert!(matches!(extracted_rates, Ok(ref rates) if rates["JPY"] == 7_350_873));
         // The BWP rate in the test JSON file has been modified to use exchangeConventionCode="I", which means the rate is inverted.

--- a/src/xrc/src/periodic.rs
+++ b/src/xrc/src/periodic.rs
@@ -293,8 +293,7 @@ mod test {
             "CHF".to_string() => 7_000,
             COMPUTED_XDR_SYMBOL.to_string() => 10_000,
         };
-        // The [ForexRatesStore] would only return a value if it has at least 4 sources for CXDR
-        // So we add here four sources with the same rates.
+        // The [ForexRatesStore] would only return a value if it has sufficiently many sources for CXDR.
         let mock_forex_sources =
             MockForexSourcesImpl::new(vec![map.clone(), map.clone(), map.clone(), map], vec![]);
         update_forex_store(timestamp, &mock_forex_sources)

--- a/src/xrc/src/periodic.rs
+++ b/src/xrc/src/periodic.rs
@@ -242,6 +242,7 @@ mod test {
     use futures::FutureExt;
     use maplit::hashmap;
 
+    use crate::forex::COMPUTED_XDR_SYMBOL;
     use crate::with_forex_rate_store;
 
     use super::*;
@@ -290,8 +291,12 @@ mod test {
             "EUR".to_string() => 10_000,
             "SGD".to_string() => 1_000,
             "CHF".to_string() => 7_000,
+            COMPUTED_XDR_SYMBOL.to_string() => 10_000,
         };
-        let mock_forex_sources = MockForexSourcesImpl::new(vec![map], vec![]);
+        // The [ForexRatesStore] would only return a value if it has at least 4 sources for CXDR
+        // So we add here four sources with the same rates.
+        let mock_forex_sources =
+            MockForexSourcesImpl::new(vec![map.clone(), map.clone(), map.clone(), map], vec![]);
         update_forex_store(timestamp, &mock_forex_sources)
             .now_or_never()
             .expect("should have executed");
@@ -299,7 +304,7 @@ mod test {
             store.get(start_of_day, timestamp + ONE_DAY_SECONDS, "eur", "usd")
         });
         assert!(
-            matches!(result, Ok(ref forex_rate) if forex_rate.rates == vec![10_000]),
+            matches!(result, Ok(ref forex_rate) if forex_rate.rates == vec![10_000, 10_000, 10_000, 10_000]),
             "Instead found {:#?}",
             result
         );


### PR DESCRIPTION
This PR changes the going back policy when looking up forex rates to go back up to 7 days, and only to consider days where the CXDR rate has at least 4 rates reported. It also fix various tests that depend on that by adding artificial values for CXDR with enough sources.