### PR TITLE
fix: Make docker build on x86

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 
 # This is the "builder", i.e. the base image used later to build the final
 # code.
-FROM ubuntu:22.04 as builder
+FROM --platform=linux/amd64 ubuntu:22.04 as builder
 SHELL ["bash", "-c"]
 
 ARG rust_version=1.90.0


### PR DESCRIPTION
Fix build on Apple Silicon by running x86 image (via macOS Rosetta).