### PR TITLE
feat: Add NNS Governance to the list of privileged canisters

### DIFF
--- a/src/xrc/src/environment.rs
+++ b/src/xrc/src/environment.rs
@@ -127,7 +127,7 @@ pub(crate) mod test {
     impl Default for TestEnvironment {
         fn default() -> Self {
             Self {
-                caller: Principal::from_text("rrkah-fqaaa-aaaaa-aaaaq-cai")
+                caller: Principal::from_text("q4eej-kyaaa-aaaaa-aaaha-cai")
                     .expect("Failed to create test principal"),
                 cycles_available: Default::default(),
                 cycles_accepted: Default::default(),

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -73,11 +73,13 @@ pub const XRC_MINIMUM_FEE_COST: u128 = 1_000_000;
 /// The maximum relative difference between accepted rates is 20%.
 pub const MAX_RELATIVE_DIFFERENCE_DIVISOR: u64 = 5;
 
-const PRIVILEGED_CANISTER_IDS: [Principal; 2] = [
+const PRIVILEGED_CANISTER_IDS: [Principal; 3] = [
     // CMC: rkp4c-7iaaa-aaaaa-aaaca-cai
     Principal::from_slice(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x01, 0x01]),
     // NNS dapp: qoctq-giaaa-aaaaa-aaaea-cai
-    Principal::from_slice(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x08, 0x01, 0x01])
+    Principal::from_slice(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x08, 0x01, 0x01]),
+    // NNS Governance: rrkah-fqaaa-aaaaa-aaaaq-cai
+    Principal::from_slice(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01, 0x01]),
 ];
 
 const PRIVILEGED_CRYPTO_ASSETS: [&str; 4] = [BTC, ETH, ICP, USDT];

--- a/src/xrc/src/utils.rs
+++ b/src/xrc/src/utils.rs
@@ -220,6 +220,13 @@ pub(crate) mod test {
     }
 
     #[test]
+    fn nns_governance_id_is_correct() {
+        let principal_from_text = Principal::from_text("rrkah-fqaaa-aaaaa-aaaaq-cai")
+            .expect("should be a valid textual principal ID");
+        assert!(is_caller_privileged(&principal_from_text));
+    }
+
+    #[test]
     fn sanitize_request_uppercases_the_asset_symbols_and_copies_the_other_properties() {
         let request = GetExchangeRateRequest {
             base_asset: Asset {


### PR DESCRIPTION
## Summary
- Adds NNS Governance (`rrkah-fqaaa-aaaaa-aaaaq-cai`) to `PRIVILEGED_CANISTER_IDS`, exempting it from cycle costs when calling the XRC.
- Adds a matching `nns_governance_id_is_correct` test mirroring the existing CMC / NNS-dapp tests.

## Motivation
Phase 2 of Mission 70 moves the maturity modulation computation into NNS Governance, which will pull ICP rate history directly from the XRC instead of relying on CMC. Treating Governance as a system caller (the same status CMC and the NNS dapp already have) avoids the per-call cycle charge on this internal NNS-to-NNS path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)