### PR TITLE
test: Add caching `e2e` test

### DIFF
--- a/src/xrc-tests/src/lib.rs
+++ b/src/xrc-tests/src/lib.rs
@@ -1,5 +1,7 @@
 #[cfg(test)]
 const ONE_DAY_SECONDS: u64 = 86_400;
+#[cfg(test)]
+const ONE_MINUTE_SECONDS: u64 = 60;
 
 #[cfg(test)]
 mod container;

--- a/src/xrc-tests/src/tests.rs
+++ b/src/xrc-tests/src/tests.rs
@@ -1,3 +1,3 @@
 mod basic_exchange_rates;
-mod can_successfully_cache_rates;
+mod caching;
 mod get_icp_xdr_rate;

--- a/src/xrc-tests/src/tests/caching.rs
+++ b/src/xrc-tests/src/tests/caching.rs
@@ -24,7 +24,7 @@ use crate::{
 ///
 /// * All queries are handled correctly
 ///
-/// How are the expected values determined:
+/// The expected values are determined as follows:
 ///
 /// Crypto-pair (retrieve ICP/BTC rate)
 /// 0. The XRC retrieves the ICP/USDT rate.

--- a/src/xrc-tests/src/tests/caching.rs
+++ b/src/xrc-tests/src/tests/caching.rs
@@ -125,14 +125,17 @@ fn caching() {
 
         // Compare the response times of the samples to ensure the cache mechanism was used
         // for subsequent requests after the first.
-        //
-        // The subsequent requests should arrive in at least half the time.
+        let first_sample_millis = samples[0].time_passed_millis as f64;
+        let threshold = first_sample_millis * 0.6;
+        println!("threshold = {}", threshold);
         for (n, sample) in samples.iter().skip(1).enumerate() {
+            let current_sample_millis = sample.time_passed_millis as f64;
             println!(
                 "r1 = {}, r{} = {}",
-                samples[0].time_passed_millis, n, sample.time_passed_millis
+                first_sample_millis, n, current_sample_millis
             );
-            assert!(samples[0].time_passed_millis / sample.time_passed_millis >= 2);
+
+            assert!(current_sample_millis / first_sample_millis <= threshold);
         }
 
         Ok(())


### PR DESCRIPTION
This PR adds an e2e test for the crypto caching mechanism.

---

Setup:
* Deploy mock FOREX data providers and exchanges with a large response delay

Start replicas and deploy the XRC, configured to use the mock data sources

Runbook:

1. Request the same exchange rate many times per second for a bounded time, e.g., 1 minute
2. Assert that all requests are answered with the same rate with a small delay after the first response (due to caching in the XRC)

Success criteria:

* All queries are handled correctly