### PR TITLE
fix: Update XRC Mock Candid file.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1702,6 +1702,7 @@ name = "xrc-mock"
 version = "0.9.0"
 dependencies = [
  "candid",
+ "candid_parser",
  "ic-cdk",
  "ic-cdk-macros",
  "ic-xrc-types 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ resolver = "2"
 
 [workspace.dependencies]
 candid = "0.10.2"
+candid_parser = "0.1.0"
 chrono = { version = "0.4.33", default-features = false, features = [
     "std",
     "alloc",

--- a/src/xrc/Cargo.toml
+++ b/src/xrc/Cargo.toml
@@ -26,7 +26,7 @@ serde-xml-rs = "0.6.0"
 
 [dev-dependencies]
 candid = { workspace = true }
-candid_parser = "0.1.0"
+candid_parser = { workspace = true }
 hex = "0.4"
 maplit = "1.0.2"
 rand = "0.8.5"

--- a/src/xrc_mock/Cargo.toml
+++ b/src/xrc_mock/Cargo.toml
@@ -9,3 +9,6 @@ ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }
 ic-xrc-types = "1.1.0"
 serde = { workspace = true }
+
+[dev-dependencies]
+candid_parser = { workspace = true }

--- a/src/xrc_mock/src/main.rs
+++ b/src/xrc_mock/src/main.rs
@@ -91,3 +91,25 @@ thread_local! {
 fn init(args: XrcMockInitPayload) {
     RESPONSE.with(|response| response.replace(Some(args.response)));
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn check_candid_compatibility() {
+        candid_parser::export_service!();
+
+        // Pull in the rust-generated interface and candid file interface.
+        let new_interface = __export_service();
+        let old_interface =
+            PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap()).join("xrc.did");
+
+        candid_parser::utils::service_compatible(
+            candid_parser::utils::CandidSource::Text(&new_interface),
+            candid_parser::utils::CandidSource::File(old_interface.as_path()),
+        )
+        .expect("Service incompatibility found");
+    }
+}

--- a/src/xrc_mock/xrc.did
+++ b/src/xrc_mock/xrc.did
@@ -58,8 +58,6 @@ type ExchangeRateError = variant {
     RateLimited: null;
     // Returned when the caller does not send enough cycles to make a request.
     NotEnoughCycles: null;
-    // Returned when the canister fails to accept enough cycles.
-    FailedToAcceptCycles: null;
     /// Returned if too many collected rates deviate substantially.
     InconsistentRatesReceived: null;
     // Until candid bug is fixed, new errors after launch will be placed here.
@@ -88,10 +86,17 @@ type Response = variant {
     Error: ExchangeRateError;
 };
 
+type SetExchangeRate = record {
+    rate : nat64;
+    quote_asset : text;
+    base_asset : text;
+};
+
 type InitPayload = record {
     response: Response;
 };
 
 service : (InitPayload) -> {
     "get_exchange_rate": (GetExchangeRateRequest) -> (GetExchangeRateResult);
+    "set_exchange_rate" : (SetExchangeRate) -> ();
 }


### PR DESCRIPTION
Note: `FailedToAcceptCycles` is also present in the other Candid specifications, and not used anywhere. But this is outside of the scope of this PR.