### PR TITLE
fix: DEFI-2860: send a curl-style User-Agent for ReserveBankOfAustralia outcalls

### DIFF
--- a/src/xrc/src/forex.rs
+++ b/src/xrc/src/forex.rs
@@ -141,6 +141,13 @@ macro_rules! forex {
                 }
             }
 
+            /// This method returns the `User-Agent` to send on outcalls to the specific source
+            pub fn get_user_agent(&self) -> &str {
+                match self {
+                    $(Forex::$name(forex) => forex.get_user_agent()),*,
+                }
+            }
+
             /// This method is used to transform the HTTP response body based on the given payload.
             /// The payload contains additional context for the specific forex to extract the rate.
             pub fn transform_http_response_body(&self, body: &[u8], payload: &[u8]) -> Result<Vec<u8>, TransformHttpResponseError> {
@@ -743,6 +750,12 @@ trait IsForex {
     /// Provides additional HTTP request headers for the specific source
     fn get_additional_http_request_headers(&self) -> Vec<(String, String)> {
         vec![]
+    }
+
+    /// The `User-Agent` to send on outcalls to this source. Defaults to the
+    /// canister-wide value; override it for sources whose endpoint rejects it.
+    fn get_user_agent(&self) -> &str {
+        crate::http::DEFAULT_USER_AGENT
     }
 
     /// Transforms the response body by using the provided payload. The payload contains arguments

--- a/src/xrc/src/forex/australia.rs
+++ b/src/xrc/src/forex/australia.rs
@@ -100,12 +100,12 @@ impl IsForex for ReserveBankOfAustralia {
         10
     }
 
-    fn get_additional_http_request_headers(&self) -> Vec<(String, String)> {
+    fn get_user_agent(&self) -> &str {
         // rba.gov.au's WAF returns HTTP 403 for the canister's default
         // "Exchange Rate Canister" User-Agent (and for browser-like UAs), but
         // accepts a curl-style UA. Override it for this source only so the
         // outcall is not blocked at the edge.
-        vec![("User-Agent".to_string(), "curl/8.0".to_string())]
+        "curl/8.0"
     }
 
     fn max_response_bytes(&self) -> u64 {
@@ -156,10 +156,7 @@ mod test {
     #[test]
     fn user_agent_override() {
         let forex = Forex::ReserveBankOfAustralia(ReserveBankOfAustralia);
-        assert_eq!(
-            forex.get_additional_http_request_headers(),
-            vec![("User-Agent".to_string(), "curl/8.0".to_string())]
-        );
+        assert_eq!(forex.get_user_agent(), "curl/8.0");
     }
 
     /// The function tests if the [ReserveBankOfAustralia] struct returns the correct forex rate.

--- a/src/xrc/src/forex/australia.rs
+++ b/src/xrc/src/forex/australia.rs
@@ -100,6 +100,14 @@ impl IsForex for ReserveBankOfAustralia {
         10
     }
 
+    fn get_additional_http_request_headers(&self) -> Vec<(String, String)> {
+        // rba.gov.au's WAF returns HTTP 403 for the canister's default
+        // "Exchange Rate Canister" User-Agent (and for browser-like UAs), but
+        // accepts a curl-style UA. Override it for this source only so the
+        // outcall is not blocked at the edge. See DEFI-2860.
+        vec![("User-Agent".to_string(), "curl/8.0".to_string())]
+    }
+
     fn max_response_bytes(&self) -> u64 {
         500 * ONE_KIB
     }
@@ -141,6 +149,17 @@ mod test {
     fn max_response_bytes() {
         let forex = Forex::ReserveBankOfAustralia(ReserveBankOfAustralia);
         assert_eq!(forex.max_response_bytes(), 500 * ONE_KIB);
+    }
+
+    /// This function tests that [ReserveBankOfAustralia] overrides the default
+    /// User-Agent with a curl-style one that the RBA WAF accepts (DEFI-2860).
+    #[test]
+    fn user_agent_override() {
+        let forex = Forex::ReserveBankOfAustralia(ReserveBankOfAustralia);
+        assert_eq!(
+            forex.get_additional_http_request_headers(),
+            vec![("User-Agent".to_string(), "curl/8.0".to_string())]
+        );
     }
 
     /// The function tests if the [ReserveBankOfAustralia] struct returns the correct forex rate.

--- a/src/xrc/src/forex/australia.rs
+++ b/src/xrc/src/forex/australia.rs
@@ -104,7 +104,7 @@ impl IsForex for ReserveBankOfAustralia {
         // rba.gov.au's WAF returns HTTP 403 for the canister's default
         // "Exchange Rate Canister" User-Agent (and for browser-like UAs), but
         // accepts a curl-style UA. Override it for this source only so the
-        // outcall is not blocked at the edge. See DEFI-2860.
+        // outcall is not blocked at the edge.
         vec![("User-Agent".to_string(), "curl/8.0".to_string())]
     }
 
@@ -152,7 +152,7 @@ mod test {
     }
 
     /// This function tests that [ReserveBankOfAustralia] overrides the default
-    /// User-Agent with a curl-style one that the RBA WAF accepts (DEFI-2860).
+    /// User-Agent with a curl-style one that the RBA WAF accepts.
     #[test]
     fn user_agent_override() {
         let forex = Forex::ReserveBankOfAustralia(ReserveBankOfAustralia);

--- a/src/xrc/src/http.rs
+++ b/src/xrc/src/http.rs
@@ -134,37 +134,46 @@ impl CanisterHttpRequest {
 mod test {
     use super::*;
 
+    /// Collects the values of every header whose name matches `name`
+    /// (case-insensitive). Lets tests assert by header name instead of relying
+    /// on the position or total count of headers, and confines the deprecated
+    /// field access to one place.
+    fn header_values(request: &CanisterHttpRequest, name: &str) -> Vec<String> {
+        // TODO(DEFI-2648): Migrate to non-deprecated.
+        #[allow(deprecated)]
+        request
+            .args
+            .headers
+            .iter()
+            .filter(|header| header.name.eq_ignore_ascii_case(name))
+            .map(|header| header.value.clone())
+            .collect()
+    }
+
     /// A new request carries the default `User-Agent` header.
     #[test]
     fn default_user_agent() {
         let request = CanisterHttpRequest::new();
-        // TODO(DEFI-2648): Migrate to non-deprecated.
-        #[allow(deprecated)]
-        let headers = &request.args.headers;
-        assert_eq!(headers.len(), 1);
-        // TODO(DEFI-2648): Migrate to non-deprecated.
-        #[allow(deprecated)]
-        {
-            assert_eq!(headers[0].name, "User-Agent");
-            assert_eq!(headers[0].value, "Exchange Rate Canister");
-        }
+        assert_eq!(
+            header_values(&request, "User-Agent"),
+            vec!["Exchange Rate Canister".to_string()]
+        );
     }
 
-    /// `add_headers` appends headers whose name is not already present.
+    /// `add_headers` appends a header whose name is not already present, leaving
+    /// the default `User-Agent` in place.
     #[test]
     fn add_headers_appends_new_header() {
         let request = CanisterHttpRequest::new()
             .add_headers(vec![("Accept".to_string(), "application/json".to_string())]);
-        // TODO(DEFI-2648): Migrate to non-deprecated.
-        #[allow(deprecated)]
-        let headers = &request.args.headers;
-        assert_eq!(headers.len(), 2);
-        // TODO(DEFI-2648): Migrate to non-deprecated.
-        #[allow(deprecated)]
-        {
-            assert_eq!(headers[1].name, "Accept");
-            assert_eq!(headers[1].value, "application/json");
-        }
+        assert_eq!(
+            header_values(&request, "Accept"),
+            vec!["application/json".to_string()]
+        );
+        assert_eq!(
+            header_values(&request, "User-Agent"),
+            vec!["Exchange Rate Canister".to_string()]
+        );
     }
 
     /// `add_headers` replaces a header with a matching (case-insensitive) name
@@ -174,15 +183,10 @@ mod test {
     fn add_headers_replaces_existing_header() {
         let request = CanisterHttpRequest::new()
             .add_headers(vec![("user-agent".to_string(), "curl/8.0".to_string())]);
-        // TODO(DEFI-2648): Migrate to non-deprecated.
-        #[allow(deprecated)]
-        let headers = &request.args.headers;
-        assert_eq!(headers.len(), 1);
-        // TODO(DEFI-2648): Migrate to non-deprecated.
-        #[allow(deprecated)]
-        {
-            assert_eq!(headers[0].name, "User-Agent");
-            assert_eq!(headers[0].value, "curl/8.0");
-        }
+        // Exactly one `User-Agent` header remains, carrying the new value.
+        assert_eq!(
+            header_values(&request, "User-Agent"),
+            vec!["curl/8.0".to_string()]
+        );
     }
 }

--- a/src/xrc/src/http.rs
+++ b/src/xrc/src/http.rs
@@ -10,6 +10,10 @@ use ic_cdk::{
     },
 };
 
+/// The `User-Agent` sent on every outcall unless a source overrides it via
+/// [`CanisterHttpRequest::user_agent`].
+pub(crate) const DEFAULT_USER_AGENT: &str = "Exchange Rate Canister";
+
 /// Used to build a request to the Management Canister's `http_request` method.
 // TODO(DEFI-2648): Migrate to non-deprecated.
 #[allow(deprecated)]
@@ -36,7 +40,7 @@ impl CanisterHttpRequest {
                 max_response_bytes: Default::default(),
                 headers: vec![HttpHeader {
                     name: "User-Agent".to_string(),
-                    value: "Exchange Rate Canister".to_string(),
+                    value: DEFAULT_USER_AGENT.to_string(),
                 }],
                 body: Default::default(),
                 // TODO(DEFI-2648): Migrate to non-deprecated.
@@ -62,22 +66,35 @@ impl CanisterHttpRequest {
         self
     }
 
-    /// Adds HTTP headers for the request, replacing any existing header with
-    /// the same (case-insensitive) name. This lets a source override a default
-    /// header such as the `User-Agent` set in [`CanisterHttpRequest::new`].
+    /// Adds HTTP headers for the request.
     pub fn add_headers(mut self, headers: Vec<(String, String)>) -> Self {
-        for (name, value) in headers {
-            // TODO(DEFI-2648): Migrate to non-deprecated.
-            #[allow(deprecated)]
-            match self
-                .args
-                .headers
-                .iter_mut()
-                .find(|header| header.name.eq_ignore_ascii_case(&name))
-            {
-                Some(header) => header.value = value,
-                None => self.args.headers.push(HttpHeader { name, value }),
-            }
+        // TODO(DEFI-2648): Migrate to non-deprecated.
+        #[allow(deprecated)]
+        self.args.headers.extend(
+            headers
+                .into_iter()
+                .map(|(name, value)| HttpHeader { name, value }),
+        );
+        self
+    }
+
+    /// Sets the `User-Agent` header for the request, overriding the default set
+    /// in [`CanisterHttpRequest::new`]. `User-Agent` is a singleton header, so
+    /// this replaces the single value rather than appending another field.
+    pub fn user_agent(mut self, user_agent: &str) -> Self {
+        // TODO(DEFI-2648): Migrate to non-deprecated.
+        #[allow(deprecated)]
+        match self
+            .args
+            .headers
+            .iter_mut()
+            .find(|header| header.name.eq_ignore_ascii_case("User-Agent"))
+        {
+            Some(header) => header.value = user_agent.to_string(),
+            None => self.args.headers.push(HttpHeader {
+                name: "User-Agent".to_string(),
+                value: user_agent.to_string(),
+            }),
         }
         self
     }
@@ -176,14 +193,11 @@ mod test {
         );
     }
 
-    /// `add_headers` replaces a header with a matching (case-insensitive) name
-    /// rather than appending a duplicate, so a source can override the default
-    /// `User-Agent`.
+    /// `user_agent` overrides the default `User-Agent` in place, leaving exactly
+    /// one `User-Agent` header that carries the new value.
     #[test]
-    fn add_headers_replaces_existing_header() {
-        let request = CanisterHttpRequest::new()
-            .add_headers(vec![("user-agent".to_string(), "curl/8.0".to_string())]);
-        // Exactly one `User-Agent` header remains, carrying the new value.
+    fn user_agent_overrides_default() {
+        let request = CanisterHttpRequest::new().user_agent("curl/8.0");
         assert_eq!(
             header_values(&request, "User-Agent"),
             vec!["curl/8.0".to_string()]

--- a/src/xrc/src/http.rs
+++ b/src/xrc/src/http.rs
@@ -132,6 +132,10 @@ impl CanisterHttpRequest {
 
 #[cfg(test)]
 mod test {
+    // The tests below read the deprecated `args.headers` / `HttpHeader` fields.
+    // TODO(DEFI-2648): Migrate to non-deprecated.
+    #![allow(deprecated)]
+
     use super::*;
 
     /// A new request carries the default `User-Agent` header.

--- a/src/xrc/src/http.rs
+++ b/src/xrc/src/http.rs
@@ -135,42 +135,54 @@ mod test {
     use super::*;
 
     /// A new request carries the default `User-Agent` header.
-    // TODO(DEFI-2648): Migrate to non-deprecated.
-    #[allow(deprecated)]
     #[test]
     fn default_user_agent() {
         let request = CanisterHttpRequest::new();
+        // TODO(DEFI-2648): Migrate to non-deprecated.
+        #[allow(deprecated)]
         let headers = &request.args.headers;
         assert_eq!(headers.len(), 1);
-        assert_eq!(headers[0].name, "User-Agent");
-        assert_eq!(headers[0].value, "Exchange Rate Canister");
+        // TODO(DEFI-2648): Migrate to non-deprecated.
+        #[allow(deprecated)]
+        {
+            assert_eq!(headers[0].name, "User-Agent");
+            assert_eq!(headers[0].value, "Exchange Rate Canister");
+        }
     }
 
     /// `add_headers` appends headers whose name is not already present.
-    // TODO(DEFI-2648): Migrate to non-deprecated.
-    #[allow(deprecated)]
     #[test]
     fn add_headers_appends_new_header() {
         let request = CanisterHttpRequest::new()
             .add_headers(vec![("Accept".to_string(), "application/json".to_string())]);
+        // TODO(DEFI-2648): Migrate to non-deprecated.
+        #[allow(deprecated)]
         let headers = &request.args.headers;
         assert_eq!(headers.len(), 2);
-        assert_eq!(headers[1].name, "Accept");
-        assert_eq!(headers[1].value, "application/json");
+        // TODO(DEFI-2648): Migrate to non-deprecated.
+        #[allow(deprecated)]
+        {
+            assert_eq!(headers[1].name, "Accept");
+            assert_eq!(headers[1].value, "application/json");
+        }
     }
 
     /// `add_headers` replaces a header with a matching (case-insensitive) name
     /// rather than appending a duplicate, so a source can override the default
     /// `User-Agent`.
-    // TODO(DEFI-2648): Migrate to non-deprecated.
-    #[allow(deprecated)]
     #[test]
     fn add_headers_replaces_existing_header() {
         let request = CanisterHttpRequest::new()
             .add_headers(vec![("user-agent".to_string(), "curl/8.0".to_string())]);
+        // TODO(DEFI-2648): Migrate to non-deprecated.
+        #[allow(deprecated)]
         let headers = &request.args.headers;
         assert_eq!(headers.len(), 1);
-        assert_eq!(headers[0].name, "User-Agent");
-        assert_eq!(headers[0].value, "curl/8.0");
+        // TODO(DEFI-2648): Migrate to non-deprecated.
+        #[allow(deprecated)]
+        {
+            assert_eq!(headers[0].name, "User-Agent");
+            assert_eq!(headers[0].value, "curl/8.0");
+        }
     }
 }

--- a/src/xrc/src/http.rs
+++ b/src/xrc/src/http.rs
@@ -132,13 +132,11 @@ impl CanisterHttpRequest {
 
 #[cfg(test)]
 mod test {
-    // The tests below read the deprecated `args.headers` / `HttpHeader` fields.
-    // TODO(DEFI-2648): Migrate to non-deprecated.
-    #![allow(deprecated)]
-
     use super::*;
 
     /// A new request carries the default `User-Agent` header.
+    // TODO(DEFI-2648): Migrate to non-deprecated.
+    #[allow(deprecated)]
     #[test]
     fn default_user_agent() {
         let request = CanisterHttpRequest::new();
@@ -149,6 +147,8 @@ mod test {
     }
 
     /// `add_headers` appends headers whose name is not already present.
+    // TODO(DEFI-2648): Migrate to non-deprecated.
+    #[allow(deprecated)]
     #[test]
     fn add_headers_appends_new_header() {
         let request = CanisterHttpRequest::new()
@@ -162,6 +162,8 @@ mod test {
     /// `add_headers` replaces a header with a matching (case-insensitive) name
     /// rather than appending a duplicate, so a source can override the default
     /// `User-Agent`.
+    // TODO(DEFI-2648): Migrate to non-deprecated.
+    #[allow(deprecated)]
     #[test]
     fn add_headers_replaces_existing_header() {
         let request = CanisterHttpRequest::new()

--- a/src/xrc/src/http.rs
+++ b/src/xrc/src/http.rs
@@ -62,16 +62,23 @@ impl CanisterHttpRequest {
         self
     }
 
-    /// Adds HTTP headers for the request
+    /// Adds HTTP headers for the request, replacing any existing header with
+    /// the same (case-insensitive) name. This lets a source override a default
+    /// header such as the `User-Agent` set in [`CanisterHttpRequest::new`].
     pub fn add_headers(mut self, headers: Vec<(String, String)>) -> Self {
-        // TODO(DEFI-2648): Migrate to non-deprecated.
-        #[allow(deprecated)]
-        self.args
-            .headers
-            .extend(headers.iter().map(|(name, value)| HttpHeader {
-                name: name.to_string(),
-                value: value.to_string(),
-            }));
+        for (name, value) in headers {
+            // TODO(DEFI-2648): Migrate to non-deprecated.
+            #[allow(deprecated)]
+            match self
+                .args
+                .headers
+                .iter_mut()
+                .find(|header| header.name.eq_ignore_ascii_case(&name))
+            {
+                Some(header) => header.value = value,
+                None => self.args.headers.push(HttpHeader { name, value }),
+            }
+        }
         self
     }
 
@@ -120,5 +127,44 @@ impl CanisterHttpRequest {
             .await
             .map(|(response,)| response)
             .map_err(|(_rejection_code, message)| message)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// A new request carries the default `User-Agent` header.
+    #[test]
+    fn default_user_agent() {
+        let request = CanisterHttpRequest::new();
+        let headers = &request.args.headers;
+        assert_eq!(headers.len(), 1);
+        assert_eq!(headers[0].name, "User-Agent");
+        assert_eq!(headers[0].value, "Exchange Rate Canister");
+    }
+
+    /// `add_headers` appends headers whose name is not already present.
+    #[test]
+    fn add_headers_appends_new_header() {
+        let request = CanisterHttpRequest::new()
+            .add_headers(vec![("Accept".to_string(), "application/json".to_string())]);
+        let headers = &request.args.headers;
+        assert_eq!(headers.len(), 2);
+        assert_eq!(headers[1].name, "Accept");
+        assert_eq!(headers[1].value, "application/json");
+    }
+
+    /// `add_headers` replaces a header with a matching (case-insensitive) name
+    /// rather than appending a duplicate, so a source can override the default
+    /// `User-Agent`.
+    #[test]
+    fn add_headers_replaces_existing_header() {
+        let request = CanisterHttpRequest::new()
+            .add_headers(vec![("user-agent".to_string(), "curl/8.0".to_string())]);
+        let headers = &request.args.headers;
+        assert_eq!(headers.len(), 1);
+        assert_eq!(headers[0].name, "User-Agent");
+        assert_eq!(headers[0].value, "curl/8.0");
     }
 }

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -1029,6 +1029,7 @@ async fn call_forex(forex: &Forex, args: ForexContextArgs) -> Result<ForexRateMa
         .transform_context("transform_forex_http_response", context)
         .max_response_bytes(forex.max_response_bytes())
         .add_headers(forex.get_additional_http_request_headers())
+        .user_agent(forex.get_user_agent())
         .cycles(cycles)
         .send()
         .await


### PR DESCRIPTION
## Purpose

`IC_XRC_ForexSourceSilent` has been firing for `ReserveBankOfAustralia`: zero successful forex fetches since the last upgrade, while every other forex source is healthy.

The cause is at the HTTP edge, not response size. The rba.gov.au WAF returns HTTP 403 for the canister's default `User-Agent: "Exchange Rate Canister"` (and for browser-like UAs, and for a request with no `User-Agent` header at all), but accepts a plain `curl`-style UA. Every outcall is therefore rejected with 403 → `http_error`, no successes.

This PR overrides the User-Agent for `ReserveBankOfAustralia` only, so the other sources keep using the default UA they already work with. Because `User-Agent` is a singleton header, it gets a first-class per-source override path on the forex trait rather than being routed through the general additional-headers hook.

## Caveat — verify on-subnet

The accepted UA was confirmed only from a single developer machine, not the 13-replica subnet that performs the real outcall, and WAFs can also key on source IP / request fingerprint. The chosen UA must be confirmed to produce successful fetches from the canister (`xrc_forex_fetch_total` success advancing) before closing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
