### PR TITLE
feat: DEFI-2810: Add labeled metrics infrastructure and per-forex observability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2028,6 +2028,7 @@ dependencies = [
  "serde_bytes",
  "serde_derive",
  "serde_json",
+ "strum",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ chrono = { version = "0.4.33", default-features = false, features = [
 ] }
 ic-cdk = "0.19.0"
 serde = { version = "1.0.228", features = ["derive"] }
+strum = { version = "0.26", features = ["derive"] }
 
 [profile.release]
 lto = true

--- a/src/xrc/Cargo.toml
+++ b/src/xrc/Cargo.toml
@@ -22,6 +22,7 @@ serde_json = "1.0.149"
 serde_derive = "1.0"
 serde_bytes = "0.11.19"
 serde-xml-rs = "0.6.0"
+strum = { workspace = true }
 
 [dev-dependencies]
 candid = { workspace = true }

--- a/src/xrc/hidden_endpoints.conf
+++ b/src/xrc/hidden_endpoints.conf
@@ -5,6 +5,7 @@ canister_query:transform_exchange_http_response
 canister_query:transform_forex_http_response
 # Canister lifecycle
 canister_heartbeat
+canister_init
 canister_inspect_message
 canister_post_upgrade
 canister_pre_upgrade

--- a/src/xrc/src/api/metrics.rs
+++ b/src/xrc/src/api/metrics.rs
@@ -147,6 +147,11 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
         "xrc_forex_last_success_seconds",
         "Unix timestamp (seconds) of the most recent successful fetch per forex source.",
     )?;
+    encode_labeled_gauge_family(
+        w,
+        "xrc_periodic_forex_run_last_seconds",
+        "Unix timestamp (seconds) of the most recent successful periodic forex-update run.",
+    )?;
 
     Ok(())
 }
