### PR TITLE
fix: Bumping the MacOS version from 12 to 13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         rust: ["1.75.0"]
-        os: [ubuntu-20.04, macos-12]
+        os: [ubuntu-20.04, macos-13]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         rust: ["1.75.0"]
-        os: [ubuntu-20.04, macos-12]
+        os: [ubuntu-20.04, macos-13]
 
     steps:
       - uses: actions/checkout@v3
@@ -86,7 +86,7 @@ jobs:
     strategy:
       matrix:
         rust: ["1.75.0"]
-        os: [ubuntu-20.04, macos-12]
+        os: [ubuntu-20.04, macos-13]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3


### PR DESCRIPTION
Since MacOS 12 is deprecated, the version needs to be bumped to 13 to fix CI.