### PR TITLE
chore: DEFI-2599: Update macos runner

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         rust: ["1.75.0"]
-        os: [ubuntu-22.04, macos-13]
+        os: [ubuntu-22.04, macos-14]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         rust: ["1.75.0"]
-        os: [ubuntu-22.04, macos-13]
+        os: [ubuntu-22.04, macos-14]
 
     steps:
       - uses: actions/checkout@v3
@@ -86,7 +86,7 @@ jobs:
     strategy:
       matrix:
         rust: ["1.75.0"]
-        os: [ubuntu-22.04, macos-13]
+        os: [ubuntu-22.04, macos-14]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         rust: ["1.75.0"]
-        os: [ubuntu-22.04, macos-14]
+        os: [ubuntu-22.04, macos-15]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         rust: ["1.75.0"]
-        os: [ubuntu-22.04, macos-14]
+        os: [ubuntu-22.04, macos-15]
 
     steps:
       - uses: actions/checkout@v3
@@ -86,7 +86,7 @@ jobs:
     strategy:
       matrix:
         rust: ["1.75.0"]
-        os: [ubuntu-22.04, macos-14]
+        os: [ubuntu-22.04, macos-15]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3


### PR DESCRIPTION
The macos 13 runners are [no longer supported](https://github.com/actions/runner-images/issues/13046) since December 2025, so bumping them to 15.