### PR TITLE
Update cycle pricing

### DIFF
--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -56,20 +56,20 @@ const RATE_DEVIATION_DIVISOR: u64 = 10;
 const LOG_PREFIX: &str = "[xrc]";
 
 /// The number of cycles needed to use the `xrc` canister.
-pub const XRC_REQUEST_CYCLES_COST: u64 = 10_000_000_000;
+pub const XRC_REQUEST_CYCLES_COST: u64 = 1_000_000_000;
 
 /// The cost in cycles needed to make an outbound HTTP call.
-pub const XRC_OUTBOUND_HTTP_CALL_CYCLES_COST: u64 = 2_400_000_000;
+pub const XRC_OUTBOUND_HTTP_CALL_CYCLES_COST: u64 = 240_000_000;
 
 /// The amount of cycles refunded off the top of a call. Number will be adjusted based
 /// on the number of sources the canister will use.
-pub const XRC_IMMEDIATE_REFUND_CYCLES: u64 = 5_000_000_000;
+pub const XRC_IMMEDIATE_REFUND_CYCLES: u64 = 500_000_000;
 
 /// The base cost in cycles that will always be charged when receiving a valid response from the `xrc` canister.
-pub const XRC_BASE_CYCLES_COST: u64 = 200_000_000;
+pub const XRC_BASE_CYCLES_COST: u64 = 20_000_000;
 
 /// The amount of cycles charged if a call fails (rate limited, failed to find forex rate in store, etc.).
-pub const XRC_MINIMUM_FEE_COST: u64 = 10_000_000;
+pub const XRC_MINIMUM_FEE_COST: u64 = 1_000_000;
 
 /// The maximum relative difference between accepted rates is 20%.
 pub const MAX_RELATIVE_DIFFERENCE_DIVISOR: u64 = 5;


### PR DESCRIPTION
The subnet `uzr34` was recently updated and now charges the [lower prices](https://internetcomputer.org/docs/current/developer-docs/gas-cost) for HTTPS outcalls.

This PR adapts the pricing of the exchange rate canister accordingly, reducing all prices by a factor of 10.