### PR TITLE
`chore`: Update Coinbase max response bytes

### DIFF
--- a/src/xrc/src/exchanges.rs
+++ b/src/xrc/src/exchanges.rs
@@ -291,6 +291,10 @@ impl IsExchange for Coinbase {
     fn supported_stablecoin_pairs(&self) -> &[(&str, &str)] {
         &[(USDT, USDC)]
     }
+
+    fn max_response_bytes(&self) -> u64 {
+        2 * ONE_KIB
+    }
 }
 
 /// KuCoin
@@ -722,7 +726,7 @@ mod test {
         let exchange = Exchange::Binance(Binance);
         assert_eq!(exchange.max_response_bytes(), ONE_KIB);
         let exchange = Exchange::Coinbase(Coinbase);
-        assert_eq!(exchange.max_response_bytes(), ONE_KIB);
+        assert_eq!(exchange.max_response_bytes(), 2 * ONE_KIB);
         let exchange = Exchange::KuCoin(KuCoin);
         assert_eq!(exchange.max_response_bytes(), 2 * ONE_KIB);
         let exchange = Exchange::Okx(Okx);


### PR DESCRIPTION
This PR updates the max response bytes for the Coinbase exchange. It has been found that occasionally not enough bytes are assigned resulting in the following message in the logs:

```
Error: Failed to retrieve rate from Coinbase: Http body exceeds size limit of 56 bytes.
```