### PR TITLE
fix: replace ondrej/nginx PPA with OpenResty for e2e tests

### DIFF
--- a/scripts/e2e-tests
+++ b/scripts/e2e-tests
@@ -2,6 +2,8 @@
 
 # vim: ft=bash
 
+set -euo pipefail
+
 # Builds the wasm locally, the e2e base image, moves the wasm to the
 # appropriate location, and runs the tests
 

--- a/src/xrc-tests/docker/base.Dockerfile
+++ b/src/xrc-tests/docker/base.Dockerfile
@@ -10,19 +10,22 @@ ARG DEBIAN_FRONTEND=noninteractive
 # Move minica over. 
 COPY  --from=minica /go/bin/minica /usr/local/bin/minica
 RUN apt-get update && apt-get install -y \
-    software-properties-common \
-    && add-apt-repository ppa:ondrej/nginx \
+    curl \
+    gnupg \
+    && curl -fsSL https://openresty.org/package/pubkey.gpg | gpg --dearmor -o /usr/share/keyrings/openresty.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/openresty.gpg] http://openresty.org/package/ubuntu jammy main" \
+       > /etc/apt/sources.list.d/openresty.list \
     && apt-get update \
     && apt-get install -y \
-    nginx \
-    libnginx-mod-http-echo \
-    libnginx-mod-http-lua \
+    openresty \
     jq \
     curl \
     vim \
     supervisor \
     libunwind-dev \
-    unzip
+    unzip \
+    && mkdir -p /etc/nginx/conf.d /var/log/nginx \
+    && ln -s /usr/local/openresty/nginx/sbin/nginx /usr/bin/nginx
 
 # Install dfx
 WORKDIR /work
@@ -43,6 +46,7 @@ COPY /src/xrc-tests/docker/docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh
 
 ADD /src/xrc-tests/docker/router.lua /etc/nginx/router.lua
+COPY /src/xrc-tests/docker/nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 

--- a/src/xrc-tests/docker/nginx.conf
+++ b/src/xrc-tests/docker/nginx.conf
@@ -1,0 +1,14 @@
+worker_processes 1;
+error_log /var/log/nginx/error.log;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include      /usr/local/openresty/nginx/conf/mime.types;
+    default_type application/octet-stream;
+    sendfile     on;
+    keepalive_timeout 65;
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/src/xrc-tests/docker/supervisord.conf
+++ b/src/xrc-tests/docker/supervisord.conf
@@ -10,7 +10,7 @@ stderr_logfile=/var/log/supervisor/dfx.log
 stderr_logfile_maxbytes=0
 
 [program:nginx]
-command=nginx -g "daemon off;"
+command=openresty -g "daemon off;"
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr


### PR DESCRIPTION
The ppa:ondrej/nginx PPA started returning 403 errors, breaking the base Docker image build. libnginx-mod-http-lua is not available in Ubuntu 22.04's standard repos, so switch to OpenResty which bundles nginx with Lua and has its own stable apt repository.

Also add set -euo pipefail to scripts/e2e-tests so a base image build failure surfaces immediately rather than producing confusing downstream errors.