### PR TITLE
chore: Update workflows to ubuntu-22.04

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   assets:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Build canister

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   assets:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Build canister

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   conventional-pr-title:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       statuses: write
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   release:
     name: "Release"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-22.04"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         rust: ["1.75.0"]
-        os: [ubuntu-20.04, macos-13]
+        os: [ubuntu-22.04, macos-13]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         rust: ["1.75.0"]
-        os: [ubuntu-20.04, macos-13]
+        os: [ubuntu-22.04, macos-13]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
@@ -86,7 +86,7 @@ jobs:
     strategy:
       matrix:
         rust: ["1.75.0"]
-        os: [ubuntu-20.04, macos-13]
+        os: [ubuntu-22.04, macos-13]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
@@ -108,7 +108,7 @@ jobs:
 
   # Runs the e2e tests after the cargo-build stage.
   e2e-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: cargo-build
     strategy:
       matrix:
@@ -146,7 +146,7 @@ jobs:
   # Lints all of the shell scripts.
   shell-checks:
     name: ShellCheck
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Run ShellCheck

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -157,7 +157,7 @@ jobs:
   # Final stage that will fail if the any of the entries in `needs` fails.
   checks-pass:
     needs: ["cargo-clippy", "e2e-tests", "cargo-tests", "shell-checks"]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checks workflow passes
         run: echo OK

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -157,7 +157,7 @@ jobs:
   # Final stage that will fail if the any of the entries in `needs` fails.
   checks-pass:
     needs: ["cargo-clippy", "e2e-tests", "cargo-tests", "shell-checks"]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checks workflow passes
         run: echo OK

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 
 # This is the "builder", i.e. the base image used later to build the final
 # code.
-FROM ubuntu:20.04 as builder
+FROM ubuntu:22.04 as builder
 SHELL ["bash", "-c"]
 
 ARG rust_version=1.75.0


### PR DESCRIPTION
Ubuntu 20.04 is near end-of-life. GitHub will stop support in April. This PR addresses that by bumping everything to 22.04.