### PR TITLE
ci: add ic-wasm check-endpoints

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install `ic-wasm`
         uses: taiki-e/install-action@cca35edeb1d01366c2843b68fc3ca441446d73d3 # v2.77.1
         with:
-          tool: ic-wasm
+          tool: ic-wasm@0.9.11
 
       - name: Check canister endpoints
         run: |

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install `ic-wasm`
         uses: taiki-e/install-action@cca35edeb1d01366c2843b68fc3ca441446d73d3 # v2.77.1
         with:
-          tool: ic-wasm@0.9.11
+          tool: ic-wasm@0.9.10
 
       - name: Check canister endpoints
         run: |

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -36,3 +36,25 @@ jobs:
           echo "WASM size:          $wasm_size"
           echo "Max supported size: $max_size"
           (( wasm_size <= max_size )) || { echo "The WASM is too large" ; exit 1 ; }
+
+  check-canister-wasm-endpoints:
+    runs-on: ubuntu-22.04
+    needs: assets
+    steps:
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+
+      - name: Download WASM
+        uses: actions/download-artifact@v4
+        with:
+          name: Exchange Rate Canister WASM Module
+          path: ./out
+
+      - name: Install `ic-wasm`
+        uses: taiki-e/install-action@v2
+        with:
+          tool: ic-wasm
+
+      - name: Check canister endpoints
+        run: |
+          ic-wasm "$GITHUB_WORKSPACE/out/xrc.wasm.gz" check-endpoints \
+            --hidden ./src/xrc/hidden_endpoints.conf

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -44,13 +44,13 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Download WASM
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: Exchange Rate Canister WASM Module
           path: ./out
 
       - name: Install `ic-wasm`
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@cca35edeb1d01366c2843b68fc3ca441446d73d3 # v2.77.1
         with:
           tool: ic-wasm
 

--- a/src/xrc/hidden_endpoints.conf
+++ b/src/xrc/hidden_endpoints.conf
@@ -1,0 +1,12 @@
+# HTTP endpoint for fetching metrics
+canister_query:http_request
+# Transform functions for HTTP outcalls to exchanges and forex sources
+canister_query:transform_exchange_http_response
+canister_query:transform_forex_http_response
+# Canister lifecycle
+canister_heartbeat
+canister_inspect_message
+canister_post_upgrade
+canister_pre_upgrade
+# Exported by the `main()` function in `main.rs`; cannot be called
+main


### PR DESCRIPTION
## Summary

Add an `ic-wasm check-endpoints` CI check for the XRC canister, mirroring dfinity/bitcoin-canister#447. The check fails the build if the produced `xrc.wasm.gz` exports anything that isn't either declared in the candid interface or explicitly allowlisted in `src/xrc/hidden_endpoints.conf` — catching accidental public exports (e.g. a dropped `#[query(hidden = true)]` or a leaked FFI symbol) before they ship.

Closes DEFI-2500.