### PR TITLE
fix: Enable beta release by upping the required cycles and lowering the minimum forexes if IPv4 support is not available.

### DIFF
--- a/canister_ids.json
+++ b/canister_ids.json
@@ -1,10 +1,11 @@
 {
     "xrc": {
         "local": "rrkah-fqaaa-aaaaa-aaaaq-cai",
-        "ic": "uf6dk-hyaaa-aaaaq-qaaaq-cai"
+        "ic": "bgicj-3yaaa-aaaag-ak4ra-cai",
+        "beta": "bgicj-3yaaa-aaaag-ak4ra-cai"
     },
     "monitor-canister": {
         "local": "rrkah-fqaaa-aaaaa-aaaaq-cai",
-        "ic": "fedux-oaaaa-aaaak-ad4sa-cai"
+        "ic": "ycppi-wyaaa-aaaal-qdwta-cai"
     }
 }

--- a/canister_ids.json
+++ b/canister_ids.json
@@ -1,7 +1,7 @@
 {
     "xrc": {
         "local": "rrkah-fqaaa-aaaaa-aaaaq-cai",
-        "ic": "bgicj-3yaaa-aaaag-ak4ra-cai",
+        "ic": "uf6dk-hyaaa-aaaaq-qaaaq-cai",
         "beta": "bgicj-3yaaa-aaaag-ak4ra-cai"
     },
     "monitor-canister": {

--- a/dfx.json
+++ b/dfx.json
@@ -27,13 +27,19 @@
       "args": ""
     },
     "replica": {
-      "subnet_type": "system"
+      "subnet_type": "application"
     }
   },
   "networks": {
     "local": {
       "bind": "127.0.0.1:8000",
       "type": "ephemeral"
+    },
+    "beta": {
+      "providers": [
+        "https://icp-api.io"
+      ],
+      "type": "persistent"
     }
   }
 }

--- a/dfx.json
+++ b/dfx.json
@@ -27,7 +27,7 @@
       "args": ""
     },
     "replica": {
-      "subnet_type": "application"
+      "subnet_type": "system"
     }
   },
   "networks": {

--- a/scripts/build-wasm
+++ b/scripts/build-wasm
@@ -45,4 +45,9 @@ echo "APPLICATION_SUBNET: $APPLICATION_SUBNET"
 echo "DISABLE_FOREX_WEEKEND_CHECK: $DISABLE_FOREX_WEEKEND_CHECK"
 echo "DISABLE_FOREX_TIMEZONE: $DISABLE_FOREX_TIMEZONE_OFFSET"
 
-cargo build -p xrc --target wasm32-unknown-unknown --release "${FEATURES[@]}"
+if [ ${#FEATURES[@]} -eq 0 ]; then
+    cargo build -p xrc --target wasm32-unknown-unknown --release
+else
+    cargo build -p xrc --target wasm32-unknown-unknown --release "${FEATURES[@]}"
+fi
+

--- a/src/monitor-canister/src/periodic.rs
+++ b/src/monitor-canister/src/periodic.rs
@@ -105,7 +105,7 @@ fn make_get_exchange_rate_requests(timestamp: u64) -> Vec<GetExchangeRateRequest
                 class: AssetClass::Cryptocurrency,
             },
             Asset {
-                symbol: "BTT".to_string(),
+                symbol: "USDT".to_string(),
                 class: AssetClass::Cryptocurrency,
             },
             timestamp,
@@ -127,7 +127,7 @@ fn make_get_exchange_rate_requests(timestamp: u64) -> Vec<GetExchangeRateRequest
                 class: AssetClass::Cryptocurrency,
             },
             Asset {
-                symbol: "BTC".to_string(),
+                symbol: "USDT".to_string(),
                 class: AssetClass::Cryptocurrency,
             },
             timestamp,

--- a/src/monitor-canister/src/periodic.rs
+++ b/src/monitor-canister/src/periodic.rs
@@ -105,7 +105,7 @@ fn make_get_exchange_rate_requests(timestamp: u64) -> Vec<GetExchangeRateRequest
                 class: AssetClass::Cryptocurrency,
             },
             Asset {
-                symbol: "USDT".to_string(),
+                symbol: "BTT".to_string(),
                 class: AssetClass::Cryptocurrency,
             },
             timestamp,
@@ -127,7 +127,7 @@ fn make_get_exchange_rate_requests(timestamp: u64) -> Vec<GetExchangeRateRequest
                 class: AssetClass::Cryptocurrency,
             },
             Asset {
-                symbol: "USDT".to_string(),
+                symbol: "BTC".to_string(),
                 class: AssetClass::Cryptocurrency,
             },
             timestamp,

--- a/src/xrc/src/exchanges.rs
+++ b/src/xrc/src/exchanges.rs
@@ -126,7 +126,7 @@ macro_rules! exchanges {
             /// required for each exchanges.
             pub fn cycles(&self) -> u128 {
                 if cfg!(feature = "application-subnet") {
-                    8_000_000
+                    500_000_000
                 } else {
                     0
                 }

--- a/src/xrc/src/forex.rs
+++ b/src/xrc/src/forex.rs
@@ -77,7 +77,7 @@ pub struct ForexRatesCollector {
 
 const TIMEZONE_AOE_SHIFT_HOURS: i16 = 12;
 const MAX_DAYS_TO_GO_BACK: u64 = 7;
-const MIN_SOURCES_TO_REPORT: usize = 4;
+const MIN_SOURCES_TO_REPORT: usize = if cfg!(feature = "ipv4-support") { 4 } else { 2 };
 
 /// This macro generates the necessary boilerplate when adding a forex data source to this module.
 macro_rules! forex {


### PR DESCRIPTION
This PR does the following:
1. Raises the required number of cycles needed to submit HTTPS requests on a 13-node subnet.
2. Lowers the minimum number of forexes required to return a forex rate if IPv4 is not available.
3. Fixes a bug in the build-wasm script if no features are enabled then we should just compile the wasm.