### PR TITLE
build: Include xrc_mock in the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,6 @@ on:
   push:
     tags:
       - "*"
-  workflow_dispatch:
 
 permissions:
   contents: write
@@ -20,39 +19,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       - name: Build canister
         uses: ./.github/actions/build
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Show output
-        run: |
-          ls -l $(find ./out)
-
-      - name: Determine tag name
-        id: tag
-        run: |
-          set -euxo pipefail
-          if [[ ${{github.event_name}} = "workflow_dispatch" ]]; then
-            tag_name="$(date +%Y.%m.%d)"
-            index=0
-            # If there is already a tag with the same name, try appending ".${next_integer}".
-            while git show-ref --tags --verify --quiet "refs/tags/${tag_name}"; do
-              echo "Tag ${tag_name} already exists."
-              index=$((index + 1))
-              tag_name="$(date +%Y.%m.%d).${index}"
-              echo "Trying tag ${tag_name}."
-            done
-            echo "Tagging as '${tag_name}'"
-            git tag "${tag_name}"
-            git push origin "refs/tags/${tag_name}"
-          else
-            tag_name="${{github.GITHUB_REF}}"
-          fi
-          echo "tag_name=${tag_name}" >> "$GITHUB_OUTPUT"
 
       - name: Release
         uses: "softprops/action-gh-release@v1"
@@ -60,5 +31,3 @@ jobs:
           files: |
             ./out/xrc.wasm.gz
             ./out/xrc_mock.wasm.gz
-          tag_name: ${{ steps.tag.outputs.tag_name }}
-          draft: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
   push:
     tags:
       - "*"
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -19,14 +20,44 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Build canister
         uses: ./.github/actions/build
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Release
-        uses: "softprops/action-gh-release@v1"
-        with:
-          files: |
-            ./out/xrc.wasm.gz
+      - name: Show output
+        run: |
+          ls -l $(find ./out)
+
+      - name: Determine tag name
+        id: tag
+        run: |
+          set -euxo pipefail
+          if [[ ${{github.event_name}} = "workflow_dispatch" ]]; then
+            tag_name="$(date +%Y.%m.%d)"
+            index=0
+            # If there is already a tag with the same name, try appending ".${next_integer}".
+            while git show-ref --tags --verify --quiet "refs/tags/${tag_name}"; do
+              echo "Tag ${tag_name} already exists."
+              index=$((index + 1))
+              tag_name="$(date +%Y.%m.%d).${index}"
+              echo "Trying tag ${tag_name}."
+            done
+            echo "Tagging as '${tag_name}'"
+            git tag "${tag_name}"
+            git push origin "refs/tags/${tag_name}"
+          else
+            tag_name="${{github.GITHUB_REF}}"
+          fi
+          echo "tag_name=${tag_name}" >> "$GITHUB_OUTPUT"
+
+
+      #- name: Release
+      #  uses: "softprops/action-gh-release@v1"
+      #  with:
+      #    files: |
+      #      ./out/xrc.wasm.gz
+      #    tag_name: ${{ steps.tag.outputs.tag_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,10 +54,11 @@ jobs:
           fi
           echo "tag_name=${tag_name}" >> "$GITHUB_OUTPUT"
 
-
-      #- name: Release
-      #  uses: "softprops/action-gh-release@v1"
-      #  with:
-      #    files: |
-      #      ./out/xrc.wasm.gz
-      #    tag_name: ${{ steps.tag.outputs.tag_name }}
+      - name: Release
+        uses: "softprops/action-gh-release@v1"
+        with:
+          files: |
+            ./out/xrc.wasm.gz
+            ./out/xrc_mock.wasm.gz
+          tag_name: ${{ steps.tag.outputs.tag_name }}
+          draft: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,8 +87,12 @@ WORKDIR /build
 # Creates the wasm without creating the canister
 RUN dfx build --check xrc
 
+# Create the wasm for the mock canister
+RUN dfx build --check xrc_mock
+
 RUN ls -sh /build
 RUN ls -sh /build/.dfx/local/canisters/xrc/xrc.wasm.gz; sha256sum /build/.dfx/local/canisters/xrc/xrc.wasm.gz
+RUN ls -sh /build/.dfx/local/canisters/xrc_mock/xrc_mock.wasm.gz; sha256sum /build/.dfx/local/canisters/xrc_mock/xrc_mock.wasm.gz
 
 FROM scratch AS scratch
-COPY --from=build /build/.dfx/local/canisters/xrc/xrc.wasm.gz /
+COPY --from=build /build/.dfx/local/canisters/xrc/xrc.wasm.gz /build/.dfx/local/canisters/xrc_mock/xrc_mock.wasm.gz /

--- a/dfx.json
+++ b/dfx.json
@@ -15,6 +15,19 @@
         "wasm_url": "https://github.com/dfinity/exchange-rate-canister/releases/latest/download/xrc.wasm.gz"
       }
     },
+    "xrc_mock": {
+      "type": "custom",
+      "candid": "./src/xrc_mock/xrc.did",
+      "build": "./scripts/build-mock-wasm",
+      "wasm": "./target/wasm32-unknown-unknown/release/xrc-mock.wasm",
+      "optimize": "cycles",
+      "gzip": true,
+      "pullable": {
+        "dependencies": [],
+        "init_guide": "",
+        "wasm_url": "https://github.com/dfinity/exchange-rate-canister/releases/latest/download/xrc_mock.wasm.gz"
+      }
+    },
     "monitor-canister": {
       "type": "rust",
       "candid": "./src/monitor-canister/monitor-canister.did",


### PR DESCRIPTION
# Why

To make it easy for scripts setting up test environments to download a WASM for the XRC mock to install.

# Changes

1. Included a section for `xrc_mock` in `dfx.json` so the wasm can be built using `dfx build` to include canister metadata.
2. Update `Dockerfile` to include building `xrc_mock`.
3. Update `.github/workflows/release.yml` to include the mock wasm in the assets.

# Tested

This [draft release](https://github.com/dfinity/exchange-rate-canister/releases/tag/untagged-c19a212e13b8615dd065) was created with the workflow.
