### PR TITLE
feat: DEFI-2868: add per-exchange listing parsers for USDT pair discovery

### DIFF
--- a/src/xrc/src/exchanges.rs
+++ b/src/xrc/src/exchanges.rs
@@ -219,6 +219,10 @@ impl ListedMarket {
 ///   guard: it stays roughly stable across refreshes (even when a venue
 ///   migrates USDT→USD, collapsing `bases`), so a sudden drop indicates a
 ///   parser break or a garbage response rather than a legitimate delisting.
+///   Caveat: MEXC's `defaultSymbols` endpoint enumerates only *tradable*
+///   symbols (see the MEXC impl), so there `total_markets` is weaker as a
+///   stability signal — a mass trading suspension would dent it even though the
+///   response is structurally sound.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ListedPairs {
     pub bases: BTreeSet<String>,
@@ -648,7 +652,10 @@ type MexcResponse = Vec<(u64, String, String, String, String, String, u64, Strin
 /// MEXC's `defaultSymbols` lists only tradable symbols as concatenated strings
 /// (e.g. `"BTCUSDT"`) with no separator, so the quote can only be recovered for
 /// the suffixes we care about. Non-USDT symbols are kept (so they count toward
-/// `total_markets`) but cannot be split, so their quote is left unknown.
+/// `total_markets`) but cannot be split, so their quote is left unknown. Note
+/// that because this endpoint omits non-tradable symbols, `total_markets` here
+/// tracks the tradable universe rather than the full listing — a weaker
+/// structural-health signal than for other exchanges (see [ListedPairs]).
 #[derive(Deserialize)]
 struct MexcDefaultSymbols {
     data: Vec<String>,

--- a/src/xrc/src/exchanges.rs
+++ b/src/xrc/src/exchanges.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use candid::{decode_args, encode_args, Deserialize, Error as CandidError};
 
 use ic_xrc_types::Asset;
@@ -67,6 +69,23 @@ macro_rules! exchanges {
             pub fn extract_rate(&self, bytes: &[u8]) -> Result<u64, ExtractError> {
                 match self {
                     $(Exchange::$name(exchange) => exchange.extract_rate(bytes)),*,
+                }
+            }
+
+            /// This method returns the URL of the exchange's public spot-listing
+            /// endpoint (used to discover tradable pairs).
+            pub fn listing_url(&self) -> &str {
+                match self {
+                    $(Exchange::$name(exchange) => exchange.listing_url()),*,
+                }
+            }
+
+            /// This method parses a listing-endpoint response into the set of base
+            /// assets the exchange currently lists against USDT, plus the total
+            /// number of spot markets parsed (see [ListedPairs]).
+            pub fn extract_listed_usdt_bases(&self, bytes: &[u8]) -> Result<ListedPairs, ExtractError> {
+                match self {
+                    $(Exchange::$name(exchange) => exchange.extract_listed_usdt_bases(bytes)),*,
                 }
             }
 
@@ -170,6 +189,75 @@ fn extract_rate<R: DeserializeOwned>(
     Ok((rate * RATE_UNIT as f64) as u64)
 }
 
+/// A single spot market parsed from an exchange's listing endpoint, normalized
+/// across the differing per-exchange schemas.
+struct ListedMarket {
+    /// The base asset symbol, as reported by the exchange.
+    base: String,
+    /// The quote asset symbol, as reported by the exchange.
+    quote: String,
+    /// Whether the market is currently tradable (per the exchange's own status
+    /// field; the rule differs per exchange).
+    tradable: bool,
+}
+
+impl ListedMarket {
+    fn new(base: impl Into<String>, quote: impl Into<String>, tradable: bool) -> Self {
+        Self {
+            base: base.into(),
+            quote: quote.into(),
+            tradable,
+        }
+    }
+}
+
+/// The result of parsing an exchange's listing endpoint:
+/// * `bases` — the base assets currently tradable against USDT, uppercased and
+///   deduplicated. This is the set the crypto path is gated on.
+/// * `total_markets` — the total number of spot markets parsed across all
+///   quotes. This is a structural-health signal for the refresh acceptance
+///   guard: it stays roughly stable across refreshes (even when a venue
+///   migrates USDT→USD, collapsing `bases`), so a sudden drop indicates a
+///   parser break or a garbage response rather than a legitimate delisting.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ListedPairs {
+    pub bases: BTreeSet<String>,
+    pub total_markets: usize,
+}
+
+/// A generic way to extract the listed USDT bases out of the provided bytes,
+/// mirroring [extract_rate]: `markets_fn` projects the deserialized response
+/// down to the exchange's spot markets, then this folds over them in a single
+/// pass — keeping the USDT-quoted tradable bases and counting every market.
+///
+/// Taking an [IntoIterator] (rather than a materialized `Vec`) lets each
+/// exchange stream its markets straight through without an intermediate
+/// allocation, while the USDT/tradable filter, base uppercasing, and
+/// total-market count stay defined in this one place for all exchanges.
+fn extract_listed_pairs<R, M>(
+    bytes: &[u8],
+    markets_fn: impl FnOnce(R) -> M,
+) -> Result<ListedPairs, ExtractError>
+where
+    R: DeserializeOwned,
+    M: IntoIterator<Item = ListedMarket>,
+{
+    let response = serde_json::from_slice::<R>(bytes)
+        .map_err(|err| ExtractError::json_deserialize(bytes, err.to_string()))?;
+    let mut total_markets = 0;
+    let mut bases = BTreeSet::new();
+    for market in markets_fn(response) {
+        total_markets += 1;
+        if market.tradable && market.quote.eq_ignore_ascii_case(USDT) {
+            bases.insert(market.base.to_uppercase());
+        }
+    }
+    Ok(ListedPairs {
+        bases,
+        total_markets,
+    })
+}
+
 /// The base URL may contain the following placeholders:
 /// `BASE_ASSET`: This string must be replaced with the base asset string in the request.
 const BASE_ASSET: &str = "BASE_ASSET";
@@ -222,6 +310,17 @@ trait IsExchange {
     /// The implementation to extract the rate from the response's body.
     fn extract_rate(&self, bytes: &[u8]) -> Result<u64, ExtractError>;
 
+    /// The URL of the exchange's public spot-listing endpoint. Unlike
+    /// [IsExchange::get_base_url] this takes no placeholders — the listing is
+    /// the same for every asset.
+    fn listing_url(&self) -> &str;
+
+    /// Parses the listing endpoint's response body into the set of base assets
+    /// tradable against USDT and the total spot-market count (see
+    /// [ListedPairs]). Implementations project their own schema to a list of
+    /// [ListedMarket] and delegate to [extract_listed_pairs].
+    fn extract_listed_usdt_bases(&self, bytes: &[u8]) -> Result<ListedPairs, ExtractError>;
+
     /// Indicates if the exchange supports IPv6.
     fn supports_ipv6(&self) -> bool {
         false
@@ -267,6 +366,18 @@ type CoinbaseResponse = Vec<(u64, f64, f64, f64, f64, f64)>;
 const COINBASE_CANDLE_END_OFFSET_SEC: u64 = 60;
 const COINBASE_CANDLE_LOOKBACK_SEC: u64 = 6 * 60;
 
+/// A single entry from Coinbase's `/products` listing (only the fields needed
+/// to decide tradability against USDT).
+#[derive(Deserialize)]
+struct CoinbaseProduct {
+    base_currency: String,
+    quote_currency: String,
+    status: String,
+    #[serde(default)]
+    trading_disabled: bool,
+}
+type CoinbaseListing = Vec<CoinbaseProduct>;
+
 impl IsExchange for Coinbase {
     fn get_base_url(&self) -> &str {
         "https://api.exchange.coinbase.com/products/BASE_ASSET-QUOTE_ASSET/candles?granularity=60&start=START_TIME&end=END_TIME"
@@ -293,6 +404,19 @@ impl IsExchange for Coinbase {
         })
     }
 
+    fn listing_url(&self) -> &str {
+        "https://api.exchange.coinbase.com/products"
+    }
+
+    fn extract_listed_usdt_bases(&self, bytes: &[u8]) -> Result<ListedPairs, ExtractError> {
+        extract_listed_pairs(bytes, |products: CoinbaseListing| {
+            products.into_iter().map(|product| {
+                let tradable = product.status == "online" && !product.trading_disabled;
+                ListedMarket::new(product.base_currency, product.quote_currency, tradable)
+            })
+        })
+    }
+
     fn supports_ipv6(&self) -> bool {
         true
     }
@@ -312,6 +436,18 @@ struct KuCoinResponse {
     data: Vec<(String, String, String, String, String, String, String)>,
 }
 
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct KuCoinSymbol {
+    base_currency: String,
+    quote_currency: String,
+    enable_trading: bool,
+}
+#[derive(Deserialize)]
+struct KuCoinSymbolsResponse {
+    data: Vec<KuCoinSymbol>,
+}
+
 impl IsExchange for KuCoin {
     fn get_base_url(&self) -> &str {
         "https://api.kucoin.com/api/v1/market/candles?symbol=BASE_ASSET-QUOTE_ASSET&type=1min&startAt=START_TIME&endAt=END_TIME"
@@ -328,6 +464,22 @@ impl IsExchange for KuCoin {
                 .data
                 .first()
                 .map(|kline| ExtractedValue::Str(kline.1.clone()))
+        })
+    }
+
+    fn listing_url(&self) -> &str {
+        "https://api.kucoin.com/api/v1/symbols"
+    }
+
+    fn extract_listed_usdt_bases(&self, bytes: &[u8]) -> Result<ListedPairs, ExtractError> {
+        extract_listed_pairs(bytes, |response: KuCoinSymbolsResponse| {
+            response.data.into_iter().map(|symbol| {
+                ListedMarket::new(
+                    symbol.base_currency,
+                    symbol.quote_currency,
+                    symbol.enable_trading,
+                )
+            })
         })
     }
 
@@ -365,6 +517,18 @@ struct OkxResponse {
     data: Vec<OkxResponseDataEntry>,
 }
 
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OkxInstrument {
+    base_ccy: String,
+    quote_ccy: String,
+    state: String,
+}
+#[derive(Deserialize)]
+struct OkxInstrumentsResponse {
+    data: Vec<OkxInstrument>,
+}
+
 impl IsExchange for Okx {
     fn get_base_url(&self) -> &str {
         // Counterintuitively, "after" specifies the end time, and "before" specifies the start time.
@@ -396,6 +560,22 @@ impl IsExchange for Okx {
         })
     }
 
+    fn listing_url(&self) -> &str {
+        "https://www.okx.com/api/v5/public/instruments?instType=SPOT"
+    }
+
+    fn extract_listed_usdt_bases(&self, bytes: &[u8]) -> Result<ListedPairs, ExtractError> {
+        extract_listed_pairs(bytes, |response: OkxInstrumentsResponse| {
+            response.data.into_iter().map(|instrument| {
+                ListedMarket::new(
+                    instrument.base_ccy,
+                    instrument.quote_ccy,
+                    instrument.state == "live",
+                )
+            })
+        })
+    }
+
     fn supports_ipv6(&self) -> bool {
         true
     }
@@ -413,6 +593,14 @@ type GateIoResponse = Vec<(
     String,
 )>;
 
+#[derive(Deserialize)]
+struct GateIoPair {
+    base: String,
+    quote: String,
+    trade_status: String,
+}
+type GateIoListing = Vec<GateIoPair>;
+
 impl IsExchange for GateIo {
     fn get_base_url(&self) -> &str {
         "https://api.gateio.ws/api/v4/spot/candlesticks?currency_pair=BASE_ASSET_QUOTE_ASSET&interval=1m&from=START_TIME&to=END_TIME"
@@ -423,6 +611,18 @@ impl IsExchange for GateIo {
             response
                 .first()
                 .map(|kline| ExtractedValue::Str(kline.3.clone()))
+        })
+    }
+
+    fn listing_url(&self) -> &str {
+        "https://api.gateio.ws/api/v4/spot/currency_pairs"
+    }
+
+    fn extract_listed_usdt_bases(&self, bytes: &[u8]) -> Result<ListedPairs, ExtractError> {
+        extract_listed_pairs(bytes, |pairs: GateIoListing| {
+            pairs
+                .into_iter()
+                .map(|pair| ListedMarket::new(pair.base, pair.quote, pair.trade_status == "tradable"))
         })
     }
 }
@@ -445,6 +645,15 @@ impl IsExchange for GateIo {
 #[allow(clippy::type_complexity)]
 type MexcResponse = Vec<(u64, String, String, String, String, String, u64, String)>;
 
+/// MEXC's `defaultSymbols` lists only tradable symbols as concatenated strings
+/// (e.g. `"BTCUSDT"`) with no separator, so the quote can only be recovered for
+/// the suffixes we care about. Non-USDT symbols are kept (so they count toward
+/// `total_markets`) but cannot be split, so their quote is left unknown.
+#[derive(Deserialize)]
+struct MexcDefaultSymbols {
+    data: Vec<String>,
+}
+
 impl IsExchange for Mexc {
     fn get_base_url(&self) -> &str {
         "https://api.mexc.com/api/v3/klines?symbol=BASE_ASSETQUOTE_ASSET&interval=1m&startTime=START_TIME&limit=1"
@@ -455,6 +664,24 @@ impl IsExchange for Mexc {
             response
                 .first()
                 .map(|kline| ExtractedValue::Str(kline.1.clone()))
+        })
+    }
+
+    fn listing_url(&self) -> &str {
+        "https://api.mexc.com/api/v3/defaultSymbols"
+    }
+
+    fn extract_listed_usdt_bases(&self, bytes: &[u8]) -> Result<ListedPairs, ExtractError> {
+        extract_listed_pairs(bytes, |response: MexcDefaultSymbols| {
+            response
+                .data
+                .into_iter()
+                .map(|symbol| match symbol.strip_suffix(USDT) {
+                    Some(base) if !base.is_empty() => ListedMarket::new(base, USDT, true),
+                    // Non-USDT symbol: keep it for the total-markets count, but
+                    // the base/quote cannot be split, so mark the quote unknown.
+                    _ => ListedMarket::new(symbol, "", true),
+                })
         })
     }
 }
@@ -478,6 +705,15 @@ type PoloniexResponse = Vec<(
     u64,
 )>;
 
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PoloniexMarket {
+    base_currency_name: String,
+    quote_currency_name: String,
+    state: String,
+}
+type PoloniexListing = Vec<PoloniexMarket>;
+
 impl IsExchange for Poloniex {
     fn get_base_url(&self) -> &str {
         "https://api.poloniex.com/markets/BASE_ASSET_QUOTE_ASSET/candles?interval=MINUTE_1&startTime=START_TIME&endTime=END_TIME"
@@ -498,6 +734,22 @@ impl IsExchange for Poloniex {
             response
                 .first()
                 .map(|kline| ExtractedValue::Str(kline.2.clone()))
+        })
+    }
+
+    fn listing_url(&self) -> &str {
+        "https://api.poloniex.com/markets"
+    }
+
+    fn extract_listed_usdt_bases(&self, bytes: &[u8]) -> Result<ListedPairs, ExtractError> {
+        extract_listed_pairs(bytes, |markets: PoloniexListing| {
+            markets.into_iter().map(|market| {
+                ListedMarket::new(
+                    market.base_currency_name,
+                    market.quote_currency_name,
+                    market.state == "NORMAL",
+                )
+            })
         })
     }
 
@@ -527,6 +779,23 @@ struct CryptoResponseResultData {
     o: String,
 }
 
+#[derive(Deserialize)]
+struct CryptoComInstrument {
+    base_ccy: String,
+    quote_ccy: String,
+    inst_type: String,
+    #[serde(default)]
+    tradable: bool,
+}
+#[derive(Deserialize)]
+struct CryptoComInstrumentsResult {
+    data: Vec<CryptoComInstrument>,
+}
+#[derive(Deserialize)]
+struct CryptoComInstrumentsResponse {
+    result: CryptoComInstrumentsResult,
+}
+
 impl IsExchange for CryptoCom {
     fn get_base_url(&self) -> &str {
         "https://api.crypto.com/exchange/v1/public/get-candlestick?instrument_name=BASE_ASSET_QUOTE_ASSET&timeframe=1m&start_ts=START_TIME&count=1"
@@ -548,6 +817,30 @@ impl IsExchange for CryptoCom {
                 .data
                 .first()
                 .map(|kline| ExtractedValue::Str(kline.o.clone()))
+        })
+    }
+
+    fn listing_url(&self) -> &str {
+        "https://api.crypto.com/exchange/v1/public/get-instruments"
+    }
+
+    fn extract_listed_usdt_bases(&self, bytes: &[u8]) -> Result<ListedPairs, ExtractError> {
+        extract_listed_pairs(bytes, |response: CryptoComInstrumentsResponse| {
+            response
+                .result
+                .data
+                .into_iter()
+                // Keep only spot currency pairs; the same endpoint also returns
+                // ~300 derivatives (PERPETUAL_SWAP, FUTURE) that are not spot
+                // markets and must not count toward total_markets.
+                .filter(|instrument| instrument.inst_type == "CCY_PAIR")
+                .map(|instrument| {
+                    ListedMarket::new(
+                        instrument.base_ccy,
+                        instrument.quote_ccy,
+                        instrument.tradable,
+                    )
+                })
         })
     }
 
@@ -574,6 +867,18 @@ struct BitgetResponse {
     data: Vec<BitgetResponseDataEntry>,
 }
 
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BitgetSymbol {
+    base_coin: String,
+    quote_coin: String,
+    status: String,
+}
+#[derive(Deserialize)]
+struct BitgetSymbolsResponse {
+    data: Vec<BitgetSymbol>,
+}
+
 impl IsExchange for Bitget {
     fn get_base_url(&self) -> &str {
         "https://api.bitget.com/api/v2/spot/market/history-candles?symbol=BASE_ASSETQUOTE_ASSET&granularity=1min&endTime=END_TIME&limit=1"
@@ -596,6 +901,25 @@ impl IsExchange for Bitget {
         })
     }
 
+    fn listing_url(&self) -> &str {
+        "https://api.bitget.com/api/v2/spot/public/symbols"
+    }
+
+    fn extract_listed_usdt_bases(&self, bytes: &[u8]) -> Result<ListedPairs, ExtractError> {
+        extract_listed_pairs(bytes, |response: BitgetSymbolsResponse| {
+            response
+                .data
+                .into_iter()
+                .map(|symbol| {
+                    ListedMarket::new(
+                        symbol.base_coin,
+                        symbol.quote_coin,
+                        symbol.status == "online",
+                    )
+                })
+        })
+    }
+
     fn supports_ipv6(&self) -> bool {
         true
     }
@@ -605,6 +929,17 @@ impl IsExchange for Bitget {
 #[derive(Deserialize)]
 struct DigifinexResponse {
     data: Vec<(u64, f64, f64, f64, f64, f64)>,
+}
+
+#[derive(Deserialize)]
+struct DigifinexSymbol {
+    base_asset: String,
+    quote_asset: String,
+    status: String,
+}
+#[derive(Deserialize)]
+struct DigifinexSymbolsResponse {
+    symbol_list: Vec<DigifinexSymbol>,
 }
 
 impl IsExchange for Digifinex {
@@ -618,6 +953,25 @@ impl IsExchange for Digifinex {
                 .data
                 .first()
                 .map(|kline| ExtractedValue::Float(kline.5))
+        })
+    }
+
+    fn listing_url(&self) -> &str {
+        "https://openapi.digifinex.com/v3/spot/symbols"
+    }
+
+    fn extract_listed_usdt_bases(&self, bytes: &[u8]) -> Result<ListedPairs, ExtractError> {
+        extract_listed_pairs(bytes, |response: DigifinexSymbolsResponse| {
+            response
+                .symbol_list
+                .into_iter()
+                .map(|symbol| {
+                    ListedMarket::new(
+                        symbol.base_asset,
+                        symbol.quote_asset,
+                        symbol.status == "TRADING",
+                    )
+                })
         })
     }
 
@@ -869,6 +1223,110 @@ mod test {
         let query_response = load_file("test-data/exchanges/digifinex.json");
         let extracted_rate = digifinex.extract_rate(&query_response);
         assert!(matches!(extracted_rate, Ok(rate) if rate == 11_357_000_000));
+    }
+
+    /// Asserts the common shape of every listing fixture: each holds four spot
+    /// markets — two tradable USDT pairs (BTC, ETH), one tradable non-USDT pair,
+    /// and one non-tradable USDT pair — so a correct parser yields exactly
+    /// `{BTC, ETH}` as the gating set while still counting all four (or, for
+    /// Crypto.com, four spot pairs plus a derivative that must be excluded) in
+    /// `total_markets`.
+    fn assert_lists_btc_and_eth(exchange: &impl IsExchange, file: &str) {
+        let body = load_file(file);
+        let listed = exchange
+            .extract_listed_usdt_bases(&body)
+            .expect("should parse the listing fixture");
+        let expected: BTreeSet<String> = ["BTC", "ETH"].iter().map(|s| s.to_string()).collect();
+        assert_eq!(listed.bases, expected, "unexpected USDT bases for {file}");
+        assert_eq!(
+            listed.total_markets, 4,
+            "unexpected total markets for {file}"
+        );
+    }
+
+    /// Pins each exchange's listing endpoint URL.
+    #[test]
+    fn listing_urls() {
+        assert_eq!(
+            Coinbase.listing_url(),
+            "https://api.exchange.coinbase.com/products"
+        );
+        assert_eq!(
+            KuCoin.listing_url(),
+            "https://api.kucoin.com/api/v1/symbols"
+        );
+        assert_eq!(
+            Okx.listing_url(),
+            "https://www.okx.com/api/v5/public/instruments?instType=SPOT"
+        );
+        assert_eq!(
+            GateIo.listing_url(),
+            "https://api.gateio.ws/api/v4/spot/currency_pairs"
+        );
+        assert_eq!(
+            Mexc.listing_url(),
+            "https://api.mexc.com/api/v3/defaultSymbols"
+        );
+        assert_eq!(Poloniex.listing_url(), "https://api.poloniex.com/markets");
+        assert_eq!(
+            CryptoCom.listing_url(),
+            "https://api.crypto.com/exchange/v1/public/get-instruments"
+        );
+        assert_eq!(
+            Bitget.listing_url(),
+            "https://api.bitget.com/api/v2/spot/public/symbols"
+        );
+        assert_eq!(
+            Digifinex.listing_url(),
+            "https://openapi.digifinex.com/v3/spot/symbols"
+        );
+    }
+
+    #[test]
+    fn extract_listed_usdt_bases_from_coinbase() {
+        assert_lists_btc_and_eth(&Coinbase, "test-data/exchanges/listings/coinbase.json");
+    }
+
+    #[test]
+    fn extract_listed_usdt_bases_from_kucoin() {
+        assert_lists_btc_and_eth(&KuCoin, "test-data/exchanges/listings/kucoin.json");
+    }
+
+    #[test]
+    fn extract_listed_usdt_bases_from_okx() {
+        assert_lists_btc_and_eth(&Okx, "test-data/exchanges/listings/okx.json");
+    }
+
+    #[test]
+    fn extract_listed_usdt_bases_from_gate_io() {
+        assert_lists_btc_and_eth(&GateIo, "test-data/exchanges/listings/gateio.json");
+    }
+
+    #[test]
+    fn extract_listed_usdt_bases_from_mexc() {
+        assert_lists_btc_and_eth(&Mexc, "test-data/exchanges/listings/mexc.json");
+    }
+
+    #[test]
+    fn extract_listed_usdt_bases_from_poloniex() {
+        assert_lists_btc_and_eth(&Poloniex, "test-data/exchanges/listings/poloniex.json");
+    }
+
+    /// Crypto.com's fixture additionally includes a `PERPETUAL_SWAP` entry; the
+    /// `total_markets == 4` assertion confirms derivatives are excluded.
+    #[test]
+    fn extract_listed_usdt_bases_from_crypto() {
+        assert_lists_btc_and_eth(&CryptoCom, "test-data/exchanges/listings/cryptocom.json");
+    }
+
+    #[test]
+    fn extract_listed_usdt_bases_from_bitget() {
+        assert_lists_btc_and_eth(&Bitget, "test-data/exchanges/listings/bitget.json");
+    }
+
+    #[test]
+    fn extract_listed_usdt_bases_from_digifinex() {
+        assert_lists_btc_and_eth(&Digifinex, "test-data/exchanges/listings/digifinex.json");
     }
 
     /// The function tests the ability of an [Exchange] to encode the context to be sent

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -1249,21 +1249,31 @@ impl core::fmt::Display for ExtractError {
     }
 }
 
-impl ExtractError {
-    fn json_deserialize(bytes: &[u8], error: String) -> Self {
-        let response = String::from_utf8(bytes.to_vec())
-            .unwrap_or_default()
-            .replace('\n', " ");
+/// Cap on how much of an upstream body is embedded in an [ExtractError], so a
+/// large or garbage response (e.g. a ~1 MiB listing returned as a 200) can't
+/// produce megabyte-sized log/trap lines. Comfortably covers a full rate
+/// response (at most a few KiB) while bounding listings.
+const MAX_ERROR_RESPONSE_LEN: usize = 4 * 1024;
 
-        Self::JsonDeserialize { response, error }
+impl ExtractError {
+    /// Renders a (possibly large or non-UTF-8) body into a bounded, log-safe
+    /// snippet: truncated to [MAX_ERROR_RESPONSE_LEN], lossily decoded so
+    /// invalid bytes become replacement characters instead of dropping the
+    /// whole snippet, with newlines flattened.
+    fn response_snippet(bytes: &[u8]) -> String {
+        let end = bytes.len().min(MAX_ERROR_RESPONSE_LEN);
+        String::from_utf8_lossy(&bytes[..end]).replace('\n', " ")
+    }
+
+    fn json_deserialize(bytes: &[u8], error: String) -> Self {
+        Self::JsonDeserialize {
+            response: Self::response_snippet(bytes),
+            error,
+        }
     }
 
     fn extract(bytes: &[u8]) -> Self {
-        let response = String::from_utf8(bytes.to_vec())
-            .unwrap_or_default()
-            .replace('\n', " ");
-
-        Self::Extract(response)
+        Self::Extract(Self::response_snippet(bytes))
     }
 }
 
@@ -1274,6 +1284,18 @@ mod test {
     use ic_xrc_types::AssetClass;
 
     use super::*;
+
+    /// A large (e.g. listing-sized) body embedded in an extraction error is
+    /// truncated, so a garbage 200 can't produce megabyte-sized log/trap lines.
+    #[test]
+    fn extract_error_response_is_bounded() {
+        let body = vec![b'a'; 2 * 1024 * 1024];
+        let response = match ExtractError::json_deserialize(&body, "boom".to_string()) {
+            ExtractError::JsonDeserialize { response, .. } => response,
+            other => panic!("expected JsonDeserialize, got {other:?}"),
+        };
+        assert_eq!(response.len(), MAX_ERROR_RESPONSE_LEN);
+    }
 
     /// The function returns sample [QueriedExchangeRate] structs for testing.
     fn get_rates(

--- a/src/xrc/test-data/exchanges/listings/bitget.json
+++ b/src/xrc/test-data/exchanges/listings/bitget.json
@@ -1,0 +1,8 @@
+{
+  "data": [
+    { "symbol": "BTCUSDT", "baseCoin": "BTC", "quoteCoin": "USDT", "status": "online" },
+    { "symbol": "ETHUSDT", "baseCoin": "ETH", "quoteCoin": "USDT", "status": "online" },
+    { "symbol": "LUMIABTC", "baseCoin": "LUMIA", "quoteCoin": "BTC", "status": "online" },
+    { "symbol": "HALTUSDT", "baseCoin": "HALT", "quoteCoin": "USDT", "status": "halt" }
+  ]
+}

--- a/src/xrc/test-data/exchanges/listings/coinbase.json
+++ b/src/xrc/test-data/exchanges/listings/coinbase.json
@@ -1,0 +1,6 @@
+[
+  { "id": "BTC-USDT", "base_currency": "BTC", "quote_currency": "USDT", "status": "online", "trading_disabled": false },
+  { "id": "ETH-USDT", "base_currency": "ETH", "quote_currency": "USDT", "status": "online", "trading_disabled": false },
+  { "id": "DOT-BTC", "base_currency": "DOT", "quote_currency": "BTC", "status": "online", "trading_disabled": false },
+  { "id": "ICP-USDT", "base_currency": "ICP", "quote_currency": "USDT", "status": "delisted", "trading_disabled": true }
+]

--- a/src/xrc/test-data/exchanges/listings/cryptocom.json
+++ b/src/xrc/test-data/exchanges/listings/cryptocom.json
@@ -1,0 +1,11 @@
+{
+  "result": {
+    "data": [
+      { "symbol": "BTC_USDT", "inst_type": "CCY_PAIR", "base_ccy": "BTC", "quote_ccy": "USDT", "tradable": true },
+      { "symbol": "ETH_USDT", "inst_type": "CCY_PAIR", "base_ccy": "ETH", "quote_ccy": "USDT", "tradable": true },
+      { "symbol": "BTC_USD", "inst_type": "CCY_PAIR", "base_ccy": "BTC", "quote_ccy": "USD", "tradable": true },
+      { "symbol": "DEAD_USDT", "inst_type": "CCY_PAIR", "base_ccy": "DEAD", "quote_ccy": "USDT", "tradable": false },
+      { "symbol": "1INCHUSD-PERP", "inst_type": "PERPETUAL_SWAP", "base_ccy": "1INCH", "quote_ccy": "USD", "tradable": true }
+    ]
+  }
+}

--- a/src/xrc/test-data/exchanges/listings/digifinex.json
+++ b/src/xrc/test-data/exchanges/listings/digifinex.json
@@ -1,0 +1,8 @@
+{
+  "symbol_list": [
+    { "symbol": "BTC_USDT", "base_asset": "BTC", "quote_asset": "USDT", "status": "TRADING" },
+    { "symbol": "ETH_USDT", "base_asset": "ETH", "quote_asset": "USDT", "status": "TRADING" },
+    { "symbol": "BTC_ETH", "base_asset": "BTC", "quote_asset": "ETH", "status": "TRADING" },
+    { "symbol": "OFF_USDT", "base_asset": "OFF", "quote_asset": "USDT", "status": "OFFLINE" }
+  ]
+}

--- a/src/xrc/test-data/exchanges/listings/gateio.json
+++ b/src/xrc/test-data/exchanges/listings/gateio.json
@@ -1,0 +1,6 @@
+[
+  { "id": "BTC_USDT", "base": "BTC", "quote": "USDT", "trade_status": "tradable" },
+  { "id": "ETH_USDT", "base": "ETH", "quote": "USDT", "trade_status": "tradable" },
+  { "id": "ALEPH_BTC", "base": "ALEPH", "quote": "BTC", "trade_status": "tradable" },
+  { "id": "OLD_USDT", "base": "OLD", "quote": "USDT", "trade_status": "untradable" }
+]

--- a/src/xrc/test-data/exchanges/listings/kucoin.json
+++ b/src/xrc/test-data/exchanges/listings/kucoin.json
@@ -1,0 +1,8 @@
+{
+  "data": [
+    { "symbol": "BTC-USDT", "baseCurrency": "BTC", "quoteCurrency": "USDT", "enableTrading": true },
+    { "symbol": "ETH-USDT", "baseCurrency": "ETH", "quoteCurrency": "USDT", "enableTrading": true },
+    { "symbol": "AVA-BTC", "baseCurrency": "AVA", "quoteCurrency": "BTC", "enableTrading": true },
+    { "symbol": "DEAD-USDT", "baseCurrency": "DEAD", "quoteCurrency": "USDT", "enableTrading": false }
+  ]
+}

--- a/src/xrc/test-data/exchanges/listings/mexc.json
+++ b/src/xrc/test-data/exchanges/listings/mexc.json
@@ -1,0 +1,4 @@
+{
+  "code": 0,
+  "data": ["BTCUSDT", "ETHUSDT", "ETHBTC", "ICPUSDC"]
+}

--- a/src/xrc/test-data/exchanges/listings/okx.json
+++ b/src/xrc/test-data/exchanges/listings/okx.json
@@ -1,0 +1,8 @@
+{
+  "data": [
+    { "instId": "BTC-USDT", "instType": "SPOT", "baseCcy": "BTC", "quoteCcy": "USDT", "state": "live" },
+    { "instId": "ETH-USDT", "instType": "SPOT", "baseCcy": "ETH", "quoteCcy": "USDT", "state": "live" },
+    { "instId": "USDT-SGD", "instType": "SPOT", "baseCcy": "USDT", "quoteCcy": "SGD", "state": "live" },
+    { "instId": "NEW-USDT", "instType": "SPOT", "baseCcy": "NEW", "quoteCcy": "USDT", "state": "preopen" }
+  ]
+}

--- a/src/xrc/test-data/exchanges/listings/poloniex.json
+++ b/src/xrc/test-data/exchanges/listings/poloniex.json
@@ -1,0 +1,6 @@
+[
+  { "symbol": "BTC_USDT", "baseCurrencyName": "BTC", "quoteCurrencyName": "USDT", "state": "NORMAL" },
+  { "symbol": "ETH_USDT", "baseCurrencyName": "ETH", "quoteCurrencyName": "USDT", "state": "NORMAL" },
+  { "symbol": "DASH_BTC", "baseCurrencyName": "DASH", "quoteCurrencyName": "BTC", "state": "NORMAL" },
+  { "symbol": "PAX_USDT", "baseCurrencyName": "PAX", "quoteCurrencyName": "USDT", "state": "PAUSE" }
+]


### PR DESCRIPTION
## DEFI-2868 PR series

Part of the **DEFI-2868** series — *discover tradable pairs per exchange and gate crypto queries by listed pairs*. The PRs land in order, with the behaviour change deliberately last, after the discovered sets have been observed populating correctly in production:

1. **#330 — listing parsers** (pure, no wiring) ← *you are here*
2. **#331 — canbench benchmarks + regression gate** (stacked on #330)
3. **#332 — store + daily refresh + metrics** (populate the sets, still no gating)
4. **#337 — gate crypto queries on the discovered sets** (the behaviour change; draft — merge/deploy only after #330–#332 are in prod and observed healthy)

---

## Purpose

First PR in the DEFI-2868 series — *discover tradable pairs per exchange and gate crypto queries by listed pairs*. The crypto path currently queries every exchange for base/USDT even when the pair isn't listed, so unlisted/delisted pairs fail on every request. This PR adds the parsing foundation: reading each exchange's public spot-listing endpoint into the set of bases it currently lists against USDT.

It is deliberately **pure** — no outcalls, storage, or behaviour change, and nothing calls the new code yet.

## What it adds

- Listing-endpoint parsing for all nine exchanges (Coinbase, KuCoin, OKX, GateIo, MEXC, Poloniex, CryptoCom, Bitget, Digifinex), each with its listing URL and tradable rule.
- A result carrying the USDT-tradable base assets plus a total spot-market count — the latter is a structural-health signal for the refresh acceptance guard in a later PR (it stays stable across delistings/migrations, so a sudden drop means a parser break rather than a legitimate change).
- Per-exchange fixtures and unit tests.

## Validation

Parsers were validated against live captures of all nine endpoints; the discovered counts matched expectations — e.g. Coinbase shows ~23 USDT bases with ICP-USDT correctly absent (the delisting this series ultimately fixes), and CryptoCom excludes its ~300 derivatives from the spot-market count.

## Follow-ups (subsequent PRs)

- **#331** — canbench benchmarks for the parsers + a regression gate.
- **#332** — wire a daily refresh timer + stable-memory store + metrics (populate the sets, still no gating).
- **#337** — gate the crypto query path on the discovered sets and remove the hardcoded Coinbase ICP skip.
