### PR TITLE
fix: DEFI-2810: Tune metrics help message character

### DIFF
--- a/src/xrc/src/api/metrics.rs
+++ b/src/xrc/src/api/metrics.rs
@@ -163,7 +163,7 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
     encode_labeled_gauge_family(
         w,
         MetricName::PeriodicForexRunLastSeconds,
-        "Unix timestamp (seconds) of the most recent periodic forex-update task run (heartbeat — not contingent on rate-fetch success).",
+        "Unix timestamp (seconds) of the most recent periodic forex-update task run (heartbeat - not contingent on rate-fetch success).",
     )?;
     encode_labeled_counter_family(
         w,


### PR DESCRIPTION
The em dash character in the metrics help was showing up as `â€”`. Replace it with a hyphen (`-`).