### PR TITLE
feat: Copy xrc_mock from tvl in ic repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,7 +178,7 @@ dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -587,6 +587,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-xrc-types"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1a2b2eaa332201f4abbd1192a307f7a5b6ea55d077a7f489ac62bf8e358b5a2"
+dependencies = [
+ "candid",
+ "serde",
+]
+
+[[package]]
 name = "ic0"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,7 +777,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax 0.6.27",
- "syn 2.0.27",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -811,7 +821,7 @@ dependencies = [
  "ic-cdk",
  "ic-cdk-macros",
  "ic-stable-structures",
- "ic-xrc-types",
+ "ic-xrc-types 1.2.0",
  "num-traits",
  "serde",
  "serde_bytes",
@@ -1003,9 +1013,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -1021,9 +1031,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.32"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -1152,9 +1162,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.143"
+version = "1.0.208"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
+checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
 dependencies = [
  "serde_derive",
 ]
@@ -1182,13 +1192,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.143"
+version = "1.0.208"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d8e8de557aee63c26b85b947f5e59b690d0454c753f3adeb5cd7835ab88391"
+checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.99",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1295,9 +1305,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.27"
+version = "2.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b60f673f44a8255b9c8c657daf66a596d435f2da81a555b06dc644d080ba45e0"
+checksum = "f6af063034fc1935ede7be0122941bafa9bacb949334d090b77ca98b5817c7d9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1676,7 +1686,7 @@ dependencies = [
  "hex",
  "ic-cdk",
  "ic-cdk-macros",
- "ic-xrc-types",
+ "ic-xrc-types 1.2.0",
  "lru",
  "maplit",
  "rand",
@@ -1688,13 +1698,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "xrc-mock"
+version = "0.9.0"
+dependencies = [
+ "candid",
+ "ic-cdk",
+ "ic-cdk-macros",
+ "ic-xrc-types 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
+]
+
+[[package]]
 name = "xrc-tests"
 version = "0.8.0"
 dependencies = [
  "candid",
  "hex",
  "ic-cdk",
- "ic-xrc-types",
+ "ic-xrc-types 1.2.0",
  "maplit",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     # crates used for development
     "src/xrc-tests",
     "src/monitor-canister",
+    "src/xrc_mock",
 ]
 resolver = "2"
 
@@ -16,7 +17,7 @@ chrono = { version = "0.4.33", default-features = false, features = [
 ] }
 ic-cdk = "0.12.1"
 ic-cdk-macros = "0.8.4"
-
+serde = { version = "1.0.203", features = ["derive"] }
 
 [profile.release]
 lto = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ COPY src/monitor-canister/Cargo.toml src/monitor-canister/Cargo.toml
 COPY src/xrc-tests/Cargo.toml src/xrc-tests/Cargo.toml
 COPY src/ic-xrc-types/Cargo.toml src/ic-xrc-types/Cargo.toml
 COPY src/xrc/Cargo.toml src/xrc/Cargo.toml
+COPY src/xrc_mock/Cargo.toml src/xrc_mock/Cargo.toml
 RUN mkdir -p src/xrc-tests/src && \
     touch src/xrc-tests/src/lib.rs && \
     mkdir -p src/monitor-canister/src && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,8 +53,11 @@ RUN mkdir -p src/xrc-tests/src && \
     touch src/ic-xrc-types/src/lib.rs && \
     mkdir -p src/xrc/src && \
     touch src/xrc/src/lib.rs && \
+    mkdir -p src/xrc_mock/src && \
+    touch src/xrc_mock/src/lib.rs && \
     cargo build --target wasm32-unknown-unknown --release --package xrc && \
     rm -rf src/xrc/ &&\
+    rm -rf src/xrc_mock/ &&\
     rm -rf src/monitor-canister/ &&\
     rm -rf src/xrc-tests/
 

--- a/scripts/build-mock-wasm
+++ b/scripts/build-mock-wasm
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cargo build --target wasm32-unknown-unknown --release -p xrc-mock
+find . -name 'xrc-mock.wasm*'

--- a/src/xrc_mock/Cargo.toml
+++ b/src/xrc_mock/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "xrc-mock"
+version = "0.9.0"
+edition = "2021"
+
+[dependencies]
+candid = { workspace = true }
+ic-cdk = { workspace = true }
+ic-cdk-macros = { workspace = true }
+ic-xrc-types = "1.1.0"
+serde = { workspace = true }

--- a/src/xrc_mock/src/lib.rs
+++ b/src/xrc_mock/src/lib.rs
@@ -1,0 +1,28 @@
+use candid::CandidType;
+use ic_xrc_types::{Asset, ExchangeRateError, ExchangeRateMetadata};
+
+#[derive(CandidType, Debug, candid::Deserialize)]
+pub struct XrcMockInitPayload {
+    pub response: Response,
+}
+
+#[derive(CandidType, Debug, candid::Deserialize)]
+pub struct ExchangeRate {
+    pub base_asset: Option<Asset>,
+    pub quote_asset: Option<Asset>,
+    pub metadata: Option<ExchangeRateMetadata>,
+    pub rate: u64,
+}
+
+#[derive(CandidType, Debug, candid::Deserialize)]
+pub enum Response {
+    ExchangeRate(ExchangeRate),
+    Error(ExchangeRateError),
+}
+
+#[derive(CandidType, Debug, candid::Deserialize)]
+pub struct SetExchangeRate {
+    pub base_asset: String,
+    pub quote_asset: String,
+    pub rate: u64,
+}

--- a/src/xrc_mock/src/main.rs
+++ b/src/xrc_mock/src/main.rs
@@ -1,0 +1,93 @@
+use candid::candid_method;
+use ic_cdk_macros::init;
+use ic_xrc_types::{
+    Asset, AssetClass, ExchangeRate, ExchangeRateMetadata, GetExchangeRateRequest,
+    GetExchangeRateResult,
+};
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use xrc_mock::{SetExchangeRate, XrcMockInitPayload};
+
+fn main() {}
+
+#[ic_cdk_macros::update]
+#[candid_method(update)]
+async fn get_exchange_rate(request: GetExchangeRateRequest) -> GetExchangeRateResult {
+    if let Some(rate) = RATES.with(|rates| {
+        rates
+            .borrow()
+            .get(&(
+                request.base_asset.symbol.clone(),
+                request.quote_asset.symbol.clone(),
+            ))
+            .cloned()
+    }) {
+        return GetExchangeRateResult::Ok(ExchangeRate {
+            base_asset: request.base_asset,
+            quote_asset: request.quote_asset,
+            // Add 6 to the timestamp to differentiate from the governance canister time.
+            timestamp: (ic_cdk::api::time() / 1_000_000_000) + 6,
+            rate,
+            metadata: ExchangeRateMetadata {
+                decimals: 8,
+                base_asset_num_received_rates: 0,
+                base_asset_num_queried_sources: 0,
+                quote_asset_num_received_rates: 0,
+                quote_asset_num_queried_sources: 0,
+                standard_deviation: 0,
+                forex_timestamp: None,
+            },
+        });
+    }
+
+    RESPONSE.with(
+        |cell| match cell.borrow().as_ref().expect("Response has not been set") {
+            xrc_mock::Response::ExchangeRate(rate) => GetExchangeRateResult::Ok(ExchangeRate {
+                base_asset: rate.base_asset.clone().unwrap_or_else(|| Asset {
+                    symbol: "ICP".into(),
+                    class: AssetClass::Cryptocurrency,
+                }),
+                quote_asset: rate.quote_asset.clone().unwrap_or_else(|| Asset {
+                    symbol: "USD".into(),
+                    class: AssetClass::FiatCurrency,
+                }),
+                // Add 6 to the timestamp to differentiate from the governance canister time.
+                timestamp: (ic_cdk::api::time() / 1_000_000_000) + 6,
+                rate: rate.rate,
+                metadata: rate.metadata.clone().unwrap_or(ExchangeRateMetadata {
+                    decimals: 8,
+                    base_asset_num_received_rates: 0,
+                    base_asset_num_queried_sources: 0,
+                    quote_asset_num_received_rates: 0,
+                    quote_asset_num_queried_sources: 0,
+                    standard_deviation: 0,
+                    forex_timestamp: None,
+                }),
+            }),
+            xrc_mock::Response::Error(error) => GetExchangeRateResult::Err(error.clone()),
+        },
+    )
+}
+
+#[ic_cdk_macros::update]
+#[candid_method(update)]
+async fn set_exchange_rate(req: SetExchangeRate) {
+    RATES.with(|rates| {
+        rates
+            .borrow_mut()
+            .entry((req.base_asset, req.quote_asset))
+            .and_modify(|curr| *curr = req.rate)
+            .or_insert(req.rate);
+    });
+}
+
+thread_local! {
+    static RESPONSE: RefCell<Option<xrc_mock::Response>> = const { RefCell::new(None) };
+
+    static RATES: RefCell<BTreeMap<(String, String), u64>> = Default::default();
+}
+
+#[init]
+fn init(args: XrcMockInitPayload) {
+    RESPONSE.with(|response| response.replace(Some(args.response)));
+}

--- a/src/xrc_mock/xrc.did
+++ b/src/xrc_mock/xrc.did
@@ -1,0 +1,97 @@
+type AssetClass = variant { Cryptocurrency; FiatCurrency; };
+
+type Asset = record {
+    symbol: text;
+    class: AssetClass;
+};
+
+// The parameters for the `get_exchange_rate` API call.
+type GetExchangeRateRequest = record {
+    base_asset: Asset;
+    quote_asset: Asset;
+    // An optional timestamp to get the rate for a specific time period.
+    timestamp: opt nat64;
+};
+
+type ExchangeRateMetadata = record {
+    decimals: nat32;
+    base_asset_num_received_rates: nat64;
+    base_asset_num_queried_sources: nat64;
+    quote_asset_num_received_rates: nat64;
+    quote_asset_num_queried_sources: nat64;
+    standard_deviation: nat64;
+    forex_timestamp: opt nat64;
+};
+
+type ExchangeRate = record {
+    base_asset: Asset;
+    quote_asset: Asset;
+    timestamp: nat64;
+    rate: nat64;
+    metadata: ExchangeRateMetadata;
+};
+
+type ExchangeRateError = variant {
+    // Returned when the canister receives a call from the anonymous principal.
+    AnonymousPrincipalNotAllowed: null;
+    /// Returned when the canister is in process of retrieving a rate from an exchange.
+    Pending: null;
+    // Returned when the base asset rates are not found from the exchanges HTTP outcalls.
+    CryptoBaseAssetNotFound: null;
+    // Returned when the quote asset rates are not found from the exchanges HTTP outcalls.
+    CryptoQuoteAssetNotFound: null;
+    // Returned when the stablecoin rates are not found from the exchanges HTTP outcalls needed for computing a crypto/fiat pair.
+    StablecoinRateNotFound: null;
+    // Returned when there are not enough stablecoin rates to determine the forex/USDT rate.
+    StablecoinRateTooFewRates: null;
+    // Returned when the stablecoin rate is zero.
+    StablecoinRateZeroRate: null;
+    // Returned when a rate for the provided forex asset could not be found at the provided timestamp.
+    ForexInvalidTimestamp: null;
+    // Returned when the forex base asset is found.
+    ForexBaseAssetNotFound: null;
+    // Returned when the forex quote asset is found.
+    ForexQuoteAssetNotFound: null;
+    // Returned when neither forex asset is found.
+    ForexAssetsNotFound: null;
+    // Returned when the caller is not the CMC and there are too many active requests.
+    RateLimited: null;
+    // Returned when the caller does not send enough cycles to make a request.
+    NotEnoughCycles: null;
+    // Returned when the canister fails to accept enough cycles.
+    FailedToAcceptCycles: null;
+    /// Returned if too many collected rates deviate substantially.
+    InconsistentRatesReceived: null;
+    // Until candid bug is fixed, new errors after launch will be placed here.
+    Other: record {
+        // The identifier for the error that occurred.
+        code: nat32;
+        // A description of the error that occurred.
+        description: text;
+    }
+};
+
+type GetExchangeRateResult = variant {
+    // Successfully retrieved the exchange rate from the cache or API calls.
+    Ok: ExchangeRate;
+    // Failed to retrieve the exchange rate due to invalid API calls, invalid timestamp, etc.
+    Err: ExchangeRateError;
+};
+
+type Response = variant {
+    ExchangeRate: record {
+        base_asset: opt Asset;
+        quote_asset: opt Asset;
+        metadata: opt ExchangeRateMetadata;
+        rate: nat64;
+    };
+    Error: ExchangeRateError;
+};
+
+type InitPayload = record {
+    response: Response;
+};
+
+service : (InitPayload) -> {
+    "get_exchange_rate": (GetExchangeRateRequest) -> (GetExchangeRateResult);
+}


### PR DESCRIPTION
# Motivation

It can be useful to have an exchange rate canister available in a test environment without it making API calls to exchanges.
Instead of everybody implementing their own mock, we should provide one in this repo so it's easy to find and share.

In plan to use this in the snsdemo repo which creates the test environment used by nns-dapp.

# Changes

1. Copied https://github.com/dfinity/ic/tree/master/rs/rosetta-api/tvl/xrc_mock to `src/xrc_mock`
2. Slightly changed the [Cargo.toml](https://github.com/dfinity/ic/blob/3dfaa18aa073deb23899ffe0601eff78697804da/rs/rosetta-api/tvl/xrc_mock/Cargo.toml) to work in the current repo.
3. Removed [BUILD.bazel](https://github.com/dfinity/ic/blob/master/rs/rosetta-api/tvl/xrc_mock/BUILD.bazel) as this repo doesn't use `bazel`.
4. Added a build script.
5. Fix the docker build workflow via cargo-culting.

I plan to include a built wasm in the release artifacts in the future PR.

# Tests

I don't think the existing mock that was copied has unit tests, but I used the mock built from this repo in my test environment to test the tvl replacement in nns-dapp.