### PR TITLE
ci: make checks-pass actually fail when dependencies fail or skip

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -154,10 +154,20 @@ jobs:
         env:
           SHELLCHECK_OPTS: -e SC1090 -e SC2119 -e SC1091
 
-  # Final stage that will fail if the any of the entries in `needs` fails.
+  # Final stage that will fail if any of the entries in `needs` fails or is skipped.
+  # NOTE: `if: always()` is required so this job runs even when a dependency
+  # fails/cancels/skips. Without it, this job would itself be skipped, and
+  # GitHub branch protection treats a skipped required check as passing,
+  # allowing PRs to merge despite failing CI.
   checks-pass:
+    if: always()
     needs: ["cargo-clippy", "e2e-tests", "cargo-tests", "shell-checks"]
     runs-on: ubuntu-22.04
     steps:
+      - name: Fail if any dependency did not succeed
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
+        run: |
+          echo "One or more required jobs did not succeed: ${{ toJSON(needs) }}"
+          exit 1
       - name: Checks workflow passes
         run: echo OK


### PR DESCRIPTION
## Problem

The branch protection rule for `main` requires the `checks-pass` job to pass before a PR can merge. However, [PR #301](https://github.com/dfinity/exchange-rate-canister/pull/301) was able to merge while `checks-pass` did not pass.

## Cause

Without `if: always()`, a job inherits the implicit `success()` condition on its `needs`. So when any required job **fails, is cancelled, or is skipped**, `checks-pass` is itself **skipped** rather than failed.

GitHub branch protection treats a skipped required check as passing, which allowed PR #301 to be merged despite the gate.

## Fix

- Add `if: always()` to `checks-pass` so it runs unconditionally.
- Add an explicit step that fails the job if any dependency's result is `failure`, `cancelled`, or `skipped`.

This way `checks-pass` reports a real success/failure status that branch protection can rely on.