### PR TITLE
fix: Set /dashboard content-type

### DIFF
--- a/src/xrc/src/api/dashboard.rs
+++ b/src/xrc/src/api/dashboard.rs
@@ -119,7 +119,13 @@ pub fn get_dashboard() -> HttpResponse {
     let body = render();
     HttpResponse {
         status_code: 200,
-        headers: vec![],
+        headers: vec![
+            (
+                "Content-Type".to_string(),
+                "text/html; charset=utf-8".to_string(),
+            ),
+            ("Content-Length".to_string(), body.len().to_string()),
+        ],
         body: ByteBuf::from(body),
     }
 }


### PR DESCRIPTION
The boundary nodes were recently upgrade to prevent browsers from guessing the content type of responses from raw. While it looks like this behavior will change back to the prior behavior, fixing the problem, it is better to set the content type header anyways to prevent further issues down the line.