### PR TITLE
fix: DEFI-2865: skip Coinbase for delisted ICP-USDT pair

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"17a1bd8a-8dde-4765-9b86-09bf1fb5a9e9","pid":2500205,"procStart":"155558557","acquiredAt":1780911307693}

--- a/src/xrc-tests/src/tests/basic_exchange_rates.rs
+++ b/src/xrc-tests/src/tests/basic_exchange_rates.rs
@@ -108,12 +108,14 @@ fn basic_exchange_rates() {
         assert_eq!(exchange_rate.base_asset, crypto_pair_request.base_asset);
         assert_eq!(exchange_rate.quote_asset, crypto_pair_request.quote_asset);
         assert_eq!(exchange_rate.timestamp, timestamp_seconds);
-        assert_eq!(exchange_rate.metadata.base_asset_num_queried_sources, 9);
-        assert_eq!(exchange_rate.metadata.base_asset_num_received_rates, 9);
+        // Coinbase is skipped for ICP (delisted ICP-USDT), so ICP is sourced
+        // from 8 exchanges; BTC (the quote) is still sourced from 9.
+        assert_eq!(exchange_rate.metadata.base_asset_num_queried_sources, 8);
+        assert_eq!(exchange_rate.metadata.base_asset_num_received_rates, 8);
         assert_eq!(exchange_rate.metadata.quote_asset_num_queried_sources, 9);
         assert_eq!(exchange_rate.metadata.quote_asset_num_received_rates, 9);
-        assert_eq!(exchange_rate.metadata.standard_deviation, 3_178_330);
-        assert_eq!(exchange_rate.rate, 88_813_559);
+        assert_eq!(exchange_rate.metadata.standard_deviation, 3_195_166);
+        assert_eq!(exchange_rate.rate, 88_838_596);
 
         // Crypto-fiat pair
         let crypto_fiat_pair_request = GetExchangeRateRequest {

--- a/src/xrc-tests/src/tests/caching.rs
+++ b/src/xrc-tests/src/tests/caching.rs
@@ -79,14 +79,16 @@ fn caching() {
             class: AssetClass::Cryptocurrency,
         },
         timestamp: timestamp_seconds,
-        rate: 88_813_559,
+        // Coinbase is skipped for ICP (its ICP-USDT market is delisted), so ICP
+        // is sourced from 8 exchanges rather than 9.
+        rate: 88_838_596,
         metadata: ExchangeRateMetadata {
             decimals: 9,
-            base_asset_num_queried_sources: 9,
-            base_asset_num_received_rates: 9,
+            base_asset_num_queried_sources: 8,
+            base_asset_num_received_rates: 8,
             quote_asset_num_queried_sources: 9,
             quote_asset_num_received_rates: 9,
-            standard_deviation: 3_178_330,
+            standard_deviation: 3_195_166,
             forex_timestamp: None,
         },
     };

--- a/src/xrc-tests/src/tests/get_icp_xdr_rate.rs
+++ b/src/xrc-tests/src/tests/get_icp_xdr_rate.rs
@@ -122,11 +122,12 @@ fn get_icp_xdr_rate() {
         assert_eq!(exchange_rate.timestamp, request_1_timestamp_seconds);
         assert_eq!(
             exchange_rate.metadata.base_asset_num_queried_sources,
-            NUM_EXCHANGES
+            // Coinbase is skipped for ICP (delisted ICP-USDT).
+            NUM_EXCHANGES - 1
         );
         assert_eq!(
             exchange_rate.metadata.base_asset_num_received_rates,
-            NUM_EXCHANGES
+            NUM_EXCHANGES - 1
         );
         assert_eq!(
             exchange_rate.metadata.quote_asset_num_queried_sources,
@@ -136,8 +137,8 @@ fn get_icp_xdr_rate() {
             exchange_rate.metadata.quote_asset_num_received_rates,
             NUM_FOREX_SOURCES
         );
-        assert_eq!(exchange_rate.metadata.standard_deviation, 83_532_932);
-        assert_eq!(exchange_rate.rate, 2_996_307_816);
+        assert_eq!(exchange_rate.metadata.standard_deviation, 84_155_954);
+        assert_eq!(exchange_rate.rate, 3_002_150_263);
 
         let request = GetExchangeRateRequest {
             base_asset: Asset {
@@ -160,11 +161,12 @@ fn get_icp_xdr_rate() {
         assert_eq!(exchange_rate.timestamp, request_2_timestamp_seconds);
         assert_eq!(
             exchange_rate.metadata.base_asset_num_queried_sources,
-            NUM_EXCHANGES
+            // Coinbase is skipped for ICP (delisted ICP-USDT).
+            NUM_EXCHANGES - 1
         );
         assert_eq!(
             exchange_rate.metadata.base_asset_num_received_rates,
-            NUM_EXCHANGES
+            NUM_EXCHANGES - 1
         );
         assert_eq!(
             exchange_rate.metadata.quote_asset_num_queried_sources,
@@ -174,8 +176,8 @@ fn get_icp_xdr_rate() {
             exchange_rate.metadata.quote_asset_num_received_rates,
             NUM_FOREX_SOURCES
         );
-        assert_eq!(exchange_rate.metadata.standard_deviation, 91_482_333);
-        assert_eq!(exchange_rate.rate, 3_264_974_572);
+        assert_eq!(exchange_rate.metadata.standard_deviation, 92_202_640);
+        assert_eq!(exchange_rate.rate, 3_258_140_904);
 
         let request = GetExchangeRateRequest {
             base_asset: Asset {
@@ -198,11 +200,12 @@ fn get_icp_xdr_rate() {
         assert_eq!(exchange_rate.timestamp, request_3_timestamp_seconds);
         assert_eq!(
             exchange_rate.metadata.base_asset_num_queried_sources,
-            NUM_EXCHANGES
+            // Coinbase is skipped for ICP (delisted ICP-USDT).
+            NUM_EXCHANGES - 1
         );
         assert_eq!(
             exchange_rate.metadata.base_asset_num_received_rates,
-            NUM_EXCHANGES
+            NUM_EXCHANGES - 1
         );
         assert_eq!(
             exchange_rate.metadata.quote_asset_num_queried_sources,
@@ -212,8 +215,8 @@ fn get_icp_xdr_rate() {
             exchange_rate.metadata.quote_asset_num_received_rates,
             NUM_FOREX_SOURCES
         );
-        assert_eq!(exchange_rate.metadata.standard_deviation, 105_527_708);
-        assert_eq!(exchange_rate.rate, 3_935_225_747);
+        assert_eq!(exchange_rate.metadata.standard_deviation, 105_869_536);
+        assert_eq!(exchange_rate.rate, 3_941_783_545);
 
         Ok(())
     })

--- a/src/xrc-tests/src/tests/metrics_endpoint.rs
+++ b/src/xrc-tests/src/tests/metrics_endpoint.rs
@@ -114,11 +114,14 @@ fn metrics_endpoint_exposes_all_labeled_series() {
         // outcome}` label set so a regression that silently drops or renames
         // one of those label keys fails the test instead of slipping through
         // on a name-only prefix match.
+        // Use Okx as the healthy crypto exchange: Coinbase is intentionally not
+        // queried for ICP (its ICP-USDT market is delisted), so it has no crypto
+        // fetch outcome for this request.
         assert!(
             body.contains(
-                r#"xrc_exchange_fetch_total{exchange="Coinbase",kind="crypto",outcome="success"}"#
+                r#"xrc_exchange_fetch_total{exchange="Okx",kind="crypto",outcome="success"}"#
             ),
-            "missing Coinbase crypto success series\n{body}"
+            "missing Okx crypto success series\n{body}"
         );
         let kucoin_failure_line = body.lines().find(|line| {
             line.starts_with(r#"xrc_exchange_fetch_total{exchange="KuCoin","#)

--- a/src/xrc-tests/src/tests/misbehavior.rs
+++ b/src/xrc-tests/src/tests/misbehavior.rs
@@ -165,8 +165,10 @@ fn misbehavior() {
             rate: 87_023_595,
             metadata: ExchangeRateMetadata {
                 decimals: 9,
-                base_asset_num_queried_sources: NUM_EXCHANGES,
-                base_asset_num_received_rates: NUM_EXCHANGES,
+                // Coinbase is skipped for ICP (delisted ICP-USDT), so the ICP
+                // base is sourced from one fewer exchange.
+                base_asset_num_queried_sources: NUM_EXCHANGES - 1,
+                base_asset_num_received_rates: NUM_EXCHANGES - 1,
                 quote_asset_num_queried_sources: NUM_EXCHANGES,
                 quote_asset_num_received_rates: NUM_EXCHANGES,
                 standard_deviation: 3_644_799,

--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -66,6 +66,19 @@ impl CallExchanges for CallExchangesImpl {
         asset: &Asset,
         timestamp: u64,
     ) -> Result<QueriedExchangeRateWithFailedExchanges, CallExchangeError> {
+        // Skip exchanges that have no usable USDT market for this base asset
+        // (e.g. Coinbase's delisted ICP-USDT), so they are neither queried nor
+        // counted as a queried source.
+        let exchanges: Vec<&Exchange> = exchanges
+            .iter()
+            .copied()
+            .filter(|exchange| {
+                !exchange
+                    .unsupported_usdt_base_assets()
+                    .iter()
+                    .any(|symbol| symbol.eq_ignore_ascii_case(&asset.symbol))
+            })
+            .collect();
         let futures = exchanges.iter().map(|exchange| {
             call_exchange(
                 exchange,

--- a/src/xrc/src/exchanges.rs
+++ b/src/xrc/src/exchanges.rs
@@ -91,6 +91,13 @@ macro_rules! exchanges {
                 }
             }
 
+            /// This method lists base assets the exchange cannot serve against USDT.
+            pub fn unsupported_usdt_base_assets(&self) -> &[&str] {
+                match self {
+                    $(Exchange::$name(exchange) => exchange.unsupported_usdt_base_assets()),*,
+                }
+            }
+
             /// Encodes the context in relation to the current exchange.
             pub fn encode_context(&self) -> Result<Vec<u8>, CandidError> {
                 let index = self.get_index();
@@ -236,6 +243,14 @@ trait IsExchange {
         &[(USDS, USDT), (USDC, USDT)]
     }
 
+    /// Base assets for which this exchange has no usable USDT market and that
+    /// must be skipped — e.g. a delisted pair whose candle fetch would always
+    /// fail. Compared case-insensitively against the requested base asset.
+    /// Default: none.
+    fn unsupported_usdt_base_assets(&self) -> &[&str] {
+        &[]
+    }
+
     fn max_response_bytes(&self) -> u64 {
         3 * ONE_KIB
     }
@@ -303,6 +318,14 @@ impl IsExchange for Coinbase {
 
     fn supported_stablecoin_pairs(&self) -> &[(&str, &str)] {
         &[(USDT, USDC)]
+    }
+
+    fn unsupported_usdt_base_assets(&self) -> &[&str] {
+        // Coinbase delisted ICP-USDT (its candles endpoint returns an empty
+        // array), while its liquid ICP market is ICP-USD. The crypto path
+        // quotes in USDT, so skip ICP on Coinbase rather than querying a
+        // delisted pair that always fails the fetch.
+        &["ICP"]
     }
 }
 
@@ -747,6 +770,22 @@ mod test {
         assert_eq!(bitget.supported_usd_asset(), usdt_asset());
         let digifinex = Digifinex;
         assert_eq!(digifinex.supported_usd_asset(), usdt_asset());
+    }
+
+    /// Only Coinbase skips a base asset (delisted ICP-USDT); the rest serve
+    /// every base asset against USDT.
+    #[test]
+    fn unsupported_usdt_base_assets() {
+        assert_eq!(
+            Exchange::Coinbase(Coinbase).unsupported_usdt_base_assets(),
+            &["ICP"]
+        );
+        for exchange in EXCHANGES.iter().filter(|e| !matches!(e, Exchange::Coinbase(_))) {
+            assert!(
+                exchange.unsupported_usdt_base_assets().is_empty(),
+                "{exchange} should not skip any base asset"
+            );
+        }
     }
 
     /// The function tests if the supported stablecoins are correct.


### PR DESCRIPTION
## Purpose

Coinbase's ICP-USDT market is **delisted** (the product reports `status: delisted` and its candles endpoint returns `[]`), while the crypto path quotes every exchange in USDT. Every ICP request to Coinbase therefore hit a delisted pair and failed — the dominant cause of Coinbase's ~62% production error rate that survived the closed-minute fix (#314). This is not geo/rate-limit (direct probes return HTTP 200 via Cloudflare, no 403/429).

This adds a per-exchange `IsExchange::unsupported_usdt_base_assets` list (default none; Coinbase → `ICP`) and skips those exchanges in `get_cryptocurrency_usdt_rate`, so the delisted pair is neither queried nor counted as a source.

> An earlier revision of this PR queried Coinbase in its liquid USD market instead, but feeding a USD-quoted sample into the base/USDT pool isn't clean — dropping the delisted pair is the honest fix.

ICP retains ~7–8 healthy USDT exchanges (OKX, GateIo, Mexc, CryptoCom, Digifinex, KuCoin, Poloniex, Bitget), well above the 2–3 source minimum (`MIN_NUM_RATES_FOR_PRIVILEGED_CANISTERS`). Coinbase already contributed nothing for ICP (it errored on the delisted pair), so this only stops the noise. The e2e ICP-base source counts and rates are repinned accordingly; all e2e tests pass.

Implements DEFI-2865.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
