### PR TITLE
fix: DEFI-2855: invert RBA forex rates to USD-per-unit

### DIFF
--- a/src/xrc-tests/src/tests/basic_exchange_rates.rs
+++ b/src/xrc-tests/src/tests/basic_exchange_rates.rs
@@ -17,53 +17,24 @@ use crate::{
 /// Success criteria:
 /// * All queries return the expected values
 ///
-///
-/// NOTE (DEFI-2855): the worked figures below (e.g. the EUR/USD rate set that
-/// still lists 917777444) illustrate the pre-fix Reserve Bank of Australia
-/// orientation. After the RBA orientation fix the forex-derived inputs and
-/// results changed; the authoritative expected values are the ones asserted in
-/// the test body below.
-///
 /// The expected values are determined as follows:
 ///
 /// Crypto-pair (retrieve ICP/BTC rate)
-/// 0. The XRC retrieves the ICP/USDT rate.
-///     1. ICP/USDT rates:
-///           GateIo      Okx         Crypto      Mexc        Coinbase    KuCoin      Bitget      Digifinex   Poloniex
-///          [ 3900000000, 3900000000, 3910000000, 3911000000, 3920000000, 3920000000, 3930000000, 4000000000, 4005000000, ]
-/// 1. The XRC retrieves the BTC/USDT rate.
-///     1. BTC/USDT rates: [ 41960000000, 42030000000, 42640000000, 44250000000, 44250000000, 44833000000, 44930000000, 46022000000, 46101000000, ]
-/// 2. The XRC divides ICP/USDT by BTC/USDT. The division inverts BTC/USDT to USDT/BTC then multiplies ICP/USDT and USDT/BTC
-///    to get the resulting ICP/BTC rate.
-///     1. ICP/BTC rates:
-///        [84596861, 84596861, 84742078, 84742078, 84813776, 84835468, 84959365, 84981094, 85030691,
-///        85030691, 85176652, 85176652, 85247606, 85393940, 86766012, 86801687, 86801687, 86874469,
-///        86914952, 86989492, 86989492, 87023595, 87024256, 87046512, 87212542, 87234847, 87246824,
-///        87246824, 87435592, 87435592, 87469392, 87658642, 88135593, 88135593, 88361581, 88384180,
-///        88587570, 88587570, 88636360, 88636360, 88813559, 88863633, 88886360, 89027372, 89090906,
-///        89090906, 89138656, 89219992, 89318178, 89331516, 90395480, 90508474, 90909088, 91022724,
-///        91463412, 91463412, 91697933, 91721386, 91932455, 91932455, 92166977, 92790863, 92790863,
-///        92945661, 92945661, 93028788, 93052580, 93183984, 93207816, 93266713, 93266713, 93422306,
-///        93422306, 93504638, 93660628, 93808628, 93925888, 95170116, 95289078, 95328884, 95448045]
-/// 3. The XRC returns the median rate and the standard deviation from the BTC/ICP rates.
-///     1. The median rate from step 2 is 88813559.
-///     2. The standard deviation from step 2 is 3178330.
+/// 0. The XRC retrieves the ICP/USDT rates from the mock exchange responses.
+/// 1. The XRC retrieves the BTC/USDT rates from the mock exchange responses.
+/// 2. The XRC divides ICP/USDT by BTC/USDT (inverting BTC/USDT to USDT/BTC and multiplying) to get the ICP/BTC rates.
+/// 3. The XRC returns the median rate and the standard deviation of the ICP/BTC rates.
+///    The concrete expected median rate and standard deviation are asserted below.
 ///
 /// Crypto-fiat pair (retrieve BTC/EUR rate)
-/// 0. The XRC retrieves rates from the mock forex sources.
-///     1. During collection the rates retrieved are normalized to USD.
-///     2. When the collected rates are normalized, then the EUR rate (EUR/USD) is collected (for more information on this collection, see xrc/forex.rs:483).
-///         1. For all requests in the following test, this should result in a EUR/USD with the following rates:
-///             [917777444, 976400000, 1052938432, 1056100000, 1056900158, 1057200262, 1057421866,
-///              1058173944, 1058502845, 1058516154, 1059297297]
-/// 1. The XRC retrieves the BTC/USDT rates from the mock exchange responses (request 1 responses).
-///     1. BTC/USDT rates: [ 41960000000, 42030000000, 42640000000, 44000000000, 44250000000, 44833000000, 44930000000, 46022000000, 46101000000]
+/// 0. The XRC retrieves rates from the mock forex sources and normalizes them to USD,
+///    collecting the EUR/USD rate (see xrc/forex.rs).
+/// 1. The XRC retrieves the BTC/USDT rates from the mock exchange responses.
 /// 2. The XRC retrieves the stablecoin rates (USDS and USDC, each quoted in USDT) from the mock exchanges.
 /// 3. The XRC determines the USDT/USD rate.
-/// 4. The XRC then multiplies the USDT/USD rate (step 3) with the BTC/USDT rate (step 1) to get the BTC/USD rate.
-/// 5. The XRC divides the BTC/USD by the forex rate EUR/USD. The division works by inverting EUR/USD to USD/EUR then multiplying
-///    USD/EUR and BTC/USD resulting in BTC/EUR.
-/// 6. The XRC then returns the median rate and the standard deviation of the resulting BTC/EUR rates.
+/// 4. The XRC multiplies the USDT/USD rate with the BTC/USDT rate to get the BTC/USD rate.
+/// 5. The XRC divides BTC/USD by the forex rate EUR/USD (inverting EUR/USD to USD/EUR and multiplying) to get BTC/EUR.
+/// 6. The XRC returns the median rate and the standard deviation of the BTC/EUR rates.
 ///    The concrete expected median rate and standard deviation are asserted below.
 ///
 /// Fiat-crypto pair (retrieve EUR/BTC rate)
@@ -71,31 +42,11 @@ use crate::{
 ///    being returned. The concrete expected median rate and standard deviation are asserted below.
 ///
 /// Fiat pair (retrieve EUR/JPY rate)
-/// 0. The XRC retrieves rates from the mock forex sources.
-///     1. During collection the rates retrieved are normalized to USD.
-///     2. When the collected rates are normalized, then the EUR rate (EUR/USD) is collected (for more information on this collection, see xrc/forex.rs:483).
-///         1. For all requests in the following test, this should result in a EUR/USD with the following rates:
-///             [917777444, 976400000, 1052938432, 1056100000, 1056900158, 1057200262, 1057421866,
-///              1058173944, 1058502845, 1058516154, 1059297297]
-///         2. For all requests in the following test, this should result in a JPY/USD with the following rates:
-///             [6900840, 7346082, 7350873, 7369729, 7380104, 7390111, 7395293, 7395822, 7395930, 7399602]
-/// 1. The XRC divides EUR/USD by JPY/USD. The division inverts JPY/USD to USD/JPY then multiplies EUR/USD and USD/JPY
-///    to get the resulting EUR/JPY rate.
-///     1. EUR/JPY rates should then include:
-///        [124030649755, 124092229644, 124094041743, 124102918437, 124358334787, 124533404687, 124852849994, 124934277074, 131953042878, 132018556151,
-///        132020483996, 132029927684, 132301658621, 132487911020, 132827760729, 132914388921, 132995033068, 135589467313, 141490021504, 142296630547, 
-///        142367279300, 142369358266, 142379542230, 142672573719, 142723892446, 142794753330, 142796838538, 142807053080, 142832027721, 142872584497, 
-///        142873426145, 142902532594, 142902942293, 142905029081, 142915251362, 142943519205, 142945606586, 142955831769, 142973482171, 142975569989, 
-///        142985797316, 143048618694, 143050417305, 143100964430, 143119640802, 143121440305, 143121730754, 143123530284, 143131968536, 143133768195, 
-///        143155982847, 143209385395, 143227058260, 143229149781, 143239395247, 143239916129, 143250049321, 143280076540, 143302419939, 143333334966, 
-///        143410993537, 143426548595, 143428351957, 143451714709, 143481784200, 143534196401, 143628462457, 143630268357, 143670010350, 143736261807, 
-///        143763709688, 143778862455, 143819688082, 143849834706, 143872632785, 143913485038, 143943651322, 143996889212, 143998699745, 144090801735, 
-///        144092613449, 144104965083, 144198948091, 144250173885, 146264455573, 146337074309, 146339211245, 146349679180, 146650881613, 146857334644, 
-///        147234043901, 147330067646, 152581197651, 153039340138, 153155290949, 153198778988, 153230891601, 153387536154, 153389464760, 153502660110, 
-///        155557713956, 156024793773, 156143006525, 156187342918, 156220081975, 156379782312, 156381748540, 156497152077, 156835799409, 159895313434]
-/// 2. The XRC then return the median and the standard deviation.
-///     1. The median rate from the group of rates in step 1.a.: 143239655688.
-///     2. The standard deviation of the group of rates in step 1.a.: 7823121871.
+/// 0. The XRC retrieves rates from the mock forex sources and normalizes them to USD,
+///    collecting the EUR/USD and JPY/USD rates (see xrc/forex.rs).
+/// 1. The XRC divides EUR/USD by JPY/USD (inverting JPY/USD to USD/JPY and multiplying) to get the EUR/JPY rates.
+/// 2. The XRC returns the median rate and the standard deviation of the EUR/JPY rates.
+///    The concrete expected median rate and standard deviation are asserted below.
 #[ignore]
 #[test]
 fn basic_exchange_rates() {

--- a/src/xrc-tests/src/tests/basic_exchange_rates.rs
+++ b/src/xrc-tests/src/tests/basic_exchange_rates.rs
@@ -18,6 +18,12 @@ use crate::{
 /// * All queries return the expected values
 ///
 ///
+/// NOTE (DEFI-2855): the worked figures below (e.g. the EUR/USD rate set that
+/// still lists 917777444) illustrate the pre-fix Reserve Bank of Australia
+/// orientation. After the RBA orientation fix the forex-derived inputs and
+/// results changed; the authoritative expected values are the ones asserted in
+/// the test body below.
+///
 /// The expected values are determined as follows:
 ///
 /// Crypto-pair (retrieve ICP/BTC rate)
@@ -203,8 +209,8 @@ fn basic_exchange_rates() {
             exchange_rate.metadata.quote_asset_num_received_rates,
             NUM_FOREX_SOURCES
         );
-        assert_eq!(exchange_rate.metadata.standard_deviation, 2_770_742_080);
-        assert_eq!(exchange_rate.rate, 42_906_558_356);
+        assert_eq!(exchange_rate.metadata.standard_deviation, 2_138_631_519);
+        assert_eq!(exchange_rate.rate, 42_522_454_766);
 
         // Fiat-crypto pair
         let fiat_crypto_pair_request = GetExchangeRateRequest {
@@ -252,8 +258,8 @@ fn basic_exchange_rates() {
             exchange_rate.metadata.quote_asset_num_received_rates,
             NUM_EXCHANGES
         );
-        assert_eq!(exchange_rate.metadata.standard_deviation, 1_420_062);
-        assert_eq!(exchange_rate.rate, 23_306_460);
+        assert_eq!(exchange_rate.metadata.standard_deviation, 1_169_238);
+        assert_eq!(exchange_rate.rate, 23_516_986);
 
         // Fiat-pair
         let fiat_pair_request = GetExchangeRateRequest {
@@ -292,8 +298,8 @@ fn basic_exchange_rates() {
             exchange_rate.metadata.quote_asset_num_received_rates,
             NUM_FOREX_SOURCES
         );
-        assert_eq!(exchange_rate.metadata.standard_deviation, 7_823_121_871);
-        assert_eq!(exchange_rate.rate, 143_239_655_688);
+        assert_eq!(exchange_rate.metadata.standard_deviation, 5_961_395_353);
+        assert_eq!(exchange_rate.rate, 143_426_548_595);
 
         Ok(())
     })

--- a/src/xrc-tests/src/tests/get_icp_xdr_rate.rs
+++ b/src/xrc-tests/src/tests/get_icp_xdr_rate.rs
@@ -16,26 +16,15 @@ use crate::{
 ///
 /// Success criteria: All queries return the expected values
 ///
-/// NOTE (DEFI-2855): the worked figures below (e.g. the CXDR/USD rates)
-/// illustrate the pre-fix Reserve Bank of Australia orientation. After the RBA
-/// orientation fix the forex-derived inputs and results changed; the
-/// authoritative expected values are the ones asserted in the test body below.
-///
 /// How are the expected values determined (using request 1 as an example):
 ///
-/// 0. The XRC retrieves rates from the mock forex sources.
-///     1. During collection the rates retrieved are normalized to USD.
-///     2. When the collected rates are normalized, then the computed XDR rate (CXDR/USD) is calculated (for more information on this calculation, see xrc/forex.rs:483).
-///         1. For all requests in the following test, this should result in a CXDR/USD with the following rates: [ 1336769190, 1336769190 ].
-/// 1. The XRC retrieves the ICP/USDT rates from the mock exchange responses (request 1 responses).
-///     1. For request 1, this should result in the following rates discovered:
-///        GateIo        Okx         Crypto     Mexc        Coinbase    KuCoin      Bitget      Digifinex   Poloniex
-///        [ 3900000000, 3900000000, 3910000000, 3911000000, 3920000000, 3920000000, 3930000000, 4000000000, 4005000000]
+/// 0. The XRC retrieves rates from the mock forex sources, normalizes them to USD,
+///    and computes the CXDR/USD rate (see xrc/forex.rs).
+/// 1. The XRC retrieves the ICP/USDT rates from the mock exchange responses.
 /// 2. The XRC retrieves the stablecoin rates (USDS and USDC, each quoted in USDT) from the mock exchanges.
 /// 3. The XRC determines if USDT has not depegged. If it has not depegged, it returns the USDT/USD rate.
-/// 4. The XRC then multiplies the USDT/USD rate (step 3) with the ICP/USDT rate (step 1) to get the ICP/USD rate.
-/// 5. The XRC divides the ICP/USD by the forex rate CXDR/USD. The division works by inverting CXDR/USD to USD/CXDR then multiplying
-///    USD/CXDR and ICP/USD resulting in ICP/CXDR.
+/// 4. The XRC multiplies the USDT/USD rate with the ICP/USDT rate to get the ICP/USD rate.
+/// 5. The XRC divides ICP/USD by the forex rate CXDR/USD (inverting CXDR/USD to USD/CXDR and multiplying) to get ICP/CXDR.
 /// 6. The XRC returns the median rate and the standard deviation of the resulting ICP/CXDR rates.
 ///    The concrete expected median rate and standard deviation for each request are asserted below.
 fn get_icp_xdr_rate() {

--- a/src/xrc-tests/src/tests/get_icp_xdr_rate.rs
+++ b/src/xrc-tests/src/tests/get_icp_xdr_rate.rs
@@ -16,6 +16,11 @@ use crate::{
 ///
 /// Success criteria: All queries return the expected values
 ///
+/// NOTE (DEFI-2855): the worked figures below (e.g. the CXDR/USD rates)
+/// illustrate the pre-fix Reserve Bank of Australia orientation. After the RBA
+/// orientation fix the forex-derived inputs and results changed; the
+/// authoritative expected values are the ones asserted in the test body below.
+///
 /// How are the expected values determined (using request 1 as an example):
 ///
 /// 0. The XRC retrieves rates from the mock forex sources.
@@ -142,8 +147,8 @@ fn get_icp_xdr_rate() {
             exchange_rate.metadata.quote_asset_num_received_rates,
             NUM_FOREX_SOURCES
         );
-        assert_eq!(exchange_rate.metadata.standard_deviation, 81_140_854);
-        assert_eq!(exchange_rate.rate, 3_015_694_093);
+        assert_eq!(exchange_rate.metadata.standard_deviation, 83_532_932);
+        assert_eq!(exchange_rate.rate, 2_996_307_816);
 
         let request = GetExchangeRateRequest {
             base_asset: Asset {
@@ -180,8 +185,8 @@ fn get_icp_xdr_rate() {
             exchange_rate.metadata.quote_asset_num_received_rates,
             NUM_FOREX_SOURCES
         );
-        assert_eq!(exchange_rate.metadata.standard_deviation, 88_887_175);
-        assert_eq!(exchange_rate.rate, 3_301_066_679);
+        assert_eq!(exchange_rate.metadata.standard_deviation, 91_482_333);
+        assert_eq!(exchange_rate.rate, 3_264_974_572);
 
         let request = GetExchangeRateRequest {
             base_asset: Asset {
@@ -218,8 +223,8 @@ fn get_icp_xdr_rate() {
             exchange_rate.metadata.quote_asset_num_received_rates,
             NUM_FOREX_SOURCES
         );
-        assert_eq!(exchange_rate.metadata.standard_deviation, 102_164_274);
-        assert_eq!(exchange_rate.rate, 3_987_503_442);
+        assert_eq!(exchange_rate.metadata.standard_deviation, 105_527_708);
+        assert_eq!(exchange_rate.rate, 3_935_225_747);
 
         Ok(())
     })

--- a/src/xrc-tests/src/tests/misbehavior.rs
+++ b/src/xrc-tests/src/tests/misbehavior.rs
@@ -37,112 +37,35 @@ const FIAT_PAIR_COMMON_DATASET_STD_DEV: u64 = 396_623_626;
 /// Success criteria:
 /// * All queries return the expected values
 ///
-/// NOTE (DEFI-2855): the worked figures below (e.g. the EUR/USD rate set that
-/// still lists 917777444) illustrate the pre-fix Reserve Bank of Australia
-/// orientation. After the RBA orientation fix the forex-derived inputs and
-/// results changed; the authoritative expected values are the ones asserted in
-/// the test body below.
-///
 /// The expected values are determined as follows:
 ///
 /// Crypto-pair (retrieve ICP/BTC rate)
-/// 0. The XRC retrieves the ICP/USDT rate.
-///     1. ICP/USDT rates: [3900000000, 3900000000, 3911000000, 3930000000, 4005000000]
-///         1. There are only 5 rates as the other 3 have been filtered out as they were >= 20% different
-///            than the median rate.
-/// 1. The XRC retrieves the BTC/USDT rate.
-///     1. BTC/USDT rates: [42030000000, 42640000000, 45000000000, 46022000000, 46101000000]
-///         1. There are only 5 rates as the other 3 have been filtered out as they were >= 20% different
-///            than the median rate.
-/// 2. The XRC divides ICP/USDT by BTC/USDT. The division inverts BTC/USDT to USDT/BTC then multiplies ICP/USDT and USDT/BTC
-///    to get the resulting ICP/BTC rate.
-///     1. ICP/BTC rates:
-///        [84596861, 84596861, 84742078, 84742078, 84835468, 84981094, 85247606, 85393940, 86666665, 86666665,
-///        86874469, 86911110, 87023595, 87333332, 88999999, 91463412, 91463412, 91721386, 92166977, 92790863,
-///        92790863, 93052580, 93504638, 93925888, 95289078]
-/// 3. The XRC returns the median rate and the standard deviation from the BTC/ICP rates.
-///     1. The median rate from step 2 is 87023595.
-///     2. The standard deviation from step 2 is 3644799.
+/// 0. The XRC retrieves the ICP/USDT and BTC/USDT rates from the mock exchange responses;
+///    rates that differ from the median by 20% or more are filtered out.
+/// 1. The XRC divides ICP/USDT by BTC/USDT (inverting BTC/USDT to USDT/BTC and multiplying) to get the ICP/BTC rates.
+/// 2. The XRC returns the median rate and the standard deviation of the ICP/BTC rates.
+///    The concrete expected median rate and standard deviation are asserted below.
 ///
 /// Crypto-fiat pair (retrieve BTC/EUR rate)
-/// 0. The XRC retrieves rates from the mock forex sources.
-///     1. During collection the rates retrieved are normalized to USD.
-///     2. When the collected rates are normalized, then the EUR rate (EUR/USD) is collected (for more information on this collection, see xrc/forex.rs:483).
-///         1. For all requests in the following test, this should result in a EUR/USD with the following rates:
-///            [917777444, 976400000, 1056100000, 1056900158, 1057200262, 1058516154]
-///         2. Large values are filtered out as they were greater than the median rate.
-/// 1. The XRC retrieves the BTC/USDT rates from the mock exchange responses (request 1 responses).
-///     1. BTC/USDT rates: [42030000000, 42640000000, 46022000000, 46101000000]
-///         1. There are only 4 rates as the other 3 have been filtered out as they were greater
-///            than the median rate.
-/// 2. The XRC retrieves the stablecoin rates from the mock exchanges.
-///     1.  USDS:  [ 950000000, 970000000, 990000000, 1000000000, 1020000000 ]
-///     2. USDC: [ 950000000, 970000000, 970000000, 970000000, 990099009, 1010101010, 1010101010, 1020000000 ]
-/// 3. The XRC determines the USDT/USD rate.
-///     1. USDT/USD: [ 980392156, 1000000000, 1010101010, 1030927835, 1052631578 ]
-/// 4. The XRC then multiplies the USDT/USD rate (step 3) with the ICP/USDT rate (step 1) to get the BTC/USD rate.
-///     1. This results in the following rates:
-///        [40701200000, 40769100000, 41137254865, 41205882316, 41360800000, 41803921531, 41960000000,
-///        42030000000, 42383838379, 42383838379, 42454545450, 42454545450, 42640000000, 42922500000,
-///        43070707066, 43070707066, 43382352903, 43488010000, 43953921529, 44168421012, 44242105223,
-///        44250000000, 44641340000, 44696969692, 44696969692, 44717970000, 44833000000, 44884210485,
-///        45119607803, 45197058783, 45285858581, 45285858581, 46022000000, 46101000000, 46486868682,
-///        46486868682, 46566666662, 46566666662, 46578947326, 47192631536, 48444210482, 48527368377]
-/// 5. The XRC divides the BTC/USD by the forex rate EUR/USD. The division works by inverting EUR/USD to USD/EUR then multiplying
-///    USD/EUR and BTC/USD resulting in BTC/EUR.
-///     1. This results in the following rates:
-///        [37668988975, 38072558056, 38215695691, 38515330948, 38563270803, 38574220730, 38603446631, 38625121949, 38834009252, 38927967367,
-///        38976420829, 38987488069, 39017027083, 39074321000, 39122956627, 39134065476, 39163715544, 39226271968, 39226271968, 39397624424,
-///        39492946194, 39542102882, 39553330746, 39583298473, 39706526750, 39755949281, 39767237866, 39795580221, 39795580221, 39797367660,
-///        40107602774, 40107602774, 40157524522, 40157524522, 40168927134, 40168927134, 40199361269, 40199361269, 40282805154, 40330823314,
-///        40332944976, 40344397398, 40374964479, 40689702172, 40689702172, 40740348456, 40740348456, 40751916559, 40751916559, 40762910125,
-///        40782792398, 40782792398, 40877904439, 41236971036, 41246781123, 41288298504, 41300022195, 41317584124, 41331313309, 41471183566,
-///        41578168365, 41678765919, 41688681106, 41730643286, 41742492580, 41754506310, 41760242659, 41774118933, 41796343910, 41848367626,
-///        41860250348, 41891965920, 41998149859, 41998149859, 42173508467, 42201845839, 42226001639, 42237991588, 42245902261, 42269993358,
-///        42298485541, 42310496072, 42342552775, 42360507948, 42402952755, 42455731515, 42467786695, 42499962570, 42512341275, 42522454766,
-///        42565256190, 42577342470, 42595447550, 42609601350, 42625337002, 42678392562, 42690510967, 42698506391, 42722855590, 42751653025,
-///        42763792232, 42796192376, 42814339913, 42941758859, 42941758859, 42951974507, 42951974507, 42995208268, 42995208268, 43007416632,
-///        43007416632, 43025704592, 43025704592, 43040001359, 43040001359, 43045882794, 43477843781, 43480689686, 43480689686, 43531960452,
-///        43544321225, 43552476558, 43577312740, 43606686124, 43619068115, 43652116263, 43670626751, 43766492976, 43917013915, 43917013915,
-///        43971677220, 43971677220, 43984162849, 43984162849, 43992400559, 43992400559, 44017487612, 44017487612, 44047157697, 44047157697,
-///        44059664758, 44059664758, 44093046725, 44093046725, 44111744188, 44111744188, 44421553645, 44705038876, 44749832880, 44760478660,
-///        44805532791, 44818255191, 44837313170, 44852211907, 44897466753, 45066263322, 45183989122, 45311455532, 45549083567, 45720339981,
-///        45766151306, 45795416129, 45798822161, 45823116224, 45836127564, 45844712124, 45870855474, 45901774826, 45914808501, 45949596024,
-///        45969080748, 46087668945, 46210167718, 46257996085, 46257996085, 46289490721, 46460065280, 46553200949, 46553200949, 46929358864,
-///        46929358864, 47134371115, 47215280578, 47560549941, 47610475869, 47610475869, 47692202599, 47692202599, 48070092884, 48205701144,
-///        48513335687, 48640702875, 48724198063, 48905331829, 49031494785, 49161818104, 49246207822, 49526762404, 49526762404, 49615127444,
-///        49700295300, 50145054511, 50231132024, 50651570207, 50651570207, 50738517190, 50738517190, 51612099727, 52784267858, 52874875766]
-/// 6. The XRC then returns the median and the standard deviation.
-///     1. The median rate from step 5 is 43552476558.
-///     2. The standard deviation from step 5 is 3213568340.
+/// 0. The XRC retrieves rates from the mock forex sources and normalizes them to USD,
+///    collecting the EUR/USD rate (see xrc/forex.rs).
+/// 1. The XRC retrieves the BTC/USDT rates from the mock exchange responses (outliers filtered as above).
+/// 2. The XRC retrieves the stablecoin rates (USDS and USDC, each quoted in USDT) and determines the USDT/USD rate.
+/// 3. The XRC multiplies USDT/USD by BTC/USDT to get BTC/USD.
+/// 4. The XRC divides BTC/USD by the forex rate EUR/USD (inverting EUR/USD to USD/EUR and multiplying) to get BTC/EUR.
+/// 5. The XRC returns the median rate and the standard deviation of the BTC/EUR rates.
+///    The concrete expected median rate and standard deviation are asserted below.
 ///
 /// Fiat-crypto pair (retrieve EUR/BTC rate)
 /// 0. The instructions are similar to the crypto-fiat pair. The only difference is that the rates are inverted before
-///    being returned.
-///     1. When inverted, the median rate is 22960806.
-///     2. When inverted, the standard deviation is 1621638.
+///    being returned. The concrete expected median rate and standard deviation are asserted below.
 ///
 /// Fiat pair (retrieve EUR/JPY rate)
-/// 0. The XRC retrieves rates from the mock forex sources.
-///     1. During collection the rates retrieved are normalized to USD.
-///     2. When the collected rates are normalized, then the EUR rate (EUR/USD) is collected (for more information on this collection, see xrc/forex.rs:483).
-///         1. For all requests in the following test, this should result in a EUR/USD with the following rates:
-///             [917777444, 976400000, 1056100000, 1056900158, 1057200262, 1058516154]
-///         2. Large values are filtered out as they were greater than the median rate.
-///         3. For all requests in the following test, this should result in a EUR/USD with the following rates:
-///             [6900840, 7217610, 7350873, 7380104, 7395293, 7395930]
-///         4. Large values are filtered out as they were greater than the median rate.
-/// 1. The XRC divides EUR/USD by JPY/USD. The division inverts JPY/USD to USD/JPY then multiplies EUR/USD and USD/JPY
-///    to get the resulting EUR/JPY rate.
-///     1. EUR/JPY rates should then include:
-///        [124092229644, 124102918437, 124358334787, 124852849994, 132018556151, 132029927684, 132301658621, 132827760729, 132995033068, 135589467313,
-///        141490021504, 142794753330, 142807053080, 142902942293, 142915251362, 142943519205, 142955831769, 143100964430, 143121440305, 143133768195,
-///        143209385395, 143250049321, 143428351957, 143670010350, 143778862455, 143819688082, 143998699745, 144250173885, 146337074309, 146349679180,
-///        146650881613, 147234043901, 153039340138, 153155290949, 153198778988, 153389464760, 156024793773, 156143006525, 156187342918, 156381748540,
-///        156835799409, 159895313434 ]
-/// 2. The XRC then return the median and the standard deviation.
-///     1. The median rate from the group of rates in step 1.a.: 143229717358.
-///     2. The standard deviation of the group of rates in step 1.a.: 9438739634.
+/// 0. The XRC retrieves rates from the mock forex sources and normalizes them to USD,
+///    collecting the EUR/USD and JPY/USD rates (see xrc/forex.rs).
+/// 1. The XRC divides EUR/USD by JPY/USD (inverting JPY/USD to USD/JPY and multiplying) to get the EUR/JPY rates.
+/// 2. The XRC returns the median rate and the standard deviation of the EUR/JPY rates.
+///    The concrete expected median rate and standard deviation are asserted below.
 #[ignore]
 #[test]
 fn misbehavior() {

--- a/src/xrc-tests/src/tests/misbehavior.rs
+++ b/src/xrc-tests/src/tests/misbehavior.rs
@@ -19,7 +19,7 @@ const CRYPTO_PAIR_BASIC_STD_DEV: u64 = 3_483_761;
 const CRYPTO_FIAT_PAIR_BASIC_STD_DEV: u64 = 80_650_883;
 
 /// This value is derived in the basic_exchange_rates fiat crypto pair portion of the test.
-const FIAT_CRYPTO_PAIR_BASIC_STD_DEV: u64 = 1_474_512;
+const FIAT_CRYPTO_PAIR_BASIC_STD_DEV: u64 = 1_169_238;
 
 /// This value is derived from using the common mock dataset (mock_responses::forex::build_common_responses).
 /// A full explanation how on the number is derived can be seen starting in the basic_exchange_rate test on line
@@ -36,6 +36,12 @@ const FIAT_PAIR_COMMON_DATASET_STD_DEV: u64 = 396_623_626;
 ///
 /// Success criteria:
 /// * All queries return the expected values
+///
+/// NOTE (DEFI-2855): the worked figures below (e.g. the EUR/USD rate set that
+/// still lists 917777444) illustrate the pre-fix Reserve Bank of Australia
+/// orientation. After the RBA orientation fix the forex-derived inputs and
+/// results changed; the authoritative expected values are the ones asserted in
+/// the test body below.
 ///
 /// The expected values are determined as follows:
 ///
@@ -264,14 +270,14 @@ fn misbehavior() {
             base_asset: btc_asset.clone(),
             quote_asset: eur_asset.clone(),
             timestamp: timestamp_seconds,
-            rate: 43_827_155_951,
+            rate: 42_722_855_590,
             metadata: ExchangeRateMetadata {
                 decimals: 9,
                 base_asset_num_queried_sources: NUM_EXCHANGES,
                 base_asset_num_received_rates: NUM_EXCHANGES,
                 quote_asset_num_queried_sources: NUM_FOREX_SOURCES,
                 quote_asset_num_received_rates: NUM_FOREX_SOURCES,
-                standard_deviation: 3_234_076_689,
+                standard_deviation: 2_462_105_239,
                 forex_timestamp: Some(yesterday_timestamp_seconds),
             },
         };
@@ -298,14 +304,14 @@ fn misbehavior() {
             base_asset: eur_asset.clone(),
             quote_asset: btc_asset,
             timestamp: timestamp_seconds,
-            rate: 22_816_903,
+            rate: 23_406_675,
             metadata: ExchangeRateMetadata {
                 decimals: 9,
                 base_asset_num_queried_sources: NUM_FOREX_SOURCES,
                 base_asset_num_received_rates: NUM_FOREX_SOURCES,
                 quote_asset_num_queried_sources: NUM_EXCHANGES,
                 quote_asset_num_received_rates: NUM_EXCHANGES,
-                standard_deviation: 1_621_251,
+                standard_deviation: 1_327_108,
                 forex_timestamp: Some(yesterday_timestamp_seconds),
             },
         };
@@ -339,14 +345,14 @@ fn misbehavior() {
                 class: AssetClass::FiatCurrency,
             },
             timestamp: yesterday_timestamp_seconds,
-            rate: 143_229_717_358,
+            rate: 143_819_688_082,
             metadata: ExchangeRateMetadata {
                 decimals: 9,
                 base_asset_num_queried_sources: NUM_FOREX_SOURCES,
                 base_asset_num_received_rates: NUM_FOREX_SOURCES,
                 quote_asset_num_queried_sources: NUM_FOREX_SOURCES,
                 quote_asset_num_received_rates: NUM_FOREX_SOURCES,
-                standard_deviation: 9_438_739_634,
+                standard_deviation: 7_313_975_259,
                 forex_timestamp: Some(yesterday_timestamp_seconds),
             },
         };

--- a/src/xrc/src/forex/australia.rs
+++ b/src/xrc/src/forex/australia.rs
@@ -92,10 +92,18 @@ impl IsForex for ReserveBankOfAustralia {
                 // orientation, i.e. AUD per 1 unit of the target currency, so the
                 // value is inverted here before being collected.
                 let value = item.statistics.exchange_rate.observation.value;
-                if value <= 0.0 {
+                // Skip non-finite or non-positive observations: they cannot be
+                // inverted and would otherwise produce a zero rate. A zero USD
+                // rate in particular would make `normalize_to_usd` divide by
+                // zero, so malformed data must fail gracefully (RateNotFound)
+                // rather than trap.
+                if !value.is_finite() || value <= 0.0 {
                     return None;
                 }
                 let rate = (RATE_UNIT as f64 / value) as u64;
+                if rate == 0 {
+                    return None;
+                }
                 Some((item.statistics.exchange_rate.target_currency.clone(), rate))
             })
             .collect::<ForexRateMap>();
@@ -161,9 +169,9 @@ mod test {
             .extract_rate(&query_response, timestamp)
             .expect("should be able to extract rates");
         // Rates are USD per 1 unit of the listed currency (scaled by RATE_UNIT),
-        // so non-USD currencies that are worth less than a USD are below
-        // RATE_UNIT and those worth more are above it. For example one USD is
-        // worth ~0.67 USD-equivalent (AUD), and one VND is worth ~0.0000426 USD.
+        // so currencies worth less than a USD are below RATE_UNIT and those
+        // worth more are above it. For example one AUD is worth ~0.67 USD, and
+        // one VND is worth ~0.0000426 USD.
         assert_eq!(
             extracted_rates,
             btreemap! {

--- a/src/xrc/src/forex/australia.rs
+++ b/src/xrc/src/forex/australia.rs
@@ -86,8 +86,16 @@ impl IsForex for ReserveBankOfAustralia {
                 if timestamp != extracted_timestamp {
                     return None;
                 }
-                let rate =
-                    (item.statistics.exchange_rate.observation.value * RATE_UNIT as f64) as u64;
+                // The RBA feed quotes AUD as the base currency, so each value is
+                // the target currency per 1 AUD (e.g. 0.6677 USD per AUD). The
+                // `normalize_to_usd` step expects rates in the opposite
+                // orientation, i.e. AUD per 1 unit of the target currency, so the
+                // value is inverted here before being collected.
+                let value = item.statistics.exchange_rate.observation.value;
+                if value <= 0.0 {
+                    return None;
+                }
+                let rate = (RATE_UNIT as f64 / value) as u64;
                 Some((item.statistics.exchange_rate.target_currency.clone(), rate))
             })
             .collect::<ForexRateMap>();
@@ -152,28 +160,32 @@ mod test {
         let extracted_rates = forex
             .extract_rate(&query_response, timestamp)
             .expect("should be able to extract rates");
+        // Rates are USD per 1 unit of the listed currency (scaled by RATE_UNIT),
+        // so non-USD currencies that are worth less than a USD are below
+        // RATE_UNIT and those worth more are above it. For example one USD is
+        // worth ~0.67 USD-equivalent (AUD), and one VND is worth ~0.0000426 USD.
         assert_eq!(
             extracted_rates,
             btreemap! {
-                "INR".to_string() => 82_057_810_393,
-                "IDR".to_string() => 14_876_441_515_650,
-                "XDR".to_string() => 741_949_977,
-                "AUD".to_string() => 1_497_678_598,
-                "TWD".to_string() => 30_477_759_472,
-                "JPY".to_string() => 133_263_441_665,
-                "THB".to_string() => 34_296_839_898,
-                "PHP".to_string() => 54_680_245_619,
-                "GBP".to_string() => 805_301_782,
-                "EUR".to_string() => 917_777_444,
-                "SGD".to_string() => 1_330_687_434,
-                "KRW".to_string() => 1_320_907_593_230,
-                "NZD".to_string() => 1_605_361_689,
-                "CHF".to_string() => 907_143_926,
+                "INR".to_string() => 12_186_529,
+                "IDR".to_string() => 67_220,
+                "XDR".to_string() => 1_347_799_757,
+                "AUD".to_string() => 667_700_000,
+                "TWD".to_string() => 32_810_810,
+                "JPY".to_string() => 7_503_933,
+                "THB".to_string() => 29_157_205,
+                "PHP".to_string() => 18_288_140,
+                "GBP".to_string() => 1_241_770_503,
+                "EUR".to_string() => 1_089_588_772,
+                "SGD".to_string() => 751_491_276,
+                "KRW".to_string() => 757_054,
+                "NZD".to_string() => 622_912_585,
+                "CHF".to_string() => 1_102_360_904,
                 "USD".to_string() => 1_000_000_000,
-                "MYR".to_string() => 4_416_504_418,
-                "CNY".to_string() => 6_884_229_444,
-                "HKD".to_string() => 7_849_932_604,
-                "VND".to_string() => 23_449_153_811_592,
+                "MYR".to_string() => 226_423_411,
+                "CNY".to_string() => 145_259_539,
+                "HKD".to_string() => 127_389_628,
+                "VND".to_string() => 42_645,
             }
         );
     }


### PR DESCRIPTION
## Purpose

The Reserve Bank of Australia forex source returned fiat rates in the wrong orientation — inverted (e.g. VND stored as ~23449 instead of ~0.0000426 USD per unit).

The RBA feed quotes AUD as the base currency, so each value is the target currency per 1 AUD. `normalize_to_usd` expects the opposite orientation (home currency per 1 unit of the target), which every other forex source already provides. RBA was the only source that omitted the inversion; this has been the case since the source was introduced (#203), and RBA has not changed their feed format.

This inverts each RBA observation before normalization and repins the `extract_rate` test (and the affected e2e golden values) to the corrected, economically sane USD-per-unit values.

## Impact

In practice the cross-source median plus the ±20% divergence filter mask the bug for served rates. Computed on real source data (each source's captured EUR/USD plus live BTC/USD), the EUR/USD and BTC/EUR rates change by only ~0.04% between the buggy and fixed orientation; the measurable effect is a ~44% wider confidence interval (standard deviation), because RBA's inverted EUR is kept as a low outlier (within ±20% of the median) and widens the cartesian-product spread without moving its median. The larger e2e golden-value shifts (~0.9% basic, ~2.5% misbehavior) are artifacts of those tests' mock datasets (the misbehavior test injects malicious exchange prices), not production behaviour. No currency is sole-sourced by RBA, so a grossly wrong served rate would require a correlated outage of a currency's other sources (thinnest: XDR, TWD, VND). Full analysis and measured numbers are in the DEFI-2855 ticket.

An audit of all 11 active forex sources found RBA to be the only affected source. Follow-up detection work (per-source outlier metric, plausibility/consistency tests) is tracked in DEFI-2856.

Fixes DEFI-2855.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
