### PR TITLE
Removing floating-point square-root operations

### DIFF
--- a/src/xrc-tests/src/tests.rs
+++ b/src/xrc-tests/src/tests.rs
@@ -1,5 +1,5 @@
 mod basic_exchange_rates;
 mod caching;
+mod determinism;
 mod get_icp_xdr_rate;
 mod misbehavior;
-mod determinism;

--- a/src/xrc/src/forex.rs
+++ b/src/xrc/src/forex.rs
@@ -20,6 +20,7 @@ use std::collections::{HashSet, VecDeque};
 use std::mem::size_of_val;
 
 use crate::api::usd_asset;
+use crate::utils::integer_sqrt;
 use crate::{
     median, standard_deviation, utils, AllocatedBytes, ExtractError, QueriedExchangeRate,
     ONE_DAY_SECONDS, ONE_HOUR_SECONDS, ONE_KIB, RATE_UNIT, USD,
@@ -565,8 +566,8 @@ impl OneDayRatesCollector {
             // The rates are set to [xdr_rate, xdr_rate, xdr_rate + difference], where
             // difference = sqrt(3*variance). This set has the required properties:
             // * The median of the set is xdr_rate.
-            // * The variance of the set corresponds is 'variance'.
-            let difference = ((3 * variance) as f64).sqrt() as u64;
+            // * The variance of the set is 'variance'.
+            let difference = integer_sqrt(3 * variance);
 
             Some(QueriedExchangeRate::new(
                 Asset {

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -1390,7 +1390,7 @@ mod test {
     fn conversion_to_exchange_rate_exceeding_limits() {
         let large_rates = vec![RATE_UNIT * RATE_UNIT, RATE_UNIT * RATE_UNIT];
 
-        let greater_than_one_rate = (1.000000001 * (RATE_UNIT as f64)) as u64;
+        let greater_than_one_rate = RATE_UNIT + 1;
 
         let greater_than_one_rates = vec![
             greater_than_one_rate,
@@ -1485,7 +1485,7 @@ mod test {
             btt_asset,
             usd_asset(),
             0,
-            &[(0.00000053 * RATE_UNIT as f64) as u64],
+            &[530], // 0.00000053 USD
             1,
             1,
             None,

--- a/src/xrc/src/utils.rs
+++ b/src/xrc/src/utils.rs
@@ -58,7 +58,7 @@ pub(crate) fn median_in_set(values: &[u64]) -> u64 {
 /// value. Since the function is used to compute the standard deviation of 64-bit numbers given
 /// its variance, this limitation is not a concern because the variance is always lower than this
 /// upper bound.
-fn integer_sqrt(number: u128) -> u64 {
+pub(crate) fn integer_sqrt(number: u128) -> u64 {
     let mut difference: u128 = number;
     let mut result: u128 = 0;
     let mut power: u128 = 1 << 126;

--- a/src/xrc/src/utils.rs
+++ b/src/xrc/src/utils.rs
@@ -96,7 +96,6 @@ pub(crate) fn standard_deviation(rates: &[u64]) -> u64 {
         .map(|rate| ((*rate as i128).saturating_sub(mean)).saturating_pow(2) as u128)
         .sum::<u128>()
         .saturating_div(count.saturating_sub(1) as u128);
-    println!("Variance: {}", variance);
     integer_sqrt(variance)
 }
 


### PR DESCRIPTION
This PR removes the square-root operations on floating-point numbers, which require a conversion to floating-point numbers and then back.
Instead, an integer square-root function is introduced and used. The function has the following property:
If `y = integer_sqrt(x)`, then `y*y <= x` and `(y+1) * (y+1) > x`.

It is worth noting that the square-root function over real numbers doesn't have this property, so the new function is in some sense more precise.