### PR TITLE
chore: Upgrade Rust version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust: ["1.69.0"]
+        rust: ["1.71.1"]
         os: [ubuntu-20.04, macos-12]
     steps:
       - uses: actions/checkout@v3
@@ -46,7 +46,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust: ["1.62.1"]
+        rust: ["1.71.1"]
         os: [ubuntu-20.04, macos-12]
 
     steps:
@@ -85,7 +85,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust: ["1.69.0"]
+        rust: ["1.71.1"]
         os: [ubuntu-20.04, macos-12]
     steps:
       - uses: actions/checkout@v3
@@ -112,7 +112,7 @@ jobs:
     needs: cargo-build
     strategy:
       matrix:
-        rust: ["1.69.0"]
+        rust: ["1.71.1"]
 
     steps:
       - uses: actions/checkout@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 FROM ubuntu:20.04 as builder
 SHELL ["bash", "-c"]
 
-ARG rust_version=1.69.0
+ARG rust_version=1.71.1
 
 ENV TZ=UTC
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.69.0"
+channel = "1.71.1"
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
Upgrading Rust to 1.71.1 due to the latest security notice found [here](https://blog.rust-lang.org/2023/08/03/cve-2023-38497.html).