### PR TITLE
fix: Bump all exchanges to default max response bytes to 3KiB

### DIFF
--- a/src/xrc/src/exchanges.rs
+++ b/src/xrc/src/exchanges.rs
@@ -219,7 +219,7 @@ trait IsExchange {
     }
 
     fn max_response_bytes(&self) -> u64 {
-        ONE_KIB
+        3 * ONE_KIB
     }
 }
 
@@ -247,10 +247,6 @@ impl IsExchange for Coinbase {
 
     fn supported_stablecoin_pairs(&self) -> &[(&str, &str)] {
         &[(USDT, USDC)]
-    }
-
-    fn max_response_bytes(&self) -> u64 {
-        2 * ONE_KIB
     }
 }
 
@@ -285,10 +281,6 @@ impl IsExchange for KuCoin {
 
     fn supported_stablecoin_pairs(&self) -> &[(&str, &str)] {
         &[(USDC, USDT), (USDT, DAI)]
-    }
-
-    fn max_response_bytes(&self) -> u64 {
-        2 * ONE_KIB
     }
 }
 
@@ -345,10 +337,6 @@ impl IsExchange for Okx {
 
     fn supports_ipv6(&self) -> bool {
         true
-    }
-
-    fn max_response_bytes(&self) -> u64 {
-        2 * ONE_KIB
     }
 }
 
@@ -736,19 +724,19 @@ mod test {
     #[test]
     fn max_response_bytes() {
         let exchange = Exchange::Coinbase(Coinbase);
-        assert_eq!(exchange.max_response_bytes(), 2 * ONE_KIB);
+        assert_eq!(exchange.max_response_bytes(), 3 * ONE_KIB);
         let exchange = Exchange::KuCoin(KuCoin);
-        assert_eq!(exchange.max_response_bytes(), 2 * ONE_KIB);
+        assert_eq!(exchange.max_response_bytes(), 3 * ONE_KIB);
         let exchange = Exchange::Okx(Okx);
-        assert_eq!(exchange.max_response_bytes(), 2 * ONE_KIB);
+        assert_eq!(exchange.max_response_bytes(), 3 * ONE_KIB);
         let exchange = Exchange::GateIo(GateIo);
-        assert_eq!(exchange.max_response_bytes(), ONE_KIB);
+        assert_eq!(exchange.max_response_bytes(), 3 * ONE_KIB);
         let exchange = Exchange::Mexc(Mexc);
-        assert_eq!(exchange.max_response_bytes(), ONE_KIB);
+        assert_eq!(exchange.max_response_bytes(), 3 * ONE_KIB);
         let exchange = Exchange::Poloniex(Poloniex);
-        assert_eq!(exchange.max_response_bytes(), ONE_KIB);
+        assert_eq!(exchange.max_response_bytes(), 3 * ONE_KIB);
         let exchange = Exchange::CryptoCom(CryptoCom);
-        assert_eq!(exchange.max_response_bytes(), ONE_KIB);
+        assert_eq!(exchange.max_response_bytes(), 3 * ONE_KIB);
     }
 
     #[test]


### PR DESCRIPTION
The exchange Mexc is failing on mainnet due to an increase in HTTP header size. To solve this, this PR bumps the default max response bytes to 3KiB. This will bump *every* exchange in order to be provide buffer for every exchange source.