### PR TITLE
chore: Add git-cliff config and seed CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [2026.05.29] - 2026-05-29
+
+### Changed
+
+- DEFI-2810: Add per-exchange and per-stablecoin observability ([#309](https://github.com/dfinity/exchange-rate-canister/pull/309))
+
+- DEFI-2810: Add labeled metrics infrastructure and per-forex observability ([#308](https://github.com/dfinity/exchange-rate-canister/pull/308))
+
+
+### Fixed
+
+- DEFI-2810: E2e coverage for labeled metrics and doc cleanups ([#310](https://github.com/dfinity/exchange-rate-canister/pull/310))
+
+
+[2026.05.29]: https://github.com/dfinity/exchange-rate-canister/compare/2026.05.15...2026.05.29
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [2026.05.29] - 2026-05-29
 
-### Changed
+### Added
 
 - DEFI-2810: Add per-exchange and per-stablecoin observability ([#309](https://github.com/dfinity/exchange-rate-canister/pull/309))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - DEFI-2810: Add per-exchange and per-stablecoin observability ([#309](https://github.com/dfinity/exchange-rate-canister/pull/309))
-
 - DEFI-2810: Add labeled metrics infrastructure and per-forex observability ([#308](https://github.com/dfinity/exchange-rate-canister/pull/308))
-
 
 ### Fixed
 
 - DEFI-2810: E2e coverage for labeled metrics and doc cleanups ([#310](https://github.com/dfinity/exchange-rate-canister/pull/310))
-
 
 [2026.05.29]: https://github.com/dfinity/exchange-rate-canister/compare/2026.05.15...2026.05.29
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,75 @@
+# git-cliff ~ configuration for changelog generation
+# https://git-cliff.org/docs/configuration
+#
+# Used by:
+# - .github/workflows/create-release-pr.yml: prepends a new entry to CHANGELOG.md
+# - .github/workflows/create-github-release.yml: generates scoped release notes
+#
+# The exchange rate canister has a single release artifact and uses date-based
+# tags of the form `YYYY.MM.DD` (e.g. `2026.05.29`). Workflows pass
+# `--tag-pattern '[0-9]{4}\.[0-9]{2}\.[0-9]{2}'` so only those tags are
+# considered when computing the previous release.
+
+[changelog]
+header = """
+# Changelog\n
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).\n
+"""
+body = """
+{% if version -%}
+    ## [{{ version }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else -%}
+    ## [Unreleased]
+{% endif -%}
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | upper_first }}
+    {% for commit in commits %}
+        {% set title = commit.message | split(pat="\n") | first | upper_first | trim -%}
+        {% set parts = title | split(pat=" (#") -%}
+        {% if parts | length > 1 -%}
+            {% set pr_part = parts[1] | split(pat=")") -%}
+            {% set pr_num = pr_part[0] -%}
+            - {{ parts[0] }} ([#{{ pr_num }}](https://github.com/dfinity/exchange-rate-canister/pull/{{ pr_num }}))
+        {%- else -%}
+            - {{ title }}
+        {%- endif %}
+    {% endfor %}
+{% endfor %}\n
+"""
+footer = """
+{% for release in releases -%}
+    {% if release.version -%}
+        {% if release.previous.version -%}
+            [{{ release.version }}]: \
+                https://github.com/dfinity/exchange-rate-canister\
+                    /compare/{{ release.previous.version }}...{{ release.version }}
+        {% endif -%}
+    {% else -%}
+        [unreleased]: https://github.com/dfinity/exchange-rate-canister\
+            /compare/{{ release.previous.version }}...HEAD
+    {% endif -%}
+{% endfor %}
+"""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+commit_parsers = [
+    { message = "^[a|A]dd", group = "Added" },
+    { message = "^[s|S]upport", group = "Added" },
+    { message = "^[r|R]emove", group = "Removed" },
+    { message = "^.*: add", group = "Added" },
+    { message = "^.*: support", group = "Added" },
+    { message = "^.*: remove", group = "Removed" },
+    { message = "^.*: delete", group = "Removed" },
+    { message = "^test", group = "Fixed" },
+    { message = "^fix", group = "Fixed" },
+    { message = "^.*: fix", group = "Fixed" },
+    { message = "^.*", group = "Changed" },
+]
+filter_commits = false
+topo_order = false
+sort_commits = "newest"

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,7 +1,7 @@
 # git-cliff ~ configuration for changelog generation
 # https://git-cliff.org/docs/configuration
 #
-# Used by:
+# Consumed by the release workflows added in follow-up PRs (DEFI-2842):
 # - .github/workflows/create-release-pr.yml: prepends a new entry to CHANGELOG.md
 # - .github/workflows/create-github-release.yml: generates scoped release notes
 #

--- a/cliff.toml
+++ b/cliff.toml
@@ -35,7 +35,7 @@ body = """
         {%- else -%}
             - {{ title }}
         {%- endif %}
-    {% endfor %}
+    {%- endfor %}
 {% endfor %}\n
 """
 footer = """

--- a/cliff.toml
+++ b/cliff.toml
@@ -58,13 +58,13 @@ trim = true
 conventional_commits = true
 filter_unconventional = false
 commit_parsers = [
-    { message = "^[a|A]dd", group = "Added" },
-    { message = "^[s|S]upport", group = "Added" },
-    { message = "^[r|R]emove", group = "Removed" },
-    { message = "^.*: add", group = "Added" },
-    { message = "^.*: support", group = "Added" },
-    { message = "^.*: remove", group = "Removed" },
-    { message = "^.*: delete", group = "Removed" },
+    { message = "(?i)^add", group = "Added" },
+    { message = "(?i)^support", group = "Added" },
+    { message = "(?i)^remove", group = "Removed" },
+    { message = "(?i)^.*: add", group = "Added" },
+    { message = "(?i)^.*: support", group = "Added" },
+    { message = "(?i)^.*: remove", group = "Removed" },
+    { message = "(?i)^.*: delete", group = "Removed" },
     { message = "^test", group = "Fixed" },
     { message = "^fix", group = "Fixed" },
     { message = "^.*: fix", group = "Fixed" },

--- a/cliff.toml
+++ b/cliff.toml
@@ -65,9 +65,9 @@ commit_parsers = [
     { message = "(?i)^.*: support", group = "Added" },
     { message = "(?i)^.*: remove", group = "Removed" },
     { message = "(?i)^.*: delete", group = "Removed" },
-    { message = "^test", group = "Fixed" },
-    { message = "^fix", group = "Fixed" },
-    { message = "^.*: fix", group = "Fixed" },
+    { message = "(?i)^test", group = "Fixed" },
+    { message = "(?i)^fix", group = "Fixed" },
+    { message = "(?i)^.*: fix", group = "Fixed" },
     { message = "^.*", group = "Changed" },
 ]
 filter_commits = false


### PR DESCRIPTION
Part of streamlining the XRC release process (DEFI-2842) to match the bitcoin/dogecoin canisters.

Adds changelog automation so release notes no longer have to be reconstructed by hand from `git log`:

- `cliff.toml` — git-cliff configuration mirroring the sibling canisters, adapted for this repo's single release artifact and date-based `YYYY.MM.DD` tags.
- `CHANGELOG.md` — seeded with the Keep-a-Changelog header and a back-filled entry for the current `2026.05.29` release, so future `git-cliff --prepend` runs append cleanly.

This is the foundation consumed by the upcoming "Create Release PR" and "Create GitHub Release" workflows (follow-up PRs).

Refs DEFI-2842.