### PR TITLE
`refactor`: Cleanup dashboard

### DIFF
--- a/src/xrc/src/api/dashboard.rs
+++ b/src/xrc/src/api/dashboard.rs
@@ -184,12 +184,11 @@ fn render_forex_collector(collector: &ForexRatesCollector, timestamp: u64) -> St
         "<h3>Forex Collection for <span class='ts-class'>{}</span></h3>",
         timestamp
     );
+    let mut sources = collector.get_sources(timestamp).unwrap_or_default();
+    sources.sort_unstable();
     let table = format!(
         "<table class='forex'><tr><th>Sources</th><td>{}</td></tr></table>",
-        collector
-            .get_sources(timestamp)
-            .unwrap_or_default()
-            .join(", ")
+        sources.join(", ")
     );
     format!("{}{}", title, table)
 }

--- a/src/xrc/src/api/dashboard.rs
+++ b/src/xrc/src/api/dashboard.rs
@@ -42,6 +42,10 @@ const DOCUMENT: &str = r#"
                 var tds = document.querySelectorAll(".ts-class");
                 for (var i = 0; i < tds.length; i++) {
                     var td = tds[i];
+                    if (td.textContent.trim() === 'None') {
+                        continue;
+                    }
+
                     var timestamp = td.textContent * 1000;
                     var date = new Date(timestamp);
                     var options = {
@@ -79,6 +83,7 @@ const REQUEST_LOG_TABLE: &str = r#"
             <th>Base Asset</th>
             <th>Quote Asset</th>
             <th>Request Timestamp</th>
+            <th>Response Timestamp</th>
             <th>Error (if occurred)</th>
             <th>Rate</th>
             <th>Base Asset Received Rates</th>
@@ -93,10 +98,6 @@ const REQUEST_LOG_TABLE: &str = r#"
 
 const METADATA_TABLE: &str = r#"
 <table>
-    <tr>
-        <th>Decimals</th>
-        <td>[DECIMALS]</td>
-    </tr>
     <tr>
         <th># of Crypto Exchanges</th>
         <td>[EXCHANGES_NUM]</td>
@@ -140,7 +141,6 @@ fn render() -> Vec<u8> {
 
 fn render_metadata() -> String {
     METADATA_TABLE
-        .replace("[DECIMALS]", &DECIMALS.to_string())
         .replace(
             "[EXCHANGES_NUM]",
             &EXCHANGES
@@ -229,7 +229,8 @@ fn render_asset(asset: &Asset) -> String {
 fn render_result(result: &GetExchangeRateResult) -> String {
     match result {
         Ok(rate) => format!(
-            "<td></td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td>",
+            "<td class='ts-class'>{}</td><td></td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td class='ts-class'>{}</td>",
+            rate.timestamp,
             format_scaled_value(rate.rate),
             rate.metadata.base_asset_num_received_rates,
             rate.metadata.quote_asset_num_received_rates,
@@ -241,7 +242,7 @@ fn render_result(result: &GetExchangeRateResult) -> String {
         ),
         Err(error) => {
             format!(
-                "<td>{:?}</td><td></td><td></td><td></td><td></td><td></td>",
+                "<td>{:?}</td><td></td><td></td><td></td><td></td><td></td><td></td>",
                 error
             )
         }

--- a/src/xrc/src/periodic.rs
+++ b/src/xrc/src/periodic.rs
@@ -242,7 +242,6 @@ mod test {
     use futures::FutureExt;
     use maplit::hashmap;
 
-    use crate::forex::COMPUTED_XDR_SYMBOL;
     use crate::with_forex_rate_store;
 
     use super::*;
@@ -291,11 +290,8 @@ mod test {
             "EUR".to_string() => 10_000,
             "SGD".to_string() => 1_000,
             "CHF".to_string() => 7_000,
-            COMPUTED_XDR_SYMBOL.to_string() => 10_000,
         };
-        // The [ForexRatesStore] would only return a value if it has sufficiently many sources for CXDR.
-        let mock_forex_sources =
-            MockForexSourcesImpl::new(vec![map.clone(), map.clone(), map.clone(), map], vec![]);
+        let mock_forex_sources = MockForexSourcesImpl::new(vec![map], vec![]);
         update_forex_store(timestamp, &mock_forex_sources)
             .now_or_never()
             .expect("should have executed");
@@ -303,7 +299,7 @@ mod test {
             store.get(start_of_day, timestamp + ONE_DAY_SECONDS, "eur", "usd")
         });
         assert!(
-            matches!(result, Ok(ref forex_rate) if forex_rate.rates == vec![10_000, 10_000, 10_000, 10_000]),
+            matches!(result, Ok(ref forex_rate) if forex_rate.rates == vec![10_000]),
             "Instead found {:#?}",
             result
         );


### PR DESCRIPTION
A minor cleanup for the dashboard to include the response timestamp, remove the decimals, and sort the forex sources.