### PR TITLE
fix: DEFI-2859: bump BankOfCanada HTTP outcall max_response_bytes to 30 KiB

### DIFF
--- a/src/xrc/src/forex/canada.rs
+++ b/src/xrc/src/forex/canada.rs
@@ -100,7 +100,7 @@ impl IsForex for BankOfCanada {
     }
 
     fn max_response_bytes(&self) -> u64 {
-        ONE_KIB * 10
+        ONE_KIB * 30
     }
 }
 
@@ -146,6 +146,6 @@ mod test {
     #[test]
     fn max_response_bytes() {
         let forex = Forex::BankOfCanada(BankOfCanada);
-        assert_eq!(forex.max_response_bytes(), 10 * ONE_KIB);
+        assert_eq!(forex.max_response_bytes(), 30 * ONE_KIB);
     }
 }


### PR DESCRIPTION
## Purpose

`IC_XRC_ForexSourceSilent` has been firing for `BankOfCanada`: zero successful forex fetches since the last upgrade, while every other forex source is healthy.

The cause is a hard byte-count limit. The single-day `FX_RATES_DAILY` response now returns ~11,093 bytes — its `seriesDetail` block carries 27 currency series of fixed overhead — which exceeds the configured `max_response_bytes` of 10 KiB. Every outcall is therefore rejected for exceeding the cap, producing `http_error` and no successes. This is deterministic and will only worsen as BoC adds more series.

This PR raises `BankOfCanada::max_response_bytes()` from 10 KiB to 30 KiB, clearing the current size with headroom for further series growth (in line with Bosnia's 30 KiB), and updates the corresponding unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)