### PR TITLE
fix: Prevent repeated calls to failed exchanges

### DIFF
--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -153,6 +153,11 @@ pub fn usd_asset() -> Asset {
     }
 }
 
+/// Helper function to get a list of available exchanges.
+fn get_available_exchanges() -> Vec<&'static Exchange> {
+    EXCHANGES.iter().filter(|e| e.is_available()).collect::<Vec<_>>()
+}
+
 /// This function retrieves the requested rate from the exchanges. The median rate of all collected
 /// rates is used as the exchange rate and a set of metadata is returned giving information on
 /// how the rate was retrieved.
@@ -510,10 +515,7 @@ async fn handle_cryptocurrency_pair(
 ) -> Result<QueriedExchangeRate, ExchangeRateError> {
     let requested_timestamp = get_normalized_timestamp(env, request);
     let mut failed_exchanges = vec![];
-    let mut exchanges = EXCHANGES
-        .iter()
-        .filter(|exchange| exchange.is_available())
-        .collect::<Vec<_>>();
+    let mut exchanges = get_available_exchanges();
     let caller = env.caller();
     let (maybe_base_rate, maybe_quote_rate) = with_cache_mut(|cache| {
         (
@@ -614,10 +616,7 @@ async fn handle_crypto_base_fiat_quote_pair(
     let requested_timestamp = get_normalized_timestamp(env, request);
     let caller = env.caller();
     let mut failed_exchanges_list = vec![];
-    let mut exchanges = EXCHANGES
-        .iter()
-        .filter(|exchange| exchange.is_available())
-        .collect::<Vec<_>>();
+    let mut exchanges = get_available_exchanges();
     let maybe_crypto_base_rate = with_cache_mut(|cache| {
         get_rate_from_cache(
             cache,

--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -773,10 +773,6 @@ async fn get_stablecoin_rate(
 ) -> Result<QueriedExchangeRateWithFailedExchanges, CallExchangeError> {
     let mut futures = vec![];
     exchanges.iter().for_each(|exchange| {
-        if !cfg!(feature = "ipv4-support") && !exchange.supports_ipv6() {
-            return;
-        }
-
         let maybe_pair = exchange
             .supported_stablecoin_pairs()
             .iter()

--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -93,8 +93,12 @@ impl CallExchanges for CallExchangesImpl {
                   );
 
                   if let CallExchangeError::Http { exchange, error: _} = err {
-                      let exchange: &Exchange = exchanges.iter().find(|e| e.to_string() == exchange).unwrap();
-                      failed_exchanges.push(exchange.clone());
+                      if let Some(exchange) = exchanges.iter().find(|e| e.to_string() == exchange) {
+                          failed_exchanges.push((*exchange).clone());
+                      }
+                      else {
+                          ic_cdk::println!("{} Exchange not found for failed exchanges: {} @ {}", LOG_PREFIX, exchange, timestamp);
+                      }
                   } 
               }
           }
@@ -810,8 +814,12 @@ async fn get_stablecoin_rate(
                     error
                 );
                 if let CallExchangeError::Http { exchange, error: _} = error {
-                    let exchange: &Exchange = exchanges.iter().find(|e| e.to_string() == exchange).unwrap();
-                    failed_exchanges.push(exchange.clone());
+                    if let Some(exchange) = exchanges.iter().find(|e| e.to_string() == exchange) {
+                        failed_exchanges.push((*exchange).clone());
+                    }
+                    else {
+                        ic_cdk::println!("{} Exchange not found for failed exchanges: {} @ {}", LOG_PREFIX, exchange, timestamp);
+                    }
                 } 
             }
         }

--- a/src/xrc/src/api/test.rs
+++ b/src/xrc/src/api/test.rs
@@ -61,6 +61,7 @@ struct TestCallExchangesImpl {
     /// Contains the responses when [CallExchanges::get_stablecoin_rates] is called.
     get_stablecoin_rates_responses:
         BTreeMap<String, Result<QueriedExchangeRateWithFailedExchanges, CallExchangeError>>,
+    #[allow(clippy::type_complexity)]
     /// The received [CallExchanges::get_cryptocurrency_usdt_rate] calls from the test.
     get_stablecoin_rates_calls: RwLock<Vec<(Vec<Exchange>, Vec<String>, u64)>>,
 }

--- a/src/xrc/src/exchanges.rs
+++ b/src/xrc/src/exchanges.rs
@@ -1,4 +1,4 @@
-use candid::{decode_args, encode_args, Deserialize, Error as CandidError};
+use candid::{decode_args, CandidType, encode_args, Deserialize, Error as CandidError};
 
 use ic_xrc_types::Asset;
 use serde::de::DeserializeOwned;
@@ -13,7 +13,7 @@ use crate::{DAI, USDC, USDT};
 macro_rules! exchanges {
     ($($name:ident),*) => {
         /// Enum that contains all of the supported cryptocurrency exchanges.
-        #[derive(PartialEq)]
+        #[derive(PartialEq, Clone, CandidType, Deserialize, Debug)]
         pub enum Exchange {
             $(
                 #[allow(missing_docs)]
@@ -22,7 +22,7 @@ macro_rules! exchanges {
         }
 
         $(
-            #[derive(PartialEq)]
+            #[derive(PartialEq, Clone, CandidType, Deserialize, Debug)]
             pub struct $name;
         )*
 

--- a/src/xrc/src/exchanges.rs
+++ b/src/xrc/src/exchanges.rs
@@ -1,4 +1,4 @@
-use candid::{decode_args, CandidType, encode_args, Deserialize, Error as CandidError};
+use candid::{decode_args, encode_args, Deserialize, Error as CandidError};
 
 use ic_xrc_types::Asset;
 use serde::de::DeserializeOwned;
@@ -13,7 +13,7 @@ use crate::{DAI, USDC, USDT};
 macro_rules! exchanges {
     ($($name:ident),*) => {
         /// Enum that contains all of the supported cryptocurrency exchanges.
-        #[derive(PartialEq, Clone, CandidType, Deserialize, Debug)]
+        #[derive(PartialEq, Clone, Debug)]
         pub enum Exchange {
             $(
                 #[allow(missing_docs)]
@@ -22,7 +22,7 @@ macro_rules! exchanges {
         }
 
         $(
-            #[derive(PartialEq, Clone, CandidType, Deserialize, Debug)]
+            #[derive(PartialEq, Clone, Debug)]
             pub struct $name;
         )*
 


### PR DESCRIPTION
- Adds a filter to remove failed exchanges in subsequent out calls within the same `get_exchange_rate` call
- Update testing 