### PR TITLE
fix: Remove access by index when inverting and dividing rates

### DIFF
--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -95,8 +95,6 @@ impl CallExchanges for CallExchangesImpl {
             return Err(CallExchangeError::NoRatesFound);
         }
 
-        rates.sort();
-
         Ok(QueriedExchangeRate::new(
             asset.clone(),
             usdt_asset(),

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -1514,7 +1514,7 @@ mod test {
 
         assert!(matches!(
             rate.inverted().validate(),
-            Err(ExchangeRateError::Other(_))
+            Err(ExchangeRateError::Other(OtherError { code, description })) if code == INVALID_RATE_ERROR_CODE && description == INVALID_RATE_ERROR_MESSAGE
         ));
     }
 
@@ -1526,7 +1526,7 @@ mod test {
 
         assert!(matches!(
             (rate.clone() / rate.clone()).validate(),
-            Err(ExchangeRateError::Other(_))
+            Err(ExchangeRateError::Other(OtherError { code, description })) if code == INVALID_RATE_ERROR_CODE && description == INVALID_RATE_ERROR_MESSAGE
         ));
 
         let btc_usd_exchange_rate = QueriedExchangeRate::new(
@@ -1541,12 +1541,12 @@ mod test {
 
         assert!(matches!(
             (btc_usd_exchange_rate.clone() / rate.clone()).validate(),
-            Err(ExchangeRateError::Other(_))
+            Err(ExchangeRateError::Other(OtherError { code, description })) if code == INVALID_RATE_ERROR_CODE && description == INVALID_RATE_ERROR_MESSAGE
         ));
 
         assert!(matches!(
             (rate / btc_usd_exchange_rate).validate(),
-            Err(ExchangeRateError::Other(_))
+            Err(ExchangeRateError::Other(OtherError { code, description })) if code == INVALID_RATE_ERROR_CODE && description == INVALID_RATE_ERROR_MESSAGE
         ));
     }
 }


### PR DESCRIPTION
If no rates are retained while instantiating a `QueriedExchangeRate`, the inner `rates` field can become empty. This causes a panic when inverting and dividing rates. This PR patches this behavior to allow the logic to reach the inevitable `validate` calls the occur in each `handle_*_pair` function in `api.rs`.

This is not a major bug as we have implemented `Drop` for our various guards, but it is still a good idea to remove panics.