@@ -278,6 +283,9 @@ impl<W: io::Write> MetricsEncoder<W> {
         help: &str,
     ) -> io::Result<()> {
         self.encode_header(name, help, typ)?;
+        if labels.is_empty() {
+            return writeln!(self.writer, "{} {} {}", name, value, self.now_millis);
+        }
         write!(self.writer, "{}{{", name)?;
         for (i, (k, v)) in labels.iter().enumerate() {
             if i > 0 {
@@ -449,11 +457,12 @@ mod test {
     }
 
     #[test]
-    fn empty_label_set_still_emits_braces() {
+    fn empty_label_set_omits_braces() {
         let out = encode(0, |e| {
             e.encode_counter_with_labels("metric", &[], 1, "h").unwrap();
         });
-        assert!(out.contains("metric{} 1 0"), "got: {out}");
+        assert!(out.contains("metric 1 0"), "got: {out}");
+        assert!(!out.contains("metric{}"), "got: {out}");
     }
 
     #[test]

--- a/src/xrc/src/api/metrics.rs
+++ b/src/xrc/src/api/metrics.rs
@@ -150,7 +150,7 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
     encode_labeled_gauge_family(
         w,
         "xrc_periodic_forex_run_last_seconds",
-        "Unix timestamp (seconds) of the most recent successful periodic forex-update run.",
+        "Unix timestamp (seconds) of the most recent periodic forex-update task run (heartbeat — not contingent on rate-fetch success).",
     )?;
 
     Ok(())

--- a/src/xrc/src/api/metrics.rs
+++ b/src/xrc/src/api/metrics.rs
@@ -1,6 +1,6 @@
 use crate::{
-    rate_limiting, types::HttpResponse, with_cache, with_forex_rate_store, AllocatedBytes,
-    MetricCounter,
+    rate_limiting, types::HttpResponse, with_cache, with_forex_rate_store, with_labeled_counters,
+    with_labeled_gauges, AllocatedBytes, LabelPairs, MetricCounter,
 };
 use ic_cdk::api::time;
 use serde_bytes::ByteBuf;
@@ -137,6 +137,69 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
         "Size of the heap memory allocated by this canister measured in bytes.",
     )?;
 
+    encode_labeled_counter_family(
+        w,
+        "xrc_forex_fetch_total",
+        "Per-forex source fetch outcomes, labeled by forex source name and outcome.",
+    )?;
+    encode_labeled_gauge_family(
+        w,
+        "xrc_forex_last_success_seconds",
+        "Unix timestamp (seconds) of the most recent successful fetch per forex source.",
+    )?;
+
+    Ok(())
+}
+
+/// Emits one line per labeled series for the given counter metric `name`.
+/// Series are sorted by their label set so the scrape output is stable.
+fn encode_labeled_counter_family(
+    w: &mut MetricsEncoder<Vec<u8>>,
+    name: &'static str,
+    help: &str,
+) -> io::Result<()> {
+    let mut entries: Vec<(LabelPairs, u64)> = with_labeled_counters(|m| {
+        m.iter()
+            .filter_map(|((n, labels), v)| {
+                if *n == name {
+                    Some((labels.clone(), *v))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    });
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+    for (labels, value) in entries {
+        let refs: Vec<(&str, &str)> = labels.iter().map(|(k, v)| (*k, v.as_str())).collect();
+        w.encode_counter_with_labels(name, &refs, value, help)?;
+    }
+    Ok(())
+}
+
+/// Emits one line per labeled series for the given gauge metric `name`.
+/// Series are sorted by their label set so the scrape output is stable.
+fn encode_labeled_gauge_family(
+    w: &mut MetricsEncoder<Vec<u8>>,
+    name: &'static str,
+    help: &str,
+) -> io::Result<()> {
+    let mut entries: Vec<(LabelPairs, f64)> = with_labeled_gauges(|m| {
+        m.iter()
+            .filter_map(|((n, labels), v)| {
+                if *n == name {
+                    Some((labels.clone(), *v))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    });
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+    for (labels, value) in entries {
+        let refs: Vec<(&str, &str)> = labels.iter().map(|(k, v)| (*k, v.as_str())).collect();
+        w.encode_gauge_with_labels(name, &refs, value, help)?;
+    }
     Ok(())
 }
 
@@ -206,7 +269,6 @@ impl<W: io::Write> MetricsEncoder<W> {
         writeln!(self.writer, "{} {} {}", name, value, self.now_millis)
     }
 
-    #[allow(dead_code)]
     fn encode_labeled_value<T: Display>(
         &mut self,
         typ: &str,
@@ -237,7 +299,6 @@ impl<W: io::Write> MetricsEncoder<W> {
         self.encode_single_value("counter", name, value, help)
     }
 
-    #[allow(dead_code)]
     fn encode_gauge_with_labels(
         &mut self,
         name: &str,
@@ -248,7 +309,6 @@ impl<W: io::Write> MetricsEncoder<W> {
         self.encode_labeled_value("gauge", name, labels, value, help)
     }
 
-    #[allow(dead_code)]
     fn encode_counter_with_labels(
         &mut self,
         name: &str,
@@ -260,7 +320,6 @@ impl<W: io::Write> MetricsEncoder<W> {
     }
 }
 
-#[allow(dead_code)]
 fn write_escaped_label_value<W: io::Write>(writer: &mut W, value: &str) -> io::Result<()> {
     for c in value.chars() {
         match c {

--- a/src/xrc/src/api/metrics.rs
+++ b/src/xrc/src/api/metrics.rs
@@ -472,6 +472,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(debug_assertions)]
     #[should_panic(expected = "encode_counter/encode_gauge called twice for metric")]
     fn unlabeled_path_panics_on_repeated_name() {
         // Emitting two `# HELP`/`# TYPE` blocks for the same metric name

--- a/src/xrc/src/api/metrics.rs
+++ b/src/xrc/src/api/metrics.rs
@@ -1,6 +1,6 @@
 use crate::{
-    metric_names, rate_limiting, types::HttpResponse, with_cache, with_forex_rate_store,
-    with_labeled_counters, with_labeled_gauges, AllocatedBytes, MetricCounter,
+    rate_limiting, types::HttpResponse, with_cache, with_forex_rate_store,
+    with_labeled_counters, with_labeled_gauges, AllocatedBytes, MetricCounter, MetricName,
 };
 use ic_cdk::api::time;
 use serde_bytes::ByteBuf;
@@ -139,17 +139,17 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
 
     encode_labeled_counter_family(
         w,
-        metric_names::FOREX_FETCH_TOTAL,
+        MetricName::ForexFetchTotal,
         "Per-forex source fetch outcomes, labeled by forex source name and outcome.",
     )?;
     encode_labeled_gauge_family(
         w,
-        metric_names::FOREX_LAST_SUCCESS_SECONDS,
+        MetricName::ForexLastSuccessSeconds,
         "Unix timestamp (seconds) of the most recent successful fetch per forex source.",
     )?;
     encode_labeled_gauge_family(
         w,
-        metric_names::PERIODIC_FOREX_RUN_LAST_SECONDS,
+        MetricName::PeriodicForexRunLastSeconds,
         "Unix timestamp (seconds) of the most recent periodic forex-update task run (heartbeat — not contingent on rate-fetch success).",
     )?;
 
@@ -161,13 +161,17 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
 /// the scrape output is naturally ordered without any per-call collect+sort.
 fn encode_labeled_counter_family(
     w: &mut MetricsEncoder<Vec<u8>>,
-    name: &'static str,
+    name: MetricName,
     help: &str,
 ) -> io::Result<()> {
+    let name_str: &'static str = name.into();
     with_labeled_counters(|m| -> io::Result<()> {
         for ((_, labels), value) in m.iter().filter(|((n, _), _)| *n == name) {
-            let refs: Vec<(&str, &str)> = labels.iter().map(|(k, v)| (*k, v.as_str())).collect();
-            w.encode_counter_with_labels(name, &refs, *value, help)?;
+            let refs: Vec<(&str, &str)> = labels
+                .iter()
+                .map(|(k, v)| ((*k).into(), v.as_str()))
+                .collect();
+            w.encode_counter_with_labels(name_str, &refs, *value, help)?;
         }
         Ok(())
     })
@@ -177,13 +181,17 @@ fn encode_labeled_counter_family(
 /// Sorted iteration comes from `BTreeMap`; see `encode_labeled_counter_family`.
 fn encode_labeled_gauge_family(
     w: &mut MetricsEncoder<Vec<u8>>,
-    name: &'static str,
+    name: MetricName,
     help: &str,
 ) -> io::Result<()> {
+    let name_str: &'static str = name.into();
     with_labeled_gauges(|m| -> io::Result<()> {
         for ((_, labels), value) in m.iter().filter(|((n, _), _)| *n == name) {
-            let refs: Vec<(&str, &str)> = labels.iter().map(|(k, v)| (*k, v.as_str())).collect();
-            w.encode_gauge_with_labels(name, &refs, *value, help)?;
+            let refs: Vec<(&str, &str)> = labels
+                .iter()
+                .map(|(k, v)| ((*k).into(), v.as_str()))
+                .collect();
+            w.encode_gauge_with_labels(name_str, &refs, *value, help)?;
         }
         Ok(())
     })

--- a/src/xrc/src/api/metrics.rs
+++ b/src/xrc/src/api/metrics.rs
@@ -257,8 +257,9 @@ impl<W: io::Write> MetricsEncoder<W> {
         value: T,
         help: &str,
     ) -> io::Result<()> {
+        let fresh = self.headers_emitted.insert(name);
         debug_assert!(
-            self.headers_emitted.insert(name),
+            fresh,
             "encode_counter/encode_gauge called twice for metric {name:?}; \
              use encode_counter_with_labels / encode_gauge_with_labels for \
              multi-series metrics"

--- a/src/xrc/src/api/metrics.rs
+++ b/src/xrc/src/api/metrics.rs
@@ -1,6 +1,6 @@
 use crate::{
-    rate_limiting, types::HttpResponse, with_cache, with_forex_rate_store, with_labeled_counters,
-    with_labeled_gauges, AllocatedBytes, MetricCounter,
+    metric_names, rate_limiting, types::HttpResponse, with_cache, with_forex_rate_store,
+    with_labeled_counters, with_labeled_gauges, AllocatedBytes, MetricCounter,
 };
 use ic_cdk::api::time;
 use serde_bytes::ByteBuf;
@@ -139,17 +139,17 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
 
     encode_labeled_counter_family(
         w,
-        "xrc_forex_fetch_total",
+        metric_names::FOREX_FETCH_TOTAL,
         "Per-forex source fetch outcomes, labeled by forex source name and outcome.",
     )?;
     encode_labeled_gauge_family(
         w,
-        "xrc_forex_last_success_seconds",
+        metric_names::FOREX_LAST_SUCCESS_SECONDS,
         "Unix timestamp (seconds) of the most recent successful fetch per forex source.",
     )?;
     encode_labeled_gauge_family(
         w,
-        "xrc_periodic_forex_run_last_seconds",
+        metric_names::PERIODIC_FOREX_RUN_LAST_SECONDS,
         "Unix timestamp (seconds) of the most recent periodic forex-update task run (heartbeat — not contingent on rate-fetch success).",
     )?;
 

--- a/src/xrc/src/api/metrics.rs
+++ b/src/xrc/src/api/metrics.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use ic_cdk::api::time;
 use serde_bytes::ByteBuf;
-use std::{collections::HashSet, fmt::Display, io};
+use std::{collections::BTreeSet, fmt::Display, io};
 
 pub fn get_metrics() -> HttpResponse {
     let now = time();
@@ -233,7 +233,7 @@ struct MetricsEncoder<W: io::Write> {
     ///
     /// `&'static str` keys (rather than `String`) avoid an allocation per
     /// first-emit; all callers pass static metric-name constants.
-    headers_emitted: HashSet<&'static str>,
+    headers_emitted: BTreeSet<&'static str>,
 }
 
 impl<W: io::Write> MetricsEncoder<W> {
@@ -243,7 +243,7 @@ impl<W: io::Write> MetricsEncoder<W> {
         Self {
             writer,
             now_millis,
-            headers_emitted: HashSet::new(),
+            headers_emitted: BTreeSet::new(),
         }
     }
 

--- a/src/xrc/src/api/metrics.rs
+++ b/src/xrc/src/api/metrics.rs
@@ -1,6 +1,6 @@
 use crate::{
     rate_limiting, types::HttpResponse, with_cache, with_forex_rate_store, with_labeled_counters,
-    with_labeled_gauges, AllocatedBytes, LabelPairs, MetricCounter,
+    with_labeled_gauges, AllocatedBytes, MetricCounter,
 };
 use ic_cdk::api::time;
 use serde_bytes::ByteBuf;
@@ -157,55 +157,36 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
 }
 
 /// Emits one line per labeled series for the given counter metric `name`.
-/// Series are sorted by their label set so the scrape output is stable.
+/// `BTreeMap` iteration is already sorted by `(metric_name, labels)`, so
+/// the scrape output is naturally ordered without any per-call collect+sort.
 fn encode_labeled_counter_family(
     w: &mut MetricsEncoder<Vec<u8>>,
     name: &'static str,
     help: &str,
 ) -> io::Result<()> {
-    let mut entries: Vec<(LabelPairs, u64)> = with_labeled_counters(|m| {
-        m.iter()
-            .filter_map(|((n, labels), v)| {
-                if *n == name {
-                    Some((labels.clone(), *v))
-                } else {
-                    None
-                }
-            })
-            .collect()
-    });
-    entries.sort_by(|a, b| a.0.cmp(&b.0));
-    for (labels, value) in entries {
-        let refs: Vec<(&str, &str)> = labels.iter().map(|(k, v)| (*k, v.as_str())).collect();
-        w.encode_counter_with_labels(name, &refs, value, help)?;
-    }
-    Ok(())
+    with_labeled_counters(|m| -> io::Result<()> {
+        for ((_, labels), value) in m.iter().filter(|((n, _), _)| *n == name) {
+            let refs: Vec<(&str, &str)> = labels.iter().map(|(k, v)| (*k, v.as_str())).collect();
+            w.encode_counter_with_labels(name, &refs, *value, help)?;
+        }
+        Ok(())
+    })
 }
 
 /// Emits one line per labeled series for the given gauge metric `name`.
-/// Series are sorted by their label set so the scrape output is stable.
+/// Sorted iteration comes from `BTreeMap`; see `encode_labeled_counter_family`.
 fn encode_labeled_gauge_family(
     w: &mut MetricsEncoder<Vec<u8>>,
     name: &'static str,
     help: &str,
 ) -> io::Result<()> {
-    let mut entries: Vec<(LabelPairs, f64)> = with_labeled_gauges(|m| {
-        m.iter()
-            .filter_map(|((n, labels), v)| {
-                if *n == name {
-                    Some((labels.clone(), *v))
-                } else {
-                    None
-                }
-            })
-            .collect()
-    });
-    entries.sort_by(|a, b| a.0.cmp(&b.0));
-    for (labels, value) in entries {
-        let refs: Vec<(&str, &str)> = labels.iter().map(|(k, v)| (*k, v.as_str())).collect();
-        w.encode_gauge_with_labels(name, &refs, value, help)?;
-    }
-    Ok(())
+    with_labeled_gauges(|m| -> io::Result<()> {
+        for ((_, labels), value) in m.iter().filter(|((n, _), _)| *n == name) {
+            let refs: Vec<(&str, &str)> = labels.iter().map(|(k, v)| (*k, v.as_str())).collect();
+            w.encode_gauge_with_labels(name, &refs, *value, help)?;
+        }
+        Ok(())
+    })
 }
 
 /// Returns the amount of heap memory in bytes that has been allocated.

--- a/src/xrc/src/api/metrics.rs
+++ b/src/xrc/src/api/metrics.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use ic_cdk::api::time;
 use serde_bytes::ByteBuf;
-use std::{fmt::Display, io};
+use std::{collections::HashSet, fmt::Display, io};
 
 pub fn get_metrics() -> HttpResponse {
     let now = time();
@@ -164,13 +164,18 @@ pub fn heap_memory_size_bytes() -> usize {
 struct MetricsEncoder<W: io::Write> {
     writer: W,
     now_millis: u64,
+    headered: HashSet<String>,
 }
 
 impl<W: io::Write> MetricsEncoder<W> {
     /// Constructs a new encoder dumping metrics with the given timestamp into
     /// the specified writer.
     fn new(writer: W, now_millis: u64) -> Self {
-        Self { writer, now_millis }
+        Self {
+            writer,
+            now_millis,
+            headered: HashSet::new(),
+        }
     }
 
     /// Returns the internal buffer that was used to record the
@@ -179,7 +184,13 @@ impl<W: io::Write> MetricsEncoder<W> {
         self.writer
     }
 
+    /// Emits the `# HELP` and `# TYPE` lines for `name`, but only the first
+    /// time this encoder sees `name`. Multiple labeled series under the same
+    /// metric name therefore share one header pair.
     fn encode_header(&mut self, name: &str, help: &str, typ: &str) -> io::Result<()> {
+        if !self.headered.insert(name.to_string()) {
+            return Ok(());
+        }
         writeln!(self.writer, "# HELP {} {}", name, help)?;
         writeln!(self.writer, "# TYPE {} {}", name, typ)
     }
@@ -195,6 +206,28 @@ impl<W: io::Write> MetricsEncoder<W> {
         writeln!(self.writer, "{} {} {}", name, value, self.now_millis)
     }
 
+    #[allow(dead_code)]
+    fn encode_labeled_value<T: Display>(
+        &mut self,
+        typ: &str,
+        name: &str,
+        labels: &[(&str, &str)],
+        value: T,
+        help: &str,
+    ) -> io::Result<()> {
+        self.encode_header(name, help, typ)?;
+        write!(self.writer, "{}{{", name)?;
+        for (i, (k, v)) in labels.iter().enumerate() {
+            if i > 0 {
+                write!(self.writer, ",")?;
+            }
+            write!(self.writer, "{}=\"", k)?;
+            write_escaped_label_value(&mut self.writer, v)?;
+            write!(self.writer, "\"")?;
+        }
+        writeln!(self.writer, "}} {} {}", value, self.now_millis)
+    }
+
     /// Encodes the metadata and the value of a gauge.
     fn encode_gauge(&mut self, name: &str, value: f64, help: &str) -> io::Result<()> {
         self.encode_single_value("gauge", name, value, help)
@@ -202,5 +235,175 @@ impl<W: io::Write> MetricsEncoder<W> {
 
     fn encode_counter(&mut self, name: &str, value: u64, help: &str) -> io::Result<()> {
         self.encode_single_value("counter", name, value, help)
+    }
+
+    #[allow(dead_code)]
+    fn encode_gauge_with_labels(
+        &mut self,
+        name: &str,
+        labels: &[(&str, &str)],
+        value: f64,
+        help: &str,
+    ) -> io::Result<()> {
+        self.encode_labeled_value("gauge", name, labels, value, help)
+    }
+
+    #[allow(dead_code)]
+    fn encode_counter_with_labels(
+        &mut self,
+        name: &str,
+        labels: &[(&str, &str)],
+        value: u64,
+        help: &str,
+    ) -> io::Result<()> {
+        self.encode_labeled_value("counter", name, labels, value, help)
+    }
+}
+
+#[allow(dead_code)]
+fn write_escaped_label_value<W: io::Write>(writer: &mut W, value: &str) -> io::Result<()> {
+    for c in value.chars() {
+        match c {
+            '\\' => write!(writer, "\\\\")?,
+            '\n' => write!(writer, "\\n")?,
+            '"' => write!(writer, "\\\"")?,
+            _ => write!(writer, "{}", c)?,
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn encode(now_millis: u64, f: impl FnOnce(&mut MetricsEncoder<Vec<u8>>)) -> String {
+        let mut encoder = MetricsEncoder::new(vec![], now_millis);
+        f(&mut encoder);
+        String::from_utf8(encoder.into_inner()).expect("encoder must emit utf-8")
+    }
+
+    #[test]
+    fn label_less_counter_format_is_unchanged() {
+        let out = encode(7, |e| {
+            e.encode_counter("xrc_requests", 42, "Total requests.").unwrap();
+        });
+        assert_eq!(
+            out,
+            "# HELP xrc_requests Total requests.\n# TYPE xrc_requests counter\nxrc_requests 42 7\n"
+        );
+    }
+
+    #[test]
+    fn label_less_gauge_format_is_unchanged() {
+        let out = encode(7, |e| {
+            e.encode_gauge("xrc_cache_size", 17.0, "Cache size.").unwrap();
+        });
+        assert_eq!(
+            out,
+            "# HELP xrc_cache_size Cache size.\n# TYPE xrc_cache_size gauge\nxrc_cache_size 17 7\n"
+        );
+    }
+
+    #[test]
+    fn labeled_counter_emits_braces_and_pairs() {
+        let out = encode(123, |e| {
+            e.encode_counter_with_labels(
+                "xrc_exchange_fetch_total",
+                &[
+                    ("exchange", "Mexc"),
+                    ("kind", "crypto"),
+                    ("outcome", "success"),
+                ],
+                5,
+                "Per-exchange fetch outcomes.",
+            )
+            .unwrap();
+        });
+        assert_eq!(
+            out,
+            concat!(
+                "# HELP xrc_exchange_fetch_total Per-exchange fetch outcomes.\n",
+                "# TYPE xrc_exchange_fetch_total counter\n",
+                "xrc_exchange_fetch_total{exchange=\"Mexc\",kind=\"crypto\",outcome=\"success\"} 5 123\n",
+            )
+        );
+    }
+
+    #[test]
+    fn multiple_labeled_series_share_one_header() {
+        let out = encode(0, |e| {
+            e.encode_counter_with_labels(
+                "xrc_exchange_fetch_total",
+                &[("exchange", "Mexc"), ("outcome", "success")],
+                10,
+                "Per-exchange fetch outcomes.",
+            )
+            .unwrap();
+            e.encode_counter_with_labels(
+                "xrc_exchange_fetch_total",
+                &[("exchange", "Mexc"), ("outcome", "http_error")],
+                3,
+                "Per-exchange fetch outcomes.",
+            )
+            .unwrap();
+        });
+        let header_lines = out.lines().filter(|l| l.starts_with("# ")).count();
+        assert_eq!(header_lines, 2, "expected one HELP + one TYPE line, got:\n{out}");
+        assert!(out.contains(r#"xrc_exchange_fetch_total{exchange="Mexc",outcome="success"} 10 0"#));
+        assert!(
+            out.contains(r#"xrc_exchange_fetch_total{exchange="Mexc",outcome="http_error"} 3 0"#)
+        );
+    }
+
+    #[test]
+    fn labeled_gauge_renders_float_value() {
+        let out = encode(0, |e| {
+            e.encode_gauge_with_labels(
+                "xrc_exchange_last_success_seconds",
+                &[("exchange", "Coinbase"), ("kind", "crypto")],
+                1_700_000_000.0,
+                "Last success timestamp.",
+            )
+            .unwrap();
+        });
+        assert!(out.contains(
+            r#"xrc_exchange_last_success_seconds{exchange="Coinbase",kind="crypto"} 1700000000 0"#
+        ));
+    }
+
+    #[test]
+    fn label_value_escapes_quotes_backslash_and_newline() {
+        let out = encode(0, |e| {
+            e.encode_counter_with_labels(
+                "metric",
+                &[("k", "a\"b\\c\nd")],
+                1,
+                "h",
+            )
+            .unwrap();
+        });
+        assert!(
+            out.contains(r#"metric{k="a\"b\\c\nd"} 1 0"#),
+            "got: {out}"
+        );
+    }
+
+    #[test]
+    fn empty_label_set_still_emits_braces() {
+        let out = encode(0, |e| {
+            e.encode_counter_with_labels("metric", &[], 1, "h").unwrap();
+        });
+        assert!(out.contains("metric{} 1 0"), "got: {out}");
+    }
+
+    #[test]
+    fn distinct_metric_names_each_get_their_own_header() {
+        let out = encode(0, |e| {
+            e.encode_counter("a", 1, "ha").unwrap();
+            e.encode_counter("b", 2, "hb").unwrap();
+        });
+        assert!(out.contains("# HELP a ha"));
+        assert!(out.contains("# HELP b hb"));
     }
 }

--- a/src/xrc/src/api/metrics.rs
+++ b/src/xrc/src/api/metrics.rs
@@ -232,7 +232,12 @@ pub fn heap_memory_size_bytes() -> usize {
 struct MetricsEncoder<W: io::Write> {
     writer: W,
     now_millis: u64,
-    headered: HashSet<String>,
+    /// Names for which the labeled path has already emitted `# HELP`/`# TYPE`.
+    /// Only the labeled methods consult this set, so the unlabeled methods
+    /// keep their historical "always emit a header" contract — useful as a
+    /// guardrail against a future caller that accidentally registers two
+    /// unrelated metrics under the same name.
+    labeled_headers_seen: HashSet<String>,
 }
 
 impl<W: io::Write> MetricsEncoder<W> {
@@ -242,7 +247,7 @@ impl<W: io::Write> MetricsEncoder<W> {
         Self {
             writer,
             now_millis,
-            headered: HashSet::new(),
+            labeled_headers_seen: HashSet::new(),
         }
     }
 
@@ -252,15 +257,24 @@ impl<W: io::Write> MetricsEncoder<W> {
         self.writer
     }
 
-    /// Emits the `# HELP` and `# TYPE` lines for `name`, but only the first
-    /// time this encoder sees `name`. Multiple labeled series under the same
-    /// metric name therefore share one header pair.
     fn encode_header(&mut self, name: &str, help: &str, typ: &str) -> io::Result<()> {
-        if !self.headered.insert(name.to_string()) {
-            return Ok(());
-        }
         writeln!(self.writer, "# HELP {} {}", name, help)?;
         writeln!(self.writer, "# TYPE {} {}", name, typ)
+    }
+
+    /// Emits the header only on the first call for a given `name` *via the
+    /// labeled path*. Multiple labeled series sharing one metric name
+    /// therefore share one `# HELP`/`# TYPE` pair.
+    fn encode_header_once_for_labeled(
+        &mut self,
+        name: &str,
+        help: &str,
+        typ: &str,
+    ) -> io::Result<()> {
+        if !self.labeled_headers_seen.insert(name.to_string()) {
+            return Ok(());
+        }
+        self.encode_header(name, help, typ)
     }
 
     fn encode_single_value<T: Display>(
@@ -282,7 +296,7 @@ impl<W: io::Write> MetricsEncoder<W> {
         value: T,
         help: &str,
     ) -> io::Result<()> {
-        self.encode_header(name, help, typ)?;
+        self.encode_header_once_for_labeled(name, help, typ)?;
         if labels.is_empty() {
             return writeln!(self.writer, "{} {} {}", name, value, self.now_millis);
         }
@@ -473,5 +487,21 @@ mod test {
         });
         assert!(out.contains("# HELP a ha"));
         assert!(out.contains("# HELP b hb"));
+    }
+
+    #[test]
+    fn unlabeled_path_does_not_dedupe_headers() {
+        // The labeled path shares one header across many series of the same
+        // name, but the unlabeled path keeps the historical "always emit"
+        // contract so that two unrelated callers can't silently lose a
+        // header pair.
+        let out = encode(0, |e| {
+            e.encode_counter("metric", 1, "help").unwrap();
+            e.encode_counter("metric", 2, "help").unwrap();
+        });
+        let help_lines = out.lines().filter(|l| l.starts_with("# HELP ")).count();
+        let type_lines = out.lines().filter(|l| l.starts_with("# TYPE ")).count();
+        assert_eq!(help_lines, 2, "got:\n{out}");
+        assert_eq!(type_lines, 2, "got:\n{out}");
     }
 }

--- a/src/xrc/src/api/metrics.rs
+++ b/src/xrc/src/api/metrics.rs
@@ -213,12 +213,16 @@ pub fn heap_memory_size_bytes() -> usize {
 struct MetricsEncoder<W: io::Write> {
     writer: W,
     now_millis: u64,
-    /// Names for which the labeled path has already emitted `# HELP`/`# TYPE`.
-    /// Only the labeled methods consult this set, so the unlabeled methods
-    /// keep their historical "always emit a header" contract — useful as a
-    /// guardrail against a future caller that accidentally registers two
-    /// unrelated metrics under the same name.
-    labeled_headers_seen: HashSet<String>,
+    /// Metric names for which `# HELP`/`# TYPE` has already been emitted
+    /// in this pass. Both paths consult this:
+    /// - the labeled path silently dedups, so many series under one name
+    ///   share a header pair;
+    /// - the unlabeled path `debug_assert!`s the name is fresh, since
+    ///   `encode_counter` / `encode_gauge` is meant for single-series
+    ///   metrics and emitting two of them would violate the Prometheus
+    ///   exposition format ("Only one HELP line may exist for any given
+    ///   metric name").
+    headers_emitted: HashSet<String>,
 }
 
 impl<W: io::Write> MetricsEncoder<W> {
@@ -228,7 +232,7 @@ impl<W: io::Write> MetricsEncoder<W> {
         Self {
             writer,
             now_millis,
-            labeled_headers_seen: HashSet::new(),
+            headers_emitted: HashSet::new(),
         }
     }
 
@@ -238,24 +242,9 @@ impl<W: io::Write> MetricsEncoder<W> {
         self.writer
     }
 
-    fn encode_header(&mut self, name: &str, help: &str, typ: &str) -> io::Result<()> {
+    fn write_header_line(&mut self, name: &str, help: &str, typ: &str) -> io::Result<()> {
         writeln!(self.writer, "# HELP {} {}", name, help)?;
         writeln!(self.writer, "# TYPE {} {}", name, typ)
-    }
-
-    /// Emits the header only on the first call for a given `name` *via the
-    /// labeled path*. Multiple labeled series sharing one metric name
-    /// therefore share one `# HELP`/`# TYPE` pair.
-    fn encode_header_once_for_labeled(
-        &mut self,
-        name: &str,
-        help: &str,
-        typ: &str,
-    ) -> io::Result<()> {
-        if !self.labeled_headers_seen.insert(name.to_string()) {
-            return Ok(());
-        }
-        self.encode_header(name, help, typ)
     }
 
     fn encode_single_value<T: Display>(
@@ -265,7 +254,13 @@ impl<W: io::Write> MetricsEncoder<W> {
         value: T,
         help: &str,
     ) -> io::Result<()> {
-        self.encode_header(name, help, typ)?;
+        debug_assert!(
+            self.headers_emitted.insert(name.to_string()),
+            "encode_counter/encode_gauge called twice for metric {name:?}; \
+             use encode_counter_with_labels / encode_gauge_with_labels for \
+             multi-series metrics"
+        );
+        self.write_header_line(name, help, typ)?;
         writeln!(self.writer, "{} {} {}", name, value, self.now_millis)
     }
 
@@ -277,7 +272,9 @@ impl<W: io::Write> MetricsEncoder<W> {
         value: T,
         help: &str,
     ) -> io::Result<()> {
-        self.encode_header_once_for_labeled(name, help, typ)?;
+        if self.headers_emitted.insert(name.to_string()) {
+            self.write_header_line(name, help, typ)?;
+        }
         if labels.is_empty() {
             return writeln!(self.writer, "{} {} {}", name, value, self.now_millis);
         }
@@ -471,18 +468,31 @@ mod test {
     }
 
     #[test]
-    fn unlabeled_path_does_not_dedupe_headers() {
-        // The labeled path shares one header across many series of the same
-        // name, but the unlabeled path keeps the historical "always emit"
-        // contract so that two unrelated callers can't silently lose a
-        // header pair.
+    #[should_panic(expected = "encode_counter/encode_gauge called twice for metric")]
+    fn unlabeled_path_panics_on_repeated_name() {
+        // Emitting two `# HELP`/`# TYPE` blocks for the same metric name
+        // would violate the Prometheus exposition format. The encoder
+        // guards against it with a `debug_assert!` instead of silently
+        // emitting invalid output. Production behaviour is to never call
+        // the unlabeled methods with the same name twice.
+        let mut encoder = MetricsEncoder::new(vec![], 0);
+        encoder.encode_counter("metric", 1, "help").unwrap();
+        encoder.encode_counter("metric", 2, "help").unwrap();
+    }
+
+    #[test]
+    fn unlabeled_then_labeled_reuses_header() {
+        // The labeled path silently dedups against a shared
+        // `headers_emitted` set, so an earlier unlabeled emit of the
+        // same name suppresses the labeled path's header (no duplicate
+        // emission). This combination is never produced in practice;
+        // the test documents the behaviour for safety.
         let out = encode(0, |e| {
             e.encode_counter("metric", 1, "help").unwrap();
-            e.encode_counter("metric", 2, "help").unwrap();
+            e.encode_counter_with_labels("metric", &[("k", "v")], 2, "help")
+                .unwrap();
         });
         let help_lines = out.lines().filter(|l| l.starts_with("# HELP ")).count();
-        let type_lines = out.lines().filter(|l| l.starts_with("# TYPE ")).count();
-        assert_eq!(help_lines, 2, "got:\n{out}");
-        assert_eq!(type_lines, 2, "got:\n{out}");
+        assert_eq!(help_lines, 1, "got:\n{out}");
     }
 }

--- a/src/xrc/src/api/metrics.rs
+++ b/src/xrc/src/api/metrics.rs
@@ -222,7 +222,10 @@ struct MetricsEncoder<W: io::Write> {
     ///   metrics and emitting two of them would violate the Prometheus
     ///   exposition format ("Only one HELP line may exist for any given
     ///   metric name").
-    headers_emitted: HashSet<String>,
+    ///
+    /// `&'static str` keys (rather than `String`) avoid an allocation per
+    /// first-emit; all callers pass static metric-name constants.
+    headers_emitted: HashSet<&'static str>,
 }
 
 impl<W: io::Write> MetricsEncoder<W> {
@@ -250,12 +253,12 @@ impl<W: io::Write> MetricsEncoder<W> {
     fn encode_single_value<T: Display>(
         &mut self,
         typ: &str,
-        name: &str,
+        name: &'static str,
         value: T,
         help: &str,
     ) -> io::Result<()> {
         debug_assert!(
-            self.headers_emitted.insert(name.to_string()),
+            self.headers_emitted.insert(name),
             "encode_counter/encode_gauge called twice for metric {name:?}; \
              use encode_counter_with_labels / encode_gauge_with_labels for \
              multi-series metrics"
@@ -267,12 +270,12 @@ impl<W: io::Write> MetricsEncoder<W> {
     fn encode_labeled_value<T: Display>(
         &mut self,
         typ: &str,
-        name: &str,
+        name: &'static str,
         labels: &[(&str, &str)],
         value: T,
         help: &str,
     ) -> io::Result<()> {
-        if self.headers_emitted.insert(name.to_string()) {
+        if self.headers_emitted.insert(name) {
             self.write_header_line(name, help, typ)?;
         }
         if labels.is_empty() {
@@ -291,17 +294,17 @@ impl<W: io::Write> MetricsEncoder<W> {
     }
 
     /// Encodes the metadata and the value of a gauge.
-    fn encode_gauge(&mut self, name: &str, value: f64, help: &str) -> io::Result<()> {
+    fn encode_gauge(&mut self, name: &'static str, value: f64, help: &str) -> io::Result<()> {
         self.encode_single_value("gauge", name, value, help)
     }
 
-    fn encode_counter(&mut self, name: &str, value: u64, help: &str) -> io::Result<()> {
+    fn encode_counter(&mut self, name: &'static str, value: u64, help: &str) -> io::Result<()> {
         self.encode_single_value("counter", name, value, help)
     }
 
     fn encode_gauge_with_labels(
         &mut self,
-        name: &str,
+        name: &'static str,
         labels: &[(&str, &str)],
         value: f64,
         help: &str,
@@ -311,7 +314,7 @@ impl<W: io::Write> MetricsEncoder<W> {
 
     fn encode_counter_with_labels(
         &mut self,
-        name: &str,
+        name: &'static str,
         labels: &[(&str, &str)],
         value: u64,
         help: &str,

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -39,7 +39,7 @@ use crate::{
 };
 
 use std::cmp::{max, min};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::{
     cell::{Cell, RefCell},
     mem::{size_of, size_of_val},
@@ -163,8 +163,13 @@ thread_local! {
     /// Per-(metric-name, label-set) labeled metrics. Populated by recording
     /// sites via [`increment_labeled_counter`] and [`set_labeled_gauge`],
     /// drained by [`api::metrics::get_metrics`]. Reset on canister upgrade.
-    static LABELED_COUNTERS: RefCell<HashMap<MetricKey, u64>> = RefCell::new(HashMap::new());
-    static LABELED_GAUGES: RefCell<HashMap<MetricKey, f64>> = RefCell::new(HashMap::new());
+    ///
+    /// `BTreeMap` (over `HashMap`) gives the encoder free sorted iteration
+    /// by `(metric_name, labels)`, which is what the scrape path wants
+    /// anyway — and groups all series of the same metric name contiguously.
+    /// O(log N) inserts are immaterial at this cardinality (≤ a few hundred).
+    static LABELED_COUNTERS: RefCell<BTreeMap<MetricKey, u64>> = RefCell::new(BTreeMap::new());
+    static LABELED_GAUGES: RefCell<BTreeMap<MetricKey, f64>> = RefCell::new(BTreeMap::new());
 }
 
 /// Clears both labeled-metrics maps. Tests in sibling modules call this
@@ -217,14 +222,14 @@ pub(crate) fn set_labeled_gauge(
 
 pub(crate) fn with_labeled_counters<F, R>(f: F) -> R
 where
-    F: FnOnce(&HashMap<MetricKey, u64>) -> R,
+    F: FnOnce(&BTreeMap<MetricKey, u64>) -> R,
 {
     LABELED_COUNTERS.with(|m| f(&m.borrow()))
 }
 
 pub(crate) fn with_labeled_gauges<F, R>(f: F) -> R
 where
-    F: FnOnce(&HashMap<MetricKey, f64>) -> R,
+    F: FnOnce(&BTreeMap<MetricKey, f64>) -> R,
 {
     LABELED_GAUGES.with(|m| f(&m.borrow()))
 }

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -162,7 +162,7 @@ thread_local! {
 
     /// Per-(metric-name, label-set) labeled metrics. Populated by recording
     /// sites via [`increment_labeled_counter`] and [`set_labeled_gauge`],
-    /// drained by [`api::metrics::get_metrics`]. Reset on canister upgrade.
+    /// encoded by [`api::metrics::get_metrics`]. Reset on canister upgrade.
     ///
     /// `BTreeMap` (over `HashMap`) gives the encoder free sorted iteration
     /// by `(metric_name, labels)`, which is what the scrape path wants

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -217,7 +217,7 @@ pub(crate) mod metric_labels {
 /// from closed enums or constants, never from caller input.
 pub(crate) type LabelPairs = Vec<(&'static str, String)>;
 
-/// The hash/equality key for [`LABELED_COUNTERS`] and [`LABELED_GAUGES`].
+/// The ordering/equality key for [`LABELED_COUNTERS`] and [`LABELED_GAUGES`].
 /// Labels are sorted by name in [`make_metric_key`] so the order in which
 /// a call site lists them does not affect identity.
 pub(crate) type MetricKey = (&'static str, LabelPairs);

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -193,6 +193,23 @@ pub(crate) mod metric_names {
     pub const PERIODIC_FOREX_RUN_LAST_SECONDS: &str = "xrc_periodic_forex_run_last_seconds";
 }
 
+/// Label keys and the closed set of label values used by labeled metrics.
+/// Recording sites reference these constants instead of free string
+/// literals, so the cardinality of any label can be audited by reading
+/// this module — and a typo at a recording site is a compile error
+/// rather than a phantom new series.
+pub(crate) mod metric_labels {
+    // Label keys
+    pub const FOREX: &str = "forex";
+    pub const OUTCOME: &str = "outcome";
+
+    // Closed set of `outcome` values for `xrc_forex_fetch_total`.
+    pub const SUCCESS: &str = "success";
+    pub const HTTP_ERROR: &str = "http_error";
+    pub const CANDID_ERROR: &str = "candid_error";
+    pub const EMPTY_MAP: &str = "empty_map";
+}
+
 /// A sorted list of `(label_name, label_value)` pairs. Label names are
 /// always `&'static str` (defined at recording sites); label values are
 /// `String` because some — like exchange/forex names from `Display` —
@@ -261,7 +278,7 @@ fn init_at(now_secs: u64) {
         let name = forex.to_string();
         set_labeled_gauge(
             metric_names::FOREX_LAST_SUCCESS_SECONDS,
-            &[("forex", name.as_str())],
+            &[(metric_labels::FOREX, name.as_str())],
             now,
         );
     }
@@ -1771,7 +1788,7 @@ mod test {
                     let name = forex.to_string();
                     let key = make_metric_key(
                         metric_names::FOREX_LAST_SUCCESS_SECONDS,
-                        &[("forex", name.as_str())],
+                        &[(metric_labels::FOREX, name.as_str())],
                     );
                     assert_eq!(
                         m.get(&key).copied(),

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -172,20 +172,22 @@ thread_local! {
 /// `String` because some — like exchange/forex names from `Display` —
 /// aren't `&'static`. Recording sites should still source label values
 /// from closed enums or constants, never from caller input.
-type LabelPairs = Vec<(&'static str, String)>;
+pub(crate) type LabelPairs = Vec<(&'static str, String)>;
 
 /// The hash/equality key for [`LABELED_COUNTERS`] and [`LABELED_GAUGES`].
 /// Labels are sorted by name in [`make_metric_key`] so the order in which
 /// a call site lists them does not affect identity.
-type MetricKey = (&'static str, LabelPairs);
+pub(crate) type MetricKey = (&'static str, LabelPairs);
 
-fn make_metric_key(name: &'static str, labels: &[(&'static str, &str)]) -> MetricKey {
+pub(crate) fn make_metric_key(
+    name: &'static str,
+    labels: &[(&'static str, &str)],
+) -> MetricKey {
     let mut pairs: LabelPairs = labels.iter().map(|(k, v)| (*k, v.to_string())).collect();
     pairs.sort_by_key(|(k, _)| *k);
     (name, pairs)
 }
 
-#[allow(dead_code)]
 pub(crate) fn increment_labeled_counter(name: &'static str, labels: &[(&'static str, &str)]) {
     LABELED_COUNTERS.with(|m| {
         let mut m = m.borrow_mut();
@@ -194,7 +196,6 @@ pub(crate) fn increment_labeled_counter(name: &'static str, labels: &[(&'static 
     });
 }
 
-#[allow(dead_code)]
 pub(crate) fn set_labeled_gauge(
     name: &'static str,
     labels: &[(&'static str, &str)],
@@ -205,7 +206,6 @@ pub(crate) fn set_labeled_gauge(
     });
 }
 
-#[allow(dead_code)]
 pub(crate) fn with_labeled_counters<F, R>(f: F) -> R
 where
     F: FnOnce(&HashMap<MetricKey, u64>) -> R,
@@ -213,7 +213,6 @@ where
     LABELED_COUNTERS.with(|m| f(&m.borrow()))
 }
 
-#[allow(dead_code)]
 pub(crate) fn with_labeled_gauges<F, R>(f: F) -> R
 where
     F: FnOnce(&HashMap<MetricKey, f64>) -> R,
@@ -223,12 +222,23 @@ where
 
 /// Initializes ephemeral state that does not survive a canister upgrade.
 /// Called from the `#[ic_cdk::init]` hook and from [`post_upgrade`] after
-/// stable state is restored. Follow-up commits will populate the body
-/// with `set_labeled_gauge` calls that seed each `*_last_success_seconds`
-/// gauge to the current time, so a freshly-deployed canister doesn't
-/// immediately page on a staleness alert.
+/// stable state is restored. Seeds every `*_last_success_seconds` gauge
+/// to the current time so a freshly-deployed canister doesn't immediately
+/// trip a staleness alert.
 pub fn init() {
-    // Intentionally empty until the first labeled gauge lands.
+    init_at(utils::time_secs());
+}
+
+fn init_at(now_secs: u64) {
+    let now = now_secs as f64;
+    for forex in FOREX_SOURCES {
+        let name = forex.to_string();
+        set_labeled_gauge(
+            "xrc_forex_last_success_seconds",
+            &[("forex", name.as_str())],
+            now,
+        );
+    }
 }
 
 /// Used to retrieve or increment the various metric counters in the state.
@@ -821,6 +831,13 @@ enum CallForexError {
         /// The error returned from the candid encode/decode.
         error: String,
     },
+    /// The forex source returned HTTP 200 but parsed to an empty rates map.
+    /// Distinguished from [Http] so that observability can tell "the upstream
+    /// is returning nothing" apart from "we couldn't reach the upstream."
+    Empty {
+        /// The forex that is associated with the error.
+        forex: String,
+    },
 }
 
 impl core::fmt::Display for CallForexError {
@@ -831,6 +848,9 @@ impl core::fmt::Display for CallForexError {
             }
             CallForexError::Candid { forex, error } => {
                 write!(f, "Failed to encode/decode {forex}: {error}")
+            }
+            CallForexError::Empty { forex } => {
+                write!(f, "Empty rates map from {forex}")
             }
         }
     }
@@ -1707,6 +1727,33 @@ mod test {
             set_labeled_gauge("shared_name", &[("k", "v")], 42.0);
             with_labeled_counters(|m| assert_eq!(m.len(), 1));
             with_labeled_gauges(|m| assert_eq!(m.len(), 1));
+        }
+
+        #[test]
+        fn init_at_seeds_forex_last_success_for_every_source() {
+            reset();
+            let now = 1_700_000_000_u64;
+            init_at(now);
+
+            with_labeled_gauges(|m| {
+                assert_eq!(
+                    m.len(),
+                    FOREX_SOURCES.len(),
+                    "expected one gauge per forex source"
+                );
+                for forex in FOREX_SOURCES {
+                    let name = forex.to_string();
+                    let key = make_metric_key(
+                        "xrc_forex_last_success_seconds",
+                        &[("forex", name.as_str())],
+                    );
+                    assert_eq!(
+                        m.get(&key).copied(),
+                        Some(now as f64),
+                        "missing or wrong-valued gauge for {name}"
+                    );
+                }
+            });
         }
     }
 }

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -168,8 +168,8 @@ thread_local! {
     /// by `(metric_name, labels)`, which is what the scrape path wants
     /// anyway — and groups all series of the same metric name contiguously.
     /// O(log N) inserts are immaterial at this cardinality (≤ a few hundred).
-    static LABELED_COUNTERS: RefCell<BTreeMap<MetricKey, u64>> = RefCell::new(BTreeMap::new());
-    static LABELED_GAUGES: RefCell<BTreeMap<MetricKey, f64>> = RefCell::new(BTreeMap::new());
+    static LABELED_COUNTERS: RefCell<BTreeMap<MetricKey, u64>> = const { RefCell::new(BTreeMap::new()) };
+    static LABELED_GAUGES: RefCell<BTreeMap<MetricKey, f64>> = const { RefCell::new(BTreeMap::new()) };
 }
 
 /// Clears both labeled-metrics maps. Tests in sibling modules call this

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -163,8 +163,17 @@ thread_local! {
     /// Per-(metric-name, label-set) labeled metrics. Populated by recording
     /// sites via [`increment_labeled_counter`] and [`set_labeled_gauge`],
     /// drained by [`api::metrics::get_metrics`]. Reset on canister upgrade.
-    pub(crate) static LABELED_COUNTERS: RefCell<HashMap<MetricKey, u64>> = RefCell::new(HashMap::new());
-    pub(crate) static LABELED_GAUGES: RefCell<HashMap<MetricKey, f64>> = RefCell::new(HashMap::new());
+    static LABELED_COUNTERS: RefCell<HashMap<MetricKey, u64>> = RefCell::new(HashMap::new());
+    static LABELED_GAUGES: RefCell<HashMap<MetricKey, f64>> = RefCell::new(HashMap::new());
+}
+
+/// Clears both labeled-metrics maps. Tests in sibling modules call this
+/// to start from a known empty state; production code has no business
+/// reaching past `increment_labeled_counter` / `set_labeled_gauge`.
+#[cfg(test)]
+pub(crate) fn reset_labeled_metrics_for_test() {
+    LABELED_COUNTERS.with(|m| m.borrow_mut().clear());
+    LABELED_GAUGES.with(|m| m.borrow_mut().clear());
 }
 
 /// A sorted list of `(label_name, label_value)` pairs. Label names are
@@ -1672,8 +1681,7 @@ mod test {
         use super::super::*;
 
         fn reset() {
-            LABELED_COUNTERS.with(|m| m.borrow_mut().clear());
-            LABELED_GAUGES.with(|m| m.borrow_mut().clear());
+            reset_labeled_metrics_for_test();
         }
 
         #[test]

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -163,8 +163,8 @@ thread_local! {
     /// Per-(metric-name, label-set) labeled metrics. Populated by recording
     /// sites via [`increment_labeled_counter`] and [`set_labeled_gauge`],
     /// drained by [`api::metrics::get_metrics`]. Reset on canister upgrade.
-    static LABELED_COUNTERS: RefCell<HashMap<MetricKey, u64>> = RefCell::new(HashMap::new());
-    static LABELED_GAUGES: RefCell<HashMap<MetricKey, f64>> = RefCell::new(HashMap::new());
+    pub(crate) static LABELED_COUNTERS: RefCell<HashMap<MetricKey, u64>> = RefCell::new(HashMap::new());
+    pub(crate) static LABELED_GAUGES: RefCell<HashMap<MetricKey, f64>> = RefCell::new(HashMap::new());
 }
 
 /// A sorted list of `(label_name, label_value)` pairs. Label names are

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -39,6 +39,7 @@ use crate::{
 };
 
 use std::cmp::{max, min};
+use std::collections::HashMap;
 use std::{
     cell::{Cell, RefCell},
     mem::{size_of, size_of_val},
@@ -159,6 +160,75 @@ thread_local! {
     static CRYPTO_ASSET_RELATED_ERRORS_COUNTER: Cell<usize> = const { Cell::new(0) };
     static FOREX_ASSET_RELATED_ERRORS_COUNTER: Cell<usize> = const { Cell::new(0) };
 
+    /// Per-(metric-name, label-set) labeled metrics. Populated by recording
+    /// sites via [`increment_labeled_counter`] and [`set_labeled_gauge`],
+    /// drained by [`api::metrics::get_metrics`]. Reset on canister upgrade.
+    static LABELED_COUNTERS: RefCell<HashMap<MetricKey, u64>> = RefCell::new(HashMap::new());
+    static LABELED_GAUGES: RefCell<HashMap<MetricKey, f64>> = RefCell::new(HashMap::new());
+}
+
+/// A sorted list of `(label_name, label_value)` pairs. Label names are
+/// always `&'static str` (defined at recording sites); label values are
+/// `String` because some — like exchange/forex names from `Display` —
+/// aren't `&'static`. Recording sites should still source label values
+/// from closed enums or constants, never from caller input.
+type LabelPairs = Vec<(&'static str, String)>;
+
+/// The hash/equality key for [`LABELED_COUNTERS`] and [`LABELED_GAUGES`].
+/// Labels are sorted by name in [`make_metric_key`] so the order in which
+/// a call site lists them does not affect identity.
+type MetricKey = (&'static str, LabelPairs);
+
+fn make_metric_key(name: &'static str, labels: &[(&'static str, &str)]) -> MetricKey {
+    let mut pairs: LabelPairs = labels.iter().map(|(k, v)| (*k, v.to_string())).collect();
+    pairs.sort_by_key(|(k, _)| *k);
+    (name, pairs)
+}
+
+#[allow(dead_code)]
+pub(crate) fn increment_labeled_counter(name: &'static str, labels: &[(&'static str, &str)]) {
+    LABELED_COUNTERS.with(|m| {
+        let mut m = m.borrow_mut();
+        let entry = m.entry(make_metric_key(name, labels)).or_insert(0);
+        *entry = entry.saturating_add(1);
+    });
+}
+
+#[allow(dead_code)]
+pub(crate) fn set_labeled_gauge(
+    name: &'static str,
+    labels: &[(&'static str, &str)],
+    value: f64,
+) {
+    LABELED_GAUGES.with(|m| {
+        m.borrow_mut().insert(make_metric_key(name, labels), value);
+    });
+}
+
+#[allow(dead_code)]
+pub(crate) fn with_labeled_counters<F, R>(f: F) -> R
+where
+    F: FnOnce(&HashMap<MetricKey, u64>) -> R,
+{
+    LABELED_COUNTERS.with(|m| f(&m.borrow()))
+}
+
+#[allow(dead_code)]
+pub(crate) fn with_labeled_gauges<F, R>(f: F) -> R
+where
+    F: FnOnce(&HashMap<MetricKey, f64>) -> R,
+{
+    LABELED_GAUGES.with(|m| f(&m.borrow()))
+}
+
+/// Initializes ephemeral state that does not survive a canister upgrade.
+/// Called from the `#[ic_cdk::init]` hook and from [`post_upgrade`] after
+/// stable state is restored. Follow-up commits will populate the body
+/// with `set_labeled_gauge` calls that seed each `*_last_success_seconds`
+/// gauge to the current time, so a freshly-deployed canister doesn't
+/// immediately page on a staleness alert.
+pub fn init() {
+    // Intentionally empty until the first labeled gauge lands.
 }
 
 /// Used to retrieve or increment the various metric counters in the state.
@@ -803,7 +873,8 @@ pub fn pre_upgrade() {
         .expect("Saving state must succeed.")
 }
 
-/// Deserializes the state from stable memory and sets the canister state.
+/// Deserializes the state from stable memory and sets the canister state,
+/// then re-initializes ephemeral state via [`init`].
 pub fn post_upgrade() {
     let store = ic_cdk::storage::stable_restore::<(ForexRateStore,)>()
         .expect("Failed to read from stable memory.")
@@ -811,6 +882,7 @@ pub fn post_upgrade() {
     FOREX_RATE_STORE.with(|cell| {
         *cell.borrow_mut() = store;
     });
+    init();
 }
 
 /// Called by the canister's heartbeat so periodic tasks can be executed.
@@ -1573,5 +1645,68 @@ mod test {
             (rate / btc_usd_exchange_rate).validate(),
             Err(ExchangeRateError::Other(OtherError { code, description })) if code == INVALID_RATE_ERROR_CODE && description == INVALID_RATE_ERROR_MESSAGE
         ));
+    }
+
+    mod labeled_metrics {
+        use super::super::*;
+
+        fn reset() {
+            LABELED_COUNTERS.with(|m| m.borrow_mut().clear());
+            LABELED_GAUGES.with(|m| m.borrow_mut().clear());
+        }
+
+        #[test]
+        fn increment_creates_then_increases() {
+            reset();
+            increment_labeled_counter("metric", &[("exchange", "Mexc")]);
+            increment_labeled_counter("metric", &[("exchange", "Mexc")]);
+            increment_labeled_counter("metric", &[("exchange", "Mexc")]);
+            with_labeled_counters(|m| {
+                let key = make_metric_key("metric", &[("exchange", "Mexc")]);
+                assert_eq!(m.get(&key).copied(), Some(3));
+            });
+        }
+
+        #[test]
+        fn different_labels_are_distinct_keys() {
+            reset();
+            increment_labeled_counter("metric", &[("exchange", "Mexc")]);
+            increment_labeled_counter("metric", &[("exchange", "Coinbase")]);
+            with_labeled_counters(|m| {
+                assert_eq!(m.len(), 2);
+            });
+        }
+
+        #[test]
+        fn labels_are_order_independent() {
+            reset();
+            increment_labeled_counter("metric", &[("a", "1"), ("b", "2")]);
+            increment_labeled_counter("metric", &[("b", "2"), ("a", "1")]);
+            with_labeled_counters(|m| {
+                assert_eq!(m.len(), 1, "label order should not create distinct keys");
+                let only = m.values().next().copied().unwrap();
+                assert_eq!(only, 2);
+            });
+        }
+
+        #[test]
+        fn set_gauge_overwrites() {
+            reset();
+            set_labeled_gauge("g", &[("k", "v")], 1.0);
+            set_labeled_gauge("g", &[("k", "v")], 7.5);
+            with_labeled_gauges(|m| {
+                let key = make_metric_key("g", &[("k", "v")]);
+                assert_eq!(m.get(&key).copied(), Some(7.5));
+            });
+        }
+
+        #[test]
+        fn counters_and_gauges_are_independent() {
+            reset();
+            increment_labeled_counter("shared_name", &[("k", "v")]);
+            set_labeled_gauge("shared_name", &[("k", "v")], 42.0);
+            with_labeled_counters(|m| assert_eq!(m.len(), 1));
+            with_labeled_gauges(|m| assert_eq!(m.len(), 1));
+        }
     }
 }

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -1806,6 +1806,7 @@ mod test {
         }
 
         #[test]
+        #[cfg(debug_assertions)]
         #[should_panic(expected = "duplicate label key")]
         fn duplicate_label_key_panics_in_debug() {
             // A labelled Prometheus series must have unique label names.

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -181,6 +181,18 @@ pub(crate) fn reset_labeled_metrics_for_test() {
     LABELED_GAUGES.with(|m| m.borrow_mut().clear());
 }
 
+/// Names of all labeled metrics. Centralised so that the recording site
+/// (e.g. `periodic.rs`), the encoder (`api/metrics.rs`), and the init
+/// seeding can never drift out of sync via typos — a typo at one site
+/// would silently produce a "recorded but never emitted" (or vice versa)
+/// split-brain metric. Every new labeled metric introduced by a follow-up
+/// PR should land its name here first.
+pub(crate) mod metric_names {
+    pub const FOREX_FETCH_TOTAL: &str = "xrc_forex_fetch_total";
+    pub const FOREX_LAST_SUCCESS_SECONDS: &str = "xrc_forex_last_success_seconds";
+    pub const PERIODIC_FOREX_RUN_LAST_SECONDS: &str = "xrc_periodic_forex_run_last_seconds";
+}
+
 /// A sorted list of `(label_name, label_value)` pairs. Label names are
 /// always `&'static str` (defined at recording sites); label values are
 /// `String` because some — like exchange/forex names from `Display` —
@@ -248,12 +260,12 @@ fn init_at(now_secs: u64) {
     for forex in FOREX_SOURCES {
         let name = forex.to_string();
         set_labeled_gauge(
-            "xrc_forex_last_success_seconds",
+            metric_names::FOREX_LAST_SUCCESS_SECONDS,
             &[("forex", name.as_str())],
             now,
         );
     }
-    set_labeled_gauge("xrc_periodic_forex_run_last_seconds", &[], now);
+    set_labeled_gauge(metric_names::PERIODIC_FOREX_RUN_LAST_SECONDS, &[], now);
 }
 
 /// Used to retrieve or increment the various metric counters in the state.
@@ -1758,7 +1770,7 @@ mod test {
                 for forex in FOREX_SOURCES {
                     let name = forex.to_string();
                     let key = make_metric_key(
-                        "xrc_forex_last_success_seconds",
+                        metric_names::FOREX_LAST_SUCCESS_SECONDS,
                         &[("forex", name.as_str())],
                     );
                     assert_eq!(
@@ -1777,7 +1789,7 @@ mod test {
             init_at(now);
 
             with_labeled_gauges(|m| {
-                let key = make_metric_key("xrc_periodic_forex_run_last_seconds", &[]);
+                let key = make_metric_key(metric_names::PERIODIC_FOREX_RUN_LAST_SECONDS, &[]);
                 assert_eq!(m.get(&key).copied(), Some(now as f64));
             });
         }

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -228,6 +228,12 @@ pub(crate) fn make_metric_key(
 ) -> MetricKey {
     let mut pairs: LabelPairs = labels.iter().map(|(k, v)| (*k, v.to_string())).collect();
     pairs.sort_by_key(|(k, _)| *k);
+    debug_assert!(
+        pairs.windows(2).all(|w| w[0].0 != w[1].0),
+        "metric {name:?} passed duplicate label key in {labels:?}; \
+         a labelled series must have unique label names per the Prometheus \
+         exposition format"
+    );
     (name, pairs)
 }
 
@@ -1797,6 +1803,16 @@ mod test {
                     );
                 }
             });
+        }
+
+        #[test]
+        #[should_panic(expected = "duplicate label key")]
+        fn duplicate_label_key_panics_in_debug() {
+            // A labelled Prometheus series must have unique label names.
+            // Passing the same key twice (e.g. via a copy-paste mistake)
+            // would silently emit invalid output; `make_metric_key`
+            // catches it under `cargo test` instead.
+            let _ = make_metric_key("metric", &[("forex", "Mexc"), ("forex", "Coinbase")]);
         }
 
         #[test]

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -181,50 +181,50 @@ pub(crate) fn reset_labeled_metrics_for_test() {
     LABELED_GAUGES.with(|m| m.borrow_mut().clear());
 }
 
-/// Names of all labeled metrics. Centralised so that the recording site
-/// (e.g. `periodic.rs`), the encoder (`api/metrics.rs`), and the init
-/// seeding can never drift out of sync via typos — a typo at one site
-/// would silently produce a "recorded but never emitted" (or vice versa)
-/// split-brain metric. Every new labeled metric introduced by a follow-up
-/// PR should land its name here first.
-pub(crate) mod metric_names {
-    pub const FOREX_FETCH_TOTAL: &str = "xrc_forex_fetch_total";
-    pub const FOREX_LAST_SUCCESS_SECONDS: &str = "xrc_forex_last_success_seconds";
-    pub const PERIODIC_FOREX_RUN_LAST_SECONDS: &str = "xrc_periodic_forex_run_last_seconds";
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, strum::IntoStaticStr)]
+pub(crate) enum MetricName {
+    #[strum(serialize = "xrc_forex_fetch_total")]
+    ForexFetchTotal,
+    #[strum(serialize = "xrc_forex_last_success_seconds")]
+    ForexLastSuccessSeconds,
+    #[strum(serialize = "xrc_periodic_forex_run_last_seconds")]
+    PeriodicForexRunLastSeconds,
 }
 
-/// Label keys and the closed set of label values used by labeled metrics.
-/// Recording sites reference these constants instead of free string
-/// literals, so the cardinality of any label can be audited by reading
-/// this module — and a typo at a recording site is a compile error
-/// rather than a phantom new series.
-pub(crate) mod metric_labels {
-    // Label keys
-    pub const FOREX: &str = "forex";
-    pub const OUTCOME: &str = "outcome";
-
-    // Closed set of `outcome` values for `xrc_forex_fetch_total`.
-    pub const SUCCESS: &str = "success";
-    pub const HTTP_ERROR: &str = "http_error";
-    pub const CANDID_ERROR: &str = "candid_error";
-    pub const EMPTY_MAP: &str = "empty_map";
+/// Declaration order is load-bearing: [`make_metric_key`] sorts label
+/// pairs by `LabelKey`, and keeping `Forex < Outcome` (matching what
+/// `&str` sort of `"forex" < "outcome"` would produce) preserves the
+/// byte-exact `/metrics` output.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, strum::IntoStaticStr)]
+pub(crate) enum LabelKey {
+    #[strum(serialize = "forex")]
+    Forex,
+    #[strum(serialize = "outcome")]
+    Outcome,
 }
 
-/// A sorted list of `(label_name, label_value)` pairs. Label names are
-/// always `&'static str` (defined at recording sites); label values are
-/// `String` because some — like exchange/forex names from `Display` —
-/// aren't `&'static`. Recording sites should still source label values
-/// from closed enums or constants, never from caller input.
-pub(crate) type LabelPairs = Vec<(&'static str, String)>;
+#[derive(Copy, Clone, Debug, PartialEq, Eq, strum::IntoStaticStr)]
+pub(crate) enum Outcome {
+    #[strum(serialize = "success")]
+    Success,
+    #[strum(serialize = "http_error")]
+    HttpError,
+    #[strum(serialize = "candid_error")]
+    CandidError,
+    #[strum(serialize = "empty_map")]
+    EmptyMap,
+}
 
-/// The ordering/equality key for [`LABELED_COUNTERS`] and [`LABELED_GAUGES`].
-/// Labels are sorted by name in [`make_metric_key`] so the order in which
-/// a call site lists them does not affect identity.
-pub(crate) type MetricKey = (&'static str, LabelPairs);
+/// Value is `String` because some labels are open-set (forex source
+/// names from `Display`); the closed-set ones still funnel through
+/// `IntoStaticStr` at the recording site.
+pub(crate) type LabelPairs = Vec<(LabelKey, String)>;
+
+pub(crate) type MetricKey = (MetricName, LabelPairs);
 
 pub(crate) fn make_metric_key(
-    name: &'static str,
-    labels: &[(&'static str, &str)],
+    name: MetricName,
+    labels: &[(LabelKey, &str)],
 ) -> MetricKey {
     let mut pairs: LabelPairs = labels.iter().map(|(k, v)| (*k, v.to_string())).collect();
     pairs.sort_by_key(|(k, _)| *k);
@@ -237,7 +237,7 @@ pub(crate) fn make_metric_key(
     (name, pairs)
 }
 
-pub(crate) fn increment_labeled_counter(name: &'static str, labels: &[(&'static str, &str)]) {
+pub(crate) fn increment_labeled_counter(name: MetricName, labels: &[(LabelKey, &str)]) {
     LABELED_COUNTERS.with(|m| {
         let mut m = m.borrow_mut();
         let entry = m.entry(make_metric_key(name, labels)).or_insert(0);
@@ -245,11 +245,7 @@ pub(crate) fn increment_labeled_counter(name: &'static str, labels: &[(&'static 
     });
 }
 
-pub(crate) fn set_labeled_gauge(
-    name: &'static str,
-    labels: &[(&'static str, &str)],
-    value: f64,
-) {
+pub(crate) fn set_labeled_gauge(name: MetricName, labels: &[(LabelKey, &str)], value: f64) {
     LABELED_GAUGES.with(|m| {
         m.borrow_mut().insert(make_metric_key(name, labels), value);
     });
@@ -283,12 +279,12 @@ fn init_at(now_secs: u64) {
     for forex in FOREX_SOURCES {
         let name = forex.to_string();
         set_labeled_gauge(
-            metric_names::FOREX_LAST_SUCCESS_SECONDS,
-            &[(metric_labels::FOREX, name.as_str())],
+            MetricName::ForexLastSuccessSeconds,
+            &[(LabelKey::Forex, name.as_str())],
             now,
         );
     }
-    set_labeled_gauge(metric_names::PERIODIC_FOREX_RUN_LAST_SECONDS, &[], now);
+    set_labeled_gauge(MetricName::PeriodicForexRunLastSeconds, &[], now);
 }
 
 /// Used to retrieve or increment the various metric counters in the state.
@@ -1727,11 +1723,23 @@ mod test {
         #[test]
         fn increment_creates_then_increases() {
             reset();
-            increment_labeled_counter("metric", &[("exchange", "Mexc")]);
-            increment_labeled_counter("metric", &[("exchange", "Mexc")]);
-            increment_labeled_counter("metric", &[("exchange", "Mexc")]);
+            increment_labeled_counter(
+                MetricName::ForexFetchTotal,
+                &[(LabelKey::Forex, "EuropeanCentralBank")],
+            );
+            increment_labeled_counter(
+                MetricName::ForexFetchTotal,
+                &[(LabelKey::Forex, "EuropeanCentralBank")],
+            );
+            increment_labeled_counter(
+                MetricName::ForexFetchTotal,
+                &[(LabelKey::Forex, "EuropeanCentralBank")],
+            );
             with_labeled_counters(|m| {
-                let key = make_metric_key("metric", &[("exchange", "Mexc")]);
+                let key = make_metric_key(
+                    MetricName::ForexFetchTotal,
+                    &[(LabelKey::Forex, "EuropeanCentralBank")],
+                );
                 assert_eq!(m.get(&key).copied(), Some(3));
             });
         }
@@ -1739,8 +1747,14 @@ mod test {
         #[test]
         fn different_labels_are_distinct_keys() {
             reset();
-            increment_labeled_counter("metric", &[("exchange", "Mexc")]);
-            increment_labeled_counter("metric", &[("exchange", "Coinbase")]);
+            increment_labeled_counter(
+                MetricName::ForexFetchTotal,
+                &[(LabelKey::Forex, "EuropeanCentralBank")],
+            );
+            increment_labeled_counter(
+                MetricName::ForexFetchTotal,
+                &[(LabelKey::Forex, "BankOfCanada")],
+            );
             with_labeled_counters(|m| {
                 assert_eq!(m.len(), 2);
             });
@@ -1749,8 +1763,20 @@ mod test {
         #[test]
         fn labels_are_order_independent() {
             reset();
-            increment_labeled_counter("metric", &[("a", "1"), ("b", "2")]);
-            increment_labeled_counter("metric", &[("b", "2"), ("a", "1")]);
+            increment_labeled_counter(
+                MetricName::ForexFetchTotal,
+                &[
+                    (LabelKey::Forex, "EuropeanCentralBank"),
+                    (LabelKey::Outcome, "success"),
+                ],
+            );
+            increment_labeled_counter(
+                MetricName::ForexFetchTotal,
+                &[
+                    (LabelKey::Outcome, "success"),
+                    (LabelKey::Forex, "EuropeanCentralBank"),
+                ],
+            );
             with_labeled_counters(|m| {
                 assert_eq!(m.len(), 1, "label order should not create distinct keys");
                 let only = m.values().next().copied().unwrap();
@@ -1761,10 +1787,21 @@ mod test {
         #[test]
         fn set_gauge_overwrites() {
             reset();
-            set_labeled_gauge("g", &[("k", "v")], 1.0);
-            set_labeled_gauge("g", &[("k", "v")], 7.5);
+            set_labeled_gauge(
+                MetricName::ForexLastSuccessSeconds,
+                &[(LabelKey::Forex, "EuropeanCentralBank")],
+                1.0,
+            );
+            set_labeled_gauge(
+                MetricName::ForexLastSuccessSeconds,
+                &[(LabelKey::Forex, "EuropeanCentralBank")],
+                7.5,
+            );
             with_labeled_gauges(|m| {
-                let key = make_metric_key("g", &[("k", "v")]);
+                let key = make_metric_key(
+                    MetricName::ForexLastSuccessSeconds,
+                    &[(LabelKey::Forex, "EuropeanCentralBank")],
+                );
                 assert_eq!(m.get(&key).copied(), Some(7.5));
             });
         }
@@ -1772,8 +1809,15 @@ mod test {
         #[test]
         fn counters_and_gauges_are_independent() {
             reset();
-            increment_labeled_counter("shared_name", &[("k", "v")]);
-            set_labeled_gauge("shared_name", &[("k", "v")], 42.0);
+            increment_labeled_counter(
+                MetricName::ForexFetchTotal,
+                &[(LabelKey::Forex, "EuropeanCentralBank")],
+            );
+            set_labeled_gauge(
+                MetricName::ForexFetchTotal,
+                &[(LabelKey::Forex, "EuropeanCentralBank")],
+                42.0,
+            );
             with_labeled_counters(|m| assert_eq!(m.len(), 1));
             with_labeled_gauges(|m| assert_eq!(m.len(), 1));
         }
@@ -1793,8 +1837,8 @@ mod test {
                 for forex in FOREX_SOURCES {
                     let name = forex.to_string();
                     let key = make_metric_key(
-                        metric_names::FOREX_LAST_SUCCESS_SECONDS,
-                        &[(metric_labels::FOREX, name.as_str())],
+                        MetricName::ForexLastSuccessSeconds,
+                        &[(LabelKey::Forex, name.as_str())],
                     );
                     assert_eq!(
                         m.get(&key).copied(),
@@ -1813,7 +1857,13 @@ mod test {
             // Passing the same key twice (e.g. via a copy-paste mistake)
             // would silently emit invalid output; `make_metric_key`
             // catches it under `cargo test` instead.
-            let _ = make_metric_key("metric", &[("forex", "Mexc"), ("forex", "Coinbase")]);
+            let _ = make_metric_key(
+                MetricName::ForexFetchTotal,
+                &[
+                    (LabelKey::Forex, "EuropeanCentralBank"),
+                    (LabelKey::Forex, "BankOfCanada"),
+                ],
+            );
         }
 
         #[test]
@@ -1823,7 +1873,7 @@ mod test {
             init_at(now);
 
             with_labeled_gauges(|m| {
-                let key = make_metric_key(metric_names::PERIODIC_FOREX_RUN_LAST_SECONDS, &[]);
+                let key = make_metric_key(MetricName::PeriodicForexRunLastSeconds, &[]);
                 assert_eq!(m.get(&key).copied(), Some(now as f64));
             });
         }

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -239,6 +239,7 @@ fn init_at(now_secs: u64) {
             now,
         );
     }
+    set_labeled_gauge("xrc_periodic_forex_run_last_seconds", &[], now);
 }
 
 /// Used to retrieve or increment the various metric counters in the state.
@@ -1738,8 +1739,8 @@ mod test {
             with_labeled_gauges(|m| {
                 assert_eq!(
                     m.len(),
-                    FOREX_SOURCES.len(),
-                    "expected one gauge per forex source"
+                    FOREX_SOURCES.len() + 1,
+                    "expected one gauge per forex source plus the heartbeat gauge"
                 );
                 for forex in FOREX_SOURCES {
                     let name = forex.to_string();
@@ -1753,6 +1754,18 @@ mod test {
                         "missing or wrong-valued gauge for {name}"
                     );
                 }
+            });
+        }
+
+        #[test]
+        fn init_at_seeds_periodic_forex_run_heartbeat() {
+            reset();
+            let now = 1_700_000_000_u64;
+            init_at(now);
+
+            with_labeled_gauges(|m| {
+                let key = make_metric_key("xrc_periodic_forex_run_last_seconds", &[]);
+                assert_eq!(m.get(&key).copied(), Some(now as f64));
             });
         }
     }

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -270,7 +270,7 @@ where
 /// stable state is restored. Seeds every `*_last_success_seconds` gauge
 /// to the current time so a freshly-deployed canister doesn't immediately
 /// trip a staleness alert.
-pub fn init() {
+pub fn init_metrics() {
     init_at(utils::time_secs());
 }
 
@@ -940,7 +940,7 @@ pub fn pre_upgrade() {
 }
 
 /// Deserializes the state from stable memory and sets the canister state,
-/// then re-initializes ephemeral state via [`init`].
+/// then re-initializes ephemeral state via [`init_metrics`].
 pub fn post_upgrade() {
     let store = ic_cdk::storage::stable_restore::<(ForexRateStore,)>()
         .expect("Failed to read from stable memory.")
@@ -948,7 +948,7 @@ pub fn post_upgrade() {
     FOREX_RATE_STORE.with(|cell| {
         *cell.borrow_mut() = store;
     });
-    init();
+    init_metrics();
 }
 
 /// Called by the canister's heartbeat so periodic tasks can be executed.

--- a/src/xrc/src/main.rs
+++ b/src/xrc/src/main.rs
@@ -22,6 +22,11 @@ fn transform_forex_http_response(args: TransformArgs) -> HttpResponse {
     xrc::transform_forex_http_response(args)
 }
 
+#[ic_cdk::init]
+fn init() {
+    xrc::init();
+}
+
 #[ic_cdk::pre_upgrade]
 fn pre_upgrade() {
     xrc::pre_upgrade();

--- a/src/xrc/src/main.rs
+++ b/src/xrc/src/main.rs
@@ -24,7 +24,7 @@ fn transform_forex_http_response(args: TransformArgs) -> HttpResponse {
 
 #[ic_cdk::init]
 fn init() {
-    xrc::init();
+    xrc::init_metrics();
 }
 
 #[ic_cdk::pre_upgrade]

--- a/src/xrc/src/periodic.rs
+++ b/src/xrc/src/periodic.rs
@@ -7,8 +7,9 @@ use futures::future::join_all;
 use crate::{
     call_forex,
     forex::{Forex, ForexContextArgs, ForexRateMap, FOREX_SOURCES},
-    with_forex_rate_collector, with_forex_rate_collector_mut, with_forex_rate_store_mut,
-    CallForexError, LOG_PREFIX, ONE_DAY_SECONDS, ONE_HOUR_SECONDS, USD,
+    increment_labeled_counter, set_labeled_gauge, with_forex_rate_collector,
+    with_forex_rate_collector_mut, with_forex_rate_store_mut, CallForexError, LOG_PREFIX,
+    ONE_DAY_SECONDS, ONE_HOUR_SECONDS, USD,
 };
 
 thread_local! {
@@ -93,9 +94,8 @@ impl ForexSources for ForexSourcesImpl {
                     if map.is_empty() {
                         errors.push((
                             forex.to_string(),
-                            CallForexError::Http {
+                            CallForexError::Empty {
                                 forex: forex.to_string(),
-                                error: "Empty rates map".to_string(),
                             },
                         ))
                     } else {
@@ -204,7 +204,10 @@ async fn update_forex_store(
 
     let start_of_day = start_of_day_timestamp(timestamp);
     let (forex_rates, errors) = forex_sources.call(start_of_day).await;
-    for (forex, error) in errors {
+
+    record_per_forex_metrics(timestamp, &forex_rates, &errors);
+
+    for (forex, error) in &errors {
         ic_cdk::println!("{} {} {}", LOG_PREFIX, forex, error);
     }
 
@@ -233,6 +236,35 @@ async fn update_forex_store(
 
 fn start_of_day_timestamp(timestamp: u64) -> u64 {
     timestamp - (timestamp % ONE_DAY_SECONDS)
+}
+
+fn record_per_forex_metrics(
+    now_secs: u64,
+    forex_rates: &[(String, u64, ForexRateMap)],
+    errors: &[(String, CallForexError)],
+) {
+    for (forex, _, _) in forex_rates {
+        increment_labeled_counter(
+            "xrc_forex_fetch_total",
+            &[("forex", forex.as_str()), ("outcome", "success")],
+        );
+        set_labeled_gauge(
+            "xrc_forex_last_success_seconds",
+            &[("forex", forex.as_str())],
+            now_secs as f64,
+        );
+    }
+    for (forex, error) in errors {
+        let outcome = match error {
+            CallForexError::Empty { .. } => "empty_map",
+            CallForexError::Http { .. } => "http_error",
+            CallForexError::Candid { .. } => "candid_error",
+        };
+        increment_labeled_counter(
+            "xrc_forex_fetch_total",
+            &[("forex", forex.as_str()), ("outcome", outcome)],
+        );
+    }
 }
 
 fn get_next_run_timestamp(timestamp: u64) -> u64 {
@@ -571,5 +603,112 @@ mod test {
             forexes_with_timestamps_and_context[9].2.timestamp,
             1680134400
         );
+    }
+
+    mod per_forex_metrics {
+        use super::*;
+        use crate::{make_metric_key, with_labeled_counters, with_labeled_gauges};
+
+        #[test]
+        fn success_increments_counter_and_sets_last_success() {
+            let now = 1_700_000_000_u64;
+            let rates = vec![(
+                "EuropeanCentralBank".to_string(),
+                123,
+                btreemap! { "EUR".to_string() => 10_000 },
+            )];
+            record_per_forex_metrics(now, &rates, &[]);
+
+            with_labeled_counters(|m| {
+                let key = make_metric_key(
+                    "xrc_forex_fetch_total",
+                    &[("forex", "EuropeanCentralBank"), ("outcome", "success")],
+                );
+                assert_eq!(m.get(&key).copied(), Some(1));
+            });
+            with_labeled_gauges(|m| {
+                let key = make_metric_key(
+                    "xrc_forex_last_success_seconds",
+                    &[("forex", "EuropeanCentralBank")],
+                );
+                assert_eq!(m.get(&key).copied(), Some(now as f64));
+            });
+        }
+
+        #[test]
+        fn empty_map_error_is_recorded_as_empty_map_outcome() {
+            let errors = vec![(
+                "BankOfCanada".to_string(),
+                CallForexError::Empty {
+                    forex: "BankOfCanada".to_string(),
+                },
+            )];
+            record_per_forex_metrics(0, &[], &errors);
+
+            with_labeled_counters(|m| {
+                let key = make_metric_key(
+                    "xrc_forex_fetch_total",
+                    &[("forex", "BankOfCanada"), ("outcome", "empty_map")],
+                );
+                assert_eq!(m.get(&key).copied(), Some(1));
+            });
+        }
+
+        #[test]
+        fn http_and_candid_errors_have_distinct_outcomes() {
+            let errors = vec![
+                (
+                    "BankOfItaly".to_string(),
+                    CallForexError::Http {
+                        forex: "BankOfItaly".to_string(),
+                        error: "boom".to_string(),
+                    },
+                ),
+                (
+                    "CentralBankOfTurkey".to_string(),
+                    CallForexError::Candid {
+                        forex: "CentralBankOfTurkey".to_string(),
+                        error: "nope".to_string(),
+                    },
+                ),
+            ];
+            record_per_forex_metrics(0, &[], &errors);
+
+            with_labeled_counters(|m| {
+                let http_key = make_metric_key(
+                    "xrc_forex_fetch_total",
+                    &[("forex", "BankOfItaly"), ("outcome", "http_error")],
+                );
+                let candid_key = make_metric_key(
+                    "xrc_forex_fetch_total",
+                    &[("forex", "CentralBankOfTurkey"), ("outcome", "candid_error")],
+                );
+                assert_eq!(m.get(&http_key).copied(), Some(1));
+                assert_eq!(m.get(&candid_key).copied(), Some(1));
+            });
+        }
+
+        #[test]
+        fn failure_does_not_advance_last_success_gauge() {
+            let errors = vec![(
+                "ReserveBankOfAustralia".to_string(),
+                CallForexError::Http {
+                    forex: "ReserveBankOfAustralia".to_string(),
+                    error: "boom".to_string(),
+                },
+            )];
+            record_per_forex_metrics(42, &[], &errors);
+
+            with_labeled_gauges(|m| {
+                let key = make_metric_key(
+                    "xrc_forex_last_success_seconds",
+                    &[("forex", "ReserveBankOfAustralia")],
+                );
+                assert!(
+                    m.get(&key).is_none(),
+                    "last_success gauge should not be set by a failure"
+                );
+            });
+        }
     }
 }

--- a/src/xrc/src/periodic.rs
+++ b/src/xrc/src/periodic.rs
@@ -613,11 +613,13 @@ mod test {
 
     mod per_forex_metrics {
         use super::*;
-        use crate::{make_metric_key, with_labeled_counters, with_labeled_gauges};
+        use crate::{
+            make_metric_key, reset_labeled_metrics_for_test, with_labeled_counters,
+            with_labeled_gauges,
+        };
 
         fn reset() {
-            crate::LABELED_COUNTERS.with(|m| m.borrow_mut().clear());
-            crate::LABELED_GAUGES.with(|m| m.borrow_mut().clear());
+            reset_labeled_metrics_for_test();
         }
 
         #[test]

--- a/src/xrc/src/periodic.rs
+++ b/src/xrc/src/periodic.rs
@@ -326,6 +326,7 @@ mod test {
     /// This function demonstrates that the forex rate store can be successfully updated by [update_forex_store].
     #[test]
     fn forex_store_can_be_updated_successfully() {
+        crate::reset_labeled_metrics_for_test();
         let timestamp = 1666371931;
         let start_of_day = start_of_day_timestamp(timestamp);
         let map = btreemap! {
@@ -354,6 +355,7 @@ mod test {
     /// on a six hour interval controlled by the [NEXT_RUN_SCHEDULED_AT_TIMESTAMP] state variable.
     #[test]
     fn forex_store_can_be_updated_on_six_hour_interval() {
+        crate::reset_labeled_metrics_for_test();
         let mock_forex_sources = MockForexSourcesImpl::default();
         set_next_run_scheduled_at_timestamp(1666375200);
 
@@ -705,7 +707,7 @@ mod test {
         }
 
         #[test]
-        fn update_forex_store_success_sets_heartbeat_gauge() {
+        fn update_forex_store_success_sets_heartbeat_and_per_forex_metrics() {
             reset();
             let timestamp = 1_700_000_000;
             let map = btreemap! {
@@ -720,9 +722,21 @@ mod test {
                 .now_or_never()
                 .expect("should execute");
 
+            // Heartbeat gauge is set unconditionally on the Success return path.
             with_labeled_gauges(|m| {
-                let key = make_metric_key("xrc_periodic_forex_run_last_seconds", &[]);
-                assert_eq!(m.get(&key).copied(), Some(timestamp as f64));
+                let heartbeat = make_metric_key("xrc_periodic_forex_run_last_seconds", &[]);
+                assert_eq!(m.get(&heartbeat).copied(), Some(timestamp as f64));
+            });
+
+            // The mock returns four success entries all named "src_name", so the
+            // labeled counter should reflect that update_forex_store routed each
+            // through record_per_forex_metrics.
+            with_labeled_counters(|m| {
+                let success_key = make_metric_key(
+                    "xrc_forex_fetch_total",
+                    &[("forex", "src_name"), ("outcome", "success")],
+                );
+                assert_eq!(m.get(&success_key).copied(), Some(4));
             });
         }
 

--- a/src/xrc/src/periodic.rs
+++ b/src/xrc/src/periodic.rs
@@ -230,6 +230,12 @@ async fn update_forex_store(
         }
     }
 
+    set_labeled_gauge(
+        "xrc_periodic_forex_run_last_seconds",
+        &[],
+        timestamp as f64,
+    );
+
     set_next_run_scheduled_at_timestamp(get_next_run_timestamp(timestamp));
     UpdateForexStoreResult::Success
 }
@@ -685,6 +691,27 @@ mod test {
                 );
                 assert_eq!(m.get(&http_key).copied(), Some(1));
                 assert_eq!(m.get(&candid_key).copied(), Some(1));
+            });
+        }
+
+        #[test]
+        fn update_forex_store_success_sets_heartbeat_gauge() {
+            let timestamp = 1_700_000_000;
+            let map = btreemap! {
+                "EUR".to_string() => 10_000,
+                crate::forex::COMPUTED_XDR_SYMBOL.to_string() => 10_000,
+            };
+            let mock = MockForexSourcesImpl::new(
+                vec![map.clone(), map.clone(), map.clone(), map],
+                vec![],
+            );
+            update_forex_store(timestamp, &mock)
+                .now_or_never()
+                .expect("should execute");
+
+            with_labeled_gauges(|m| {
+                let key = make_metric_key("xrc_periodic_forex_run_last_seconds", &[]);
+                assert_eq!(m.get(&key).copied(), Some(timestamp as f64));
             });
         }
 

--- a/src/xrc/src/periodic.rs
+++ b/src/xrc/src/periodic.rs
@@ -615,8 +615,14 @@ mod test {
         use super::*;
         use crate::{make_metric_key, with_labeled_counters, with_labeled_gauges};
 
+        fn reset() {
+            crate::LABELED_COUNTERS.with(|m| m.borrow_mut().clear());
+            crate::LABELED_GAUGES.with(|m| m.borrow_mut().clear());
+        }
+
         #[test]
         fn success_increments_counter_and_sets_last_success() {
+            reset();
             let now = 1_700_000_000_u64;
             let rates = vec![(
                 "EuropeanCentralBank".to_string(),
@@ -643,6 +649,7 @@ mod test {
 
         #[test]
         fn empty_map_error_is_recorded_as_empty_map_outcome() {
+            reset();
             let errors = vec![(
                 "BankOfCanada".to_string(),
                 CallForexError::Empty {
@@ -662,6 +669,7 @@ mod test {
 
         #[test]
         fn http_and_candid_errors_have_distinct_outcomes() {
+            reset();
             let errors = vec![
                 (
                     "BankOfItaly".to_string(),
@@ -696,6 +704,7 @@ mod test {
 
         #[test]
         fn update_forex_store_success_sets_heartbeat_gauge() {
+            reset();
             let timestamp = 1_700_000_000;
             let map = btreemap! {
                 "EUR".to_string() => 10_000,
@@ -717,6 +726,7 @@ mod test {
 
         #[test]
         fn failure_does_not_advance_last_success_gauge() {
+            reset();
             let errors = vec![(
                 "ReserveBankOfAustralia".to_string(),
                 CallForexError::Http {

--- a/src/xrc/src/periodic.rs
+++ b/src/xrc/src/periodic.rs
@@ -7,9 +7,9 @@ use futures::future::join_all;
 use crate::{
     call_forex,
     forex::{Forex, ForexContextArgs, ForexRateMap, FOREX_SOURCES},
-    increment_labeled_counter, metric_names, set_labeled_gauge, with_forex_rate_collector,
-    with_forex_rate_collector_mut, with_forex_rate_store_mut, CallForexError, LOG_PREFIX,
-    ONE_DAY_SECONDS, ONE_HOUR_SECONDS, USD,
+    increment_labeled_counter, metric_labels, metric_names, set_labeled_gauge,
+    with_forex_rate_collector, with_forex_rate_collector_mut, with_forex_rate_store_mut,
+    CallForexError, LOG_PREFIX, ONE_DAY_SECONDS, ONE_HOUR_SECONDS, USD,
 };
 
 thread_local! {
@@ -252,23 +252,29 @@ fn record_per_forex_metrics(
     for (forex, _, _) in forex_rates {
         increment_labeled_counter(
             metric_names::FOREX_FETCH_TOTAL,
-            &[("forex", forex.as_str()), ("outcome", "success")],
+            &[
+                (metric_labels::FOREX, forex.as_str()),
+                (metric_labels::OUTCOME, metric_labels::SUCCESS),
+            ],
         );
         set_labeled_gauge(
             metric_names::FOREX_LAST_SUCCESS_SECONDS,
-            &[("forex", forex.as_str())],
+            &[(metric_labels::FOREX, forex.as_str())],
             now_secs as f64,
         );
     }
     for (forex, error) in errors {
         let outcome = match error {
-            CallForexError::Empty { .. } => "empty_map",
-            CallForexError::Http { .. } => "http_error",
-            CallForexError::Candid { .. } => "candid_error",
+            CallForexError::Empty { .. } => metric_labels::EMPTY_MAP,
+            CallForexError::Http { .. } => metric_labels::HTTP_ERROR,
+            CallForexError::Candid { .. } => metric_labels::CANDID_ERROR,
         };
         increment_labeled_counter(
             metric_names::FOREX_FETCH_TOTAL,
-            &[("forex", forex.as_str()), ("outcome", outcome)],
+            &[
+                (metric_labels::FOREX, forex.as_str()),
+                (metric_labels::OUTCOME, outcome),
+            ],
         );
     }
 }
@@ -616,8 +622,8 @@ mod test {
     mod per_forex_metrics {
         use super::*;
         use crate::{
-            make_metric_key, metric_names, reset_labeled_metrics_for_test, with_labeled_counters,
-            with_labeled_gauges,
+            make_metric_key, metric_labels, metric_names, reset_labeled_metrics_for_test,
+            with_labeled_counters, with_labeled_gauges,
         };
 
         fn reset() {
@@ -638,14 +644,17 @@ mod test {
             with_labeled_counters(|m| {
                 let key = make_metric_key(
                     metric_names::FOREX_FETCH_TOTAL,
-                    &[("forex", "EuropeanCentralBank"), ("outcome", "success")],
+                    &[
+                        (metric_labels::FOREX, "EuropeanCentralBank"),
+                        (metric_labels::OUTCOME, metric_labels::SUCCESS),
+                    ],
                 );
                 assert_eq!(m.get(&key).copied(), Some(1));
             });
             with_labeled_gauges(|m| {
                 let key = make_metric_key(
                     metric_names::FOREX_LAST_SUCCESS_SECONDS,
-                    &[("forex", "EuropeanCentralBank")],
+                    &[(metric_labels::FOREX, "EuropeanCentralBank")],
                 );
                 assert_eq!(m.get(&key).copied(), Some(now as f64));
             });
@@ -665,7 +674,10 @@ mod test {
             with_labeled_counters(|m| {
                 let key = make_metric_key(
                     metric_names::FOREX_FETCH_TOTAL,
-                    &[("forex", "BankOfCanada"), ("outcome", "empty_map")],
+                    &[
+                        (metric_labels::FOREX, "BankOfCanada"),
+                        (metric_labels::OUTCOME, metric_labels::EMPTY_MAP),
+                    ],
                 );
                 assert_eq!(m.get(&key).copied(), Some(1));
             });
@@ -695,11 +707,17 @@ mod test {
             with_labeled_counters(|m| {
                 let http_key = make_metric_key(
                     metric_names::FOREX_FETCH_TOTAL,
-                    &[("forex", "BankOfItaly"), ("outcome", "http_error")],
+                    &[
+                        (metric_labels::FOREX, "BankOfItaly"),
+                        (metric_labels::OUTCOME, metric_labels::HTTP_ERROR),
+                    ],
                 );
                 let candid_key = make_metric_key(
                     metric_names::FOREX_FETCH_TOTAL,
-                    &[("forex", "CentralBankOfTurkey"), ("outcome", "candid_error")],
+                    &[
+                        (metric_labels::FOREX, "CentralBankOfTurkey"),
+                        (metric_labels::OUTCOME, metric_labels::CANDID_ERROR),
+                    ],
                 );
                 assert_eq!(m.get(&http_key).copied(), Some(1));
                 assert_eq!(m.get(&candid_key).copied(), Some(1));
@@ -735,7 +753,10 @@ mod test {
             with_labeled_counters(|m| {
                 let success_key = make_metric_key(
                     metric_names::FOREX_FETCH_TOTAL,
-                    &[("forex", "src_name"), ("outcome", "success")],
+                    &[
+                        (metric_labels::FOREX, "src_name"),
+                        (metric_labels::OUTCOME, metric_labels::SUCCESS),
+                    ],
                 );
                 assert_eq!(m.get(&success_key).copied(), Some(4));
             });
@@ -756,7 +777,7 @@ mod test {
             with_labeled_gauges(|m| {
                 let key = make_metric_key(
                     metric_names::FOREX_LAST_SUCCESS_SECONDS,
-                    &[("forex", "ReserveBankOfAustralia")],
+                    &[(metric_labels::FOREX, "ReserveBankOfAustralia")],
                 );
                 assert!(
                     m.get(&key).is_none(),

--- a/src/xrc/src/periodic.rs
+++ b/src/xrc/src/periodic.rs
@@ -7,7 +7,7 @@ use futures::future::join_all;
 use crate::{
     call_forex,
     forex::{Forex, ForexContextArgs, ForexRateMap, FOREX_SOURCES},
-    increment_labeled_counter, set_labeled_gauge, with_forex_rate_collector,
+    increment_labeled_counter, metric_names, set_labeled_gauge, with_forex_rate_collector,
     with_forex_rate_collector_mut, with_forex_rate_store_mut, CallForexError, LOG_PREFIX,
     ONE_DAY_SECONDS, ONE_HOUR_SECONDS, USD,
 };
@@ -231,7 +231,7 @@ async fn update_forex_store(
     }
 
     set_labeled_gauge(
-        "xrc_periodic_forex_run_last_seconds",
+        metric_names::PERIODIC_FOREX_RUN_LAST_SECONDS,
         &[],
         timestamp as f64,
     );
@@ -251,11 +251,11 @@ fn record_per_forex_metrics(
 ) {
     for (forex, _, _) in forex_rates {
         increment_labeled_counter(
-            "xrc_forex_fetch_total",
+            metric_names::FOREX_FETCH_TOTAL,
             &[("forex", forex.as_str()), ("outcome", "success")],
         );
         set_labeled_gauge(
-            "xrc_forex_last_success_seconds",
+            metric_names::FOREX_LAST_SUCCESS_SECONDS,
             &[("forex", forex.as_str())],
             now_secs as f64,
         );
@@ -267,7 +267,7 @@ fn record_per_forex_metrics(
             CallForexError::Candid { .. } => "candid_error",
         };
         increment_labeled_counter(
-            "xrc_forex_fetch_total",
+            metric_names::FOREX_FETCH_TOTAL,
             &[("forex", forex.as_str()), ("outcome", outcome)],
         );
     }
@@ -616,7 +616,7 @@ mod test {
     mod per_forex_metrics {
         use super::*;
         use crate::{
-            make_metric_key, reset_labeled_metrics_for_test, with_labeled_counters,
+            make_metric_key, metric_names, reset_labeled_metrics_for_test, with_labeled_counters,
             with_labeled_gauges,
         };
 
@@ -637,14 +637,14 @@ mod test {
 
             with_labeled_counters(|m| {
                 let key = make_metric_key(
-                    "xrc_forex_fetch_total",
+                    metric_names::FOREX_FETCH_TOTAL,
                     &[("forex", "EuropeanCentralBank"), ("outcome", "success")],
                 );
                 assert_eq!(m.get(&key).copied(), Some(1));
             });
             with_labeled_gauges(|m| {
                 let key = make_metric_key(
-                    "xrc_forex_last_success_seconds",
+                    metric_names::FOREX_LAST_SUCCESS_SECONDS,
                     &[("forex", "EuropeanCentralBank")],
                 );
                 assert_eq!(m.get(&key).copied(), Some(now as f64));
@@ -664,7 +664,7 @@ mod test {
 
             with_labeled_counters(|m| {
                 let key = make_metric_key(
-                    "xrc_forex_fetch_total",
+                    metric_names::FOREX_FETCH_TOTAL,
                     &[("forex", "BankOfCanada"), ("outcome", "empty_map")],
                 );
                 assert_eq!(m.get(&key).copied(), Some(1));
@@ -694,11 +694,11 @@ mod test {
 
             with_labeled_counters(|m| {
                 let http_key = make_metric_key(
-                    "xrc_forex_fetch_total",
+                    metric_names::FOREX_FETCH_TOTAL,
                     &[("forex", "BankOfItaly"), ("outcome", "http_error")],
                 );
                 let candid_key = make_metric_key(
-                    "xrc_forex_fetch_total",
+                    metric_names::FOREX_FETCH_TOTAL,
                     &[("forex", "CentralBankOfTurkey"), ("outcome", "candid_error")],
                 );
                 assert_eq!(m.get(&http_key).copied(), Some(1));
@@ -724,7 +724,8 @@ mod test {
 
             // Heartbeat gauge is set unconditionally on the Success return path.
             with_labeled_gauges(|m| {
-                let heartbeat = make_metric_key("xrc_periodic_forex_run_last_seconds", &[]);
+                let heartbeat =
+                    make_metric_key(metric_names::PERIODIC_FOREX_RUN_LAST_SECONDS, &[]);
                 assert_eq!(m.get(&heartbeat).copied(), Some(timestamp as f64));
             });
 
@@ -733,7 +734,7 @@ mod test {
             // through record_per_forex_metrics.
             with_labeled_counters(|m| {
                 let success_key = make_metric_key(
-                    "xrc_forex_fetch_total",
+                    metric_names::FOREX_FETCH_TOTAL,
                     &[("forex", "src_name"), ("outcome", "success")],
                 );
                 assert_eq!(m.get(&success_key).copied(), Some(4));
@@ -754,7 +755,7 @@ mod test {
 
             with_labeled_gauges(|m| {
                 let key = make_metric_key(
-                    "xrc_forex_last_success_seconds",
+                    metric_names::FOREX_LAST_SUCCESS_SECONDS,
                     &[("forex", "ReserveBankOfAustralia")],
                 );
                 assert!(

--- a/src/xrc/src/periodic.rs
+++ b/src/xrc/src/periodic.rs
@@ -7,9 +7,9 @@ use futures::future::join_all;
 use crate::{
     call_forex,
     forex::{Forex, ForexContextArgs, ForexRateMap, FOREX_SOURCES},
-    increment_labeled_counter, metric_labels, metric_names, set_labeled_gauge,
-    with_forex_rate_collector, with_forex_rate_collector_mut, with_forex_rate_store_mut,
-    CallForexError, LOG_PREFIX, ONE_DAY_SECONDS, ONE_HOUR_SECONDS, USD,
+    increment_labeled_counter, set_labeled_gauge, with_forex_rate_collector,
+    with_forex_rate_collector_mut, with_forex_rate_store_mut, CallForexError, LabelKey,
+    MetricName, Outcome, LOG_PREFIX, ONE_DAY_SECONDS, ONE_HOUR_SECONDS, USD,
 };
 
 thread_local! {
@@ -231,7 +231,7 @@ async fn update_forex_store(
     }
 
     set_labeled_gauge(
-        metric_names::PERIODIC_FOREX_RUN_LAST_SECONDS,
+        MetricName::PeriodicForexRunLastSeconds,
         &[],
         timestamp as f64,
     );
@@ -251,29 +251,29 @@ fn record_per_forex_metrics(
 ) {
     for (forex, _, _) in forex_rates {
         increment_labeled_counter(
-            metric_names::FOREX_FETCH_TOTAL,
+            MetricName::ForexFetchTotal,
             &[
-                (metric_labels::FOREX, forex.as_str()),
-                (metric_labels::OUTCOME, metric_labels::SUCCESS),
+                (LabelKey::Forex, forex.as_str()),
+                (LabelKey::Outcome, Outcome::Success.into()),
             ],
         );
         set_labeled_gauge(
-            metric_names::FOREX_LAST_SUCCESS_SECONDS,
-            &[(metric_labels::FOREX, forex.as_str())],
+            MetricName::ForexLastSuccessSeconds,
+            &[(LabelKey::Forex, forex.as_str())],
             now_secs as f64,
         );
     }
     for (forex, error) in errors {
         let outcome = match error {
-            CallForexError::Empty { .. } => metric_labels::EMPTY_MAP,
-            CallForexError::Http { .. } => metric_labels::HTTP_ERROR,
-            CallForexError::Candid { .. } => metric_labels::CANDID_ERROR,
+            CallForexError::Empty { .. } => Outcome::EmptyMap,
+            CallForexError::Http { .. } => Outcome::HttpError,
+            CallForexError::Candid { .. } => Outcome::CandidError,
         };
         increment_labeled_counter(
-            metric_names::FOREX_FETCH_TOTAL,
+            MetricName::ForexFetchTotal,
             &[
-                (metric_labels::FOREX, forex.as_str()),
-                (metric_labels::OUTCOME, outcome),
+                (LabelKey::Forex, forex.as_str()),
+                (LabelKey::Outcome, outcome.into()),
             ],
         );
     }
@@ -622,8 +622,8 @@ mod test {
     mod per_forex_metrics {
         use super::*;
         use crate::{
-            make_metric_key, metric_labels, metric_names, reset_labeled_metrics_for_test,
-            with_labeled_counters, with_labeled_gauges,
+            make_metric_key, reset_labeled_metrics_for_test, with_labeled_counters,
+            with_labeled_gauges,
         };
 
         fn reset() {
@@ -643,18 +643,18 @@ mod test {
 
             with_labeled_counters(|m| {
                 let key = make_metric_key(
-                    metric_names::FOREX_FETCH_TOTAL,
+                    MetricName::ForexFetchTotal,
                     &[
-                        (metric_labels::FOREX, "EuropeanCentralBank"),
-                        (metric_labels::OUTCOME, metric_labels::SUCCESS),
+                        (LabelKey::Forex, "EuropeanCentralBank"),
+                        (LabelKey::Outcome, Outcome::Success.into()),
                     ],
                 );
                 assert_eq!(m.get(&key).copied(), Some(1));
             });
             with_labeled_gauges(|m| {
                 let key = make_metric_key(
-                    metric_names::FOREX_LAST_SUCCESS_SECONDS,
-                    &[(metric_labels::FOREX, "EuropeanCentralBank")],
+                    MetricName::ForexLastSuccessSeconds,
+                    &[(LabelKey::Forex, "EuropeanCentralBank")],
                 );
                 assert_eq!(m.get(&key).copied(), Some(now as f64));
             });
@@ -673,10 +673,10 @@ mod test {
 
             with_labeled_counters(|m| {
                 let key = make_metric_key(
-                    metric_names::FOREX_FETCH_TOTAL,
+                    MetricName::ForexFetchTotal,
                     &[
-                        (metric_labels::FOREX, "BankOfCanada"),
-                        (metric_labels::OUTCOME, metric_labels::EMPTY_MAP),
+                        (LabelKey::Forex, "BankOfCanada"),
+                        (LabelKey::Outcome, Outcome::EmptyMap.into()),
                     ],
                 );
                 assert_eq!(m.get(&key).copied(), Some(1));
@@ -706,17 +706,17 @@ mod test {
 
             with_labeled_counters(|m| {
                 let http_key = make_metric_key(
-                    metric_names::FOREX_FETCH_TOTAL,
+                    MetricName::ForexFetchTotal,
                     &[
-                        (metric_labels::FOREX, "BankOfItaly"),
-                        (metric_labels::OUTCOME, metric_labels::HTTP_ERROR),
+                        (LabelKey::Forex, "BankOfItaly"),
+                        (LabelKey::Outcome, Outcome::HttpError.into()),
                     ],
                 );
                 let candid_key = make_metric_key(
-                    metric_names::FOREX_FETCH_TOTAL,
+                    MetricName::ForexFetchTotal,
                     &[
-                        (metric_labels::FOREX, "CentralBankOfTurkey"),
-                        (metric_labels::OUTCOME, metric_labels::CANDID_ERROR),
+                        (LabelKey::Forex, "CentralBankOfTurkey"),
+                        (LabelKey::Outcome, Outcome::CandidError.into()),
                     ],
                 );
                 assert_eq!(m.get(&http_key).copied(), Some(1));
@@ -743,7 +743,7 @@ mod test {
             // Heartbeat gauge is set unconditionally on the Success return path.
             with_labeled_gauges(|m| {
                 let heartbeat =
-                    make_metric_key(metric_names::PERIODIC_FOREX_RUN_LAST_SECONDS, &[]);
+                    make_metric_key(MetricName::PeriodicForexRunLastSeconds, &[]);
                 assert_eq!(m.get(&heartbeat).copied(), Some(timestamp as f64));
             });
 
@@ -752,10 +752,10 @@ mod test {
             // through record_per_forex_metrics.
             with_labeled_counters(|m| {
                 let success_key = make_metric_key(
-                    metric_names::FOREX_FETCH_TOTAL,
+                    MetricName::ForexFetchTotal,
                     &[
-                        (metric_labels::FOREX, "src_name"),
-                        (metric_labels::OUTCOME, metric_labels::SUCCESS),
+                        (LabelKey::Forex, "src_name"),
+                        (LabelKey::Outcome, Outcome::Success.into()),
                     ],
                 );
                 assert_eq!(m.get(&success_key).copied(), Some(4));
@@ -776,8 +776,8 @@ mod test {
 
             with_labeled_gauges(|m| {
                 let key = make_metric_key(
-                    metric_names::FOREX_LAST_SUCCESS_SECONDS,
-                    &[(metric_labels::FOREX, "ReserveBankOfAustralia")],
+                    MetricName::ForexLastSuccessSeconds,
+                    &[(LabelKey::Forex, "ReserveBankOfAustralia")],
                 );
                 assert!(
                     m.get(&key).is_none(),


### PR DESCRIPTION
This is the first of three PRs implementing [DEFI-2810](https://dfinity.atlassian.net/browse/DEFI-2810). It introduces the per-source observability we were missing during the MEXC outage and the DAI→USDS migration - incidents where individual exchange/forex sources were silently failing while the aggregate `xrc_errors_returned` counter looked normal.

## What this PR ships

Three new Prometheus series on `/metrics`:

- **`xrc_forex_fetch_total{forex, outcome}`** — counter. Outcomes: `success`, `http_error`, `candid_error`, `empty_map`. Distinguishes "we couldn't reach the upstream" from "the upstream returned HTTP 200 with no rates."
- **`xrc_forex_last_success_seconds{forex}`** — gauge. Wall-clock seconds when each source most recently produced a non-empty rate map. Seeded to `time()` on canister `init` and `post_upgrade`, so a freshly-deployed canister doesn't trip a staleness alert before its first scheduled run.
- **`xrc_periodic_forex_run_last_seconds`** — heartbeat gauge for the 6h periodic task itself. Set on the `Success` return path of `update_forex_store` regardless of per-source success — orthogonal to the per-source metric above. Catches "the periodic task stopped firing" as distinct from "every individual forex returned nothing."

Plus the shared infrastructure those metrics ride on: a small label-aware extension to `MetricsEncoder`, a `LABELED_COUNTERS` / `LABELED_GAUGES` thread-local backing store accessed via `increment_labeled_counter` / `set_labeled_gauge` helpers, and an `init()` hook plumbed from `#[ic_cdk::init]` that also runs at the end of `post_upgrade` to re-seed ephemeral gauges. The labeled state is **not** persisted across upgrades (Prometheus `rate()`/`increase()` already tolerate counter resets, and we didn't want to expand the stable-memory schema).

## What this PR does **not** ship — coming in follow-up PRs

- **PR 2** — per-exchange (`xrc_exchange_fetch_total{exchange, kind, outcome}` + `_last_success_seconds`) and per-stablecoin (`xrc_stablecoin_symbol_rates_received{symbol}`) metrics. This is the PR that would have caught the MEXC and DAI scenarios directly.
- **PR 3** — `xrc_forex_collector_sources` gauge and a cross-cutting integration test under `xrc-tests` that exercises both PR 1 and PR 2 metrics end-to-end against the docker mock.

The existing aggregate counters (`xrc_stablecoin_errors`, `xrc_forex_asset_errors`, etc.) are left untouched in this PR — they overlap semantically with the new labeled metrics, but external dashboards depend on the current names. Coordinating their removal is a separate follow-up after consumers migrate.

## Behavior change worth flagging for log-based alerts

`CallForexError::Empty` is now a distinct enum variant (previously the empty-map case was stuffed into `CallForexError::Http` with a sentinel message string). The canister log line for that case changes:

- Before: `[xrc] <forex> Failed to retrieve rates from <forex>: Empty rates map`
- After:  `[xrc] <forex> Empty rates map from <forex>`

[DEFI-2810]: https://dfinity.atlassian.net/browse/DEFI-2810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