### PR TITLE
chore: DEFI-2596: Set the DeFi team as the owner of the repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-# The IC Integrations team is the owner of this repository.
-*	@dfinity/integrations
+# The DeFi team is the owner of this repository.
+*	@dfinity/defi


### PR DESCRIPTION
Set the DeFi team as the owner of the repository.