### PR TITLE
`chore`: Improve workflows for release

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -16,15 +16,13 @@ runs:
     - name: Set up docker buildx
       uses: docker/setup-buildx-action@v1
 
-    - name: Build base Docker image
+    - name: Build Exchange Rate Canister Docker image
       uses: docker/build-push-action@v2
       with:
         context: .
         file: Dockerfile
-        cache-from: type=gha,scope=cached-stage
-        cache-to: type=gha,scope=cached-stage,mode=max
+        # Exports the artifacts from the final stage
         outputs: ./out
-        target: builder
 
     - name: "Upload wasm module"
       uses: actions/upload-artifact@v2

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -27,5 +27,5 @@ runs:
     - name: "Upload wasm module"
       uses: actions/upload-artifact@v2
       with:
-        name: Exchange Rate Canister wasm module
+        name: Exchange Rate Canister WASM Module
         path: ./out/xrc.wasm.gz

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,0 +1,29 @@
+name: 'Build the XRC'
+description: |
+  Builds the artifacts for the XRC release.
+
+inputs:
+  token:
+    description: "Github access token used to make the release"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v2
+
+    # We use buildx and its GitHub Actions caching support `type=gha`. For
+    # more information, see
+    # https://github.com/docker/build-push-action/issues/539
+    - name: Set up docker buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Build base Docker image
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: Dockerfile
+        cache-from: type=gha,scope=cached-stage
+        cache-to: type=gha,scope=cached-stage,mode=max
+        outputs: type=cacheonly
+        target: builder

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -10,8 +10,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v2
-
     # We use buildx and its GitHub Actions caching support `type=gha`. For
     # more information, see
     # https://github.com/docker/build-push-action/issues/539
@@ -25,5 +23,11 @@ runs:
         file: Dockerfile
         cache-from: type=gha,scope=cached-stage
         cache-to: type=gha,scope=cached-stage,mode=max
-        outputs: type=cacheonly
+        outputs: ./out
         target: builder
+
+    - name: "Upload wasm module"
+      uses: actions/upload-artifact@v2
+      with:
+        name: Exchange Rate Canister wasm module
+        path: ./out/xrc.wasm.gz

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -31,10 +31,6 @@ jobs:
   assets:
     needs: builder
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        include:
-          - BUILD_NAME: "mainnet"
     steps:
       - uses: actions/checkout@v2
       - name: Set up docker buildx
@@ -47,12 +43,12 @@ jobs:
           file: Dockerfile
           cache-from: type=gha,scope=cached-stage
           # Exports the artifacts from the final stage
-          outputs: ./${{ matrix.BUILD_NAME }}-out
-      - name: "Upload ${{ matrix.BUILD_NAME }} wasm module"
+          outputs: ./out
+      - name: "Upload wasm module"
         uses: actions/upload-artifact@v2
         with:
           name: Exchange Rate Canister wasm module
-          path: ${{ matrix.BUILD_NAME }}-out/xrc.wasm.gz
+          path: ./out/xrc.wasm.gz
       - name: "Link the build sha to this commit"
         run: |
           : Set up git
@@ -60,16 +56,16 @@ jobs:
           git config user.email "<>"
           : Make a note of the WASM shasum.
           NOTE="refs/notes/*"
-          SHA="$(sha256sum < "${{ matrix.BUILD_NAME }}-out/xrc.wasm.gz")"
+          SHA="$(sha256sum < "./out/xrc.wasm.gz")"
           echo $SHA
           git fetch origin "+${NOTE}:${NOTE}"
-          if git notes --ref="${{ matrix.BUILD_NAME }}/wasm-sha" add -m "$SHA"
+          if git notes --ref="wasm-sha" add -m "$SHA"
           then git push origin "${NOTE}:${NOTE}" || true
           else echo SHA already set
           fi
       - name: "Verify that the WASM module is small enough to deploy"
         run: |
-          wasm_size="$(wc -c < "${{ matrix.BUILD_NAME }}-out/xrc.wasm.gz")"
+          wasm_size="$(wc -c < "./out/xrc.wasm.gz")"
           max_size=2097000
           echo "WASM size:          $wasm_size"
           echo "Max supported size: $max_size"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -7,48 +7,13 @@ on:
   pull_request:
 
 jobs:
-  builder:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-
-      # We use buildx and its GitHub Actions caching support `type=gha`. For
-      # more information, see
-      # https://github.com/docker/build-push-action/issues/539
-      - name: Set up docker buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Build base Docker image
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          file: Dockerfile
-          cache-from: type=gha,scope=cached-stage
-          cache-to: type=gha,scope=cached-stage,mode=max
-          outputs: type=cacheonly
-          target: builder
-
   assets:
-    needs: builder
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up docker buildx
-        uses: docker/setup-buildx-action@v1
-      # Build and upload
-      - name: Build Exchange Rate Canister Docker image
-        uses: docker/build-push-action@v2
+      - name: Build canister
+        uses: ./.github/actions/build
         with:
-          context: .
-          file: Dockerfile
-          cache-from: type=gha,scope=cached-stage
-          # Exports the artifacts from the final stage
-          outputs: ./out
-      - name: "Upload wasm module"
-        uses: actions/upload-artifact@v2
-        with:
-          name: Exchange Rate Canister wasm module
-          path: ./out/xrc.wasm.gz
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: "Link the build sha to this commit"
         run: |
           : Set up git

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -10,6 +10,7 @@ jobs:
   assets:
     runs-on: ubuntu-20.04
     steps:
+      - uses: actions/checkout@v3
       - name: Build canister
         uses: ./.github/actions/build
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,6 @@ on:
   push:
     tags:
       - "*"
-  pull_request:
 
 env:
   DFX_VERSION: "0.14.1"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,8 @@ name: "release"
 
 on:
   push:
-    tags: '*'
+    tags:
+      - "*"
   pull_request:
 
 env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,4 +31,5 @@ jobs:
       - name: Release
         uses: "softprops/action-gh-release@v1"
         with:
-          files: ./out/xrc.wasm.gz
+          files: |
+            ./out/xrc.wasm.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,7 @@ name: "release"
 
 on:
   push:
-    branches:
-      - main
+    tags: '*'
   pull_request:
 
 env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,14 +27,9 @@ jobs:
       - name: Build canister
         uses: ./.github/actions/build
         with:
-          assets_dir: 'out'
           token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build canister
-        run: |
-          dfx build --network ic
 
       - name: Release
         uses: "softprops/action-gh-release@v1"
         with:
-          files: .dfx/ic/canisters/service/service.wasm
+          files: ./out/xrc.wasm.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+# Steps:
+# 1. Build the xrc
+# 2. Push the release out.
+
+name: "release"
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+env:
+  DFX_VERSION: "0.14.1"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: "Release"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build canister
+        uses: ./.github/actions/build
+        with:
+          assets_dir: 'out'
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build canister
+        run: |
+          dfx build --network ic
+
+      - name: Release
+        uses: "softprops/action-gh-release@v1"
+        with:
+          files: .dfx/ic/canisters/service/service.wasm


### PR DESCRIPTION
This PR updates the GitHub workflows to allow to create a release via a tag.