### PR TITLE
feat: DEFI-2868: discover listings periodically - store, refresh, metrics

### DIFF
--- a/src/xrc/hidden_endpoints.conf
+++ b/src/xrc/hidden_endpoints.conf
@@ -1,8 +1,9 @@
 # HTTP endpoint for fetching metrics
 canister_query:http_request
-# Transform functions for HTTP outcalls to exchanges and forex sources
+# Transform functions for HTTP outcalls to exchanges, forex sources and listings
 canister_query:transform_exchange_http_response
 canister_query:transform_forex_http_response
+canister_query:transform_listing_http_response
 # Canister lifecycle
 canister_heartbeat
 canister_init

--- a/src/xrc/src/api/metrics.rs
+++ b/src/xrc/src/api/metrics.rs
@@ -188,7 +188,7 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
     encode_labeled_counter_family(
         w,
         MetricName::ExchangeListingRejectedTotal,
-        "Total per-exchange listing refreshes not applied, labeled by reason: 'fetch' (HTTP outcall failed - exchange unreachable) or 'guard' (a 200 that failed the structural acceptance guard - API change or parser break). A rising 'guard' rate points at a parser/API issue; a rising 'fetch' rate at connectivity.",
+        "Total per-exchange listing refreshes not applied, labeled by reason: 'fetch' (no listing could be fetched and parsed - an HTTP outcall error, transform trap, or candid encode/decode failure) or 'guard' (a 200 that failed the structural acceptance guard - API change or parser break). A rising 'guard' rate points at a parser/API issue; a rising 'fetch' rate at connectivity or a malformed/oversized response.",
     )?;
 
     Ok(())

--- a/src/xrc/src/api/metrics.rs
+++ b/src/xrc/src/api/metrics.rs
@@ -188,7 +188,7 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
     encode_labeled_counter_family(
         w,
         MetricName::ExchangeListingRejectedTotal,
-        "Total per-exchange listing refreshes rejected by the structural acceptance guard or that failed to fetch; a rising rate indicates an exchange API change or a parser break.",
+        "Total per-exchange listing refreshes not applied, labeled by reason: 'fetch' (HTTP outcall failed - exchange unreachable) or 'guard' (a 200 that failed the structural acceptance guard - API change or parser break). A rising 'guard' rate points at a parser/API issue; a rising 'fetch' rate at connectivity.",
     )?;
 
     Ok(())

--- a/src/xrc/src/api/metrics.rs
+++ b/src/xrc/src/api/metrics.rs
@@ -170,6 +170,26 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
         MetricName::StablecoinSymbolRatesReceived,
         "Count of individual exchange rate samples received per stablecoin symbol; its rate drops to zero when an upstream symbol stops returning data (e.g. after a rebrand).",
     )?;
+    encode_labeled_gauge_family(
+        w,
+        MetricName::ExchangeListedUsdtPairs,
+        "Number of base assets each exchange currently lists against USDT, from the last accepted listing refresh (the set the crypto path is gated on).",
+    )?;
+    encode_labeled_gauge_family(
+        w,
+        MetricName::ExchangeListingTotalMarkets,
+        "Total spot markets parsed (across all quotes) per exchange in the last accepted listing refresh; a structural-health signal that stays stable across delistings and USDT-to-USD migrations.",
+    )?;
+    encode_labeled_gauge_family(
+        w,
+        MetricName::ExchangeListingLastSuccessSeconds,
+        "Unix timestamp (seconds) of the most recent accepted listing refresh per exchange.",
+    )?;
+    encode_labeled_counter_family(
+        w,
+        MetricName::ExchangeListingRejectedTotal,
+        "Total per-exchange listing refreshes rejected by the structural acceptance guard or that failed to fetch; a rising rate indicates an exchange API change or a parser break.",
+    )?;
 
     Ok(())
 }

--- a/src/xrc/src/exchanges.rs
+++ b/src/xrc/src/exchanges.rs
@@ -131,10 +131,36 @@ macro_rules! exchanges {
                 decode_args::<(u64,)>(bytes).map(|decoded| decoded.0)
             }
 
+            /// Encodes a parsed listing as the listing transform's output — the
+            /// small, canonical payload the replicas reach consensus on. The
+            /// bases are a `BTreeSet`, so candid emits them in a deterministic
+            /// (sorted) order.
+            pub fn encode_listing_response(listed: &ListedPairs) -> Result<Vec<u8>, CandidError> {
+                encode_args((&listed.bases, listed.total_markets as u64))
+            }
+
+            /// Decodes the listing payload produced by [encode_listing_response].
+            pub fn decode_listing_response(bytes: &[u8]) -> Result<ListedPairs, CandidError> {
+                decode_args::<(BTreeSet<String>, u64)>(bytes).map(|(bases, total_markets)| {
+                    ListedPairs {
+                        bases,
+                        total_markets: total_markets as usize,
+                    }
+                })
+            }
+
             /// This method returns the exchange's max response bytes.
             pub fn max_response_bytes(&self) -> u64 {
                 match self {
                     $(Exchange::$name(exchange) => exchange.max_response_bytes()),*,
+                }
+            }
+
+            /// This method returns the exchange's max response bytes for a
+            /// listing outcall.
+            pub fn listing_max_response_bytes(&self) -> u64 {
+                match self {
+                    $(Exchange::$name(exchange) => exchange.listing_max_response_bytes()),*,
                 }
             }
 
@@ -272,6 +298,13 @@ const START_TIME: &str = "START_TIME";
 /// `END_TIME`: This string must be replaced with the end time derived from the timestamp in the request.
 const END_TIME: &str = "END_TIME";
 
+/// Default cap on the raw listing response a refresh outcall will accept. The
+/// XRC's largest listing (OKX, ~1.3 MiB) fits with headroom under the IC's
+/// ~2 MiB HTTP-outcall limit, and the subnet is feeless so over-provisioning
+/// costs nothing; a per-exchange override can tighten or loosen it if a venue's
+/// listing grows.
+const DEFAULT_LISTING_MAX_RESPONSE_BYTES: u64 = 1_900_000;
+
 /// This trait is use to provide the basic methods needed for an exchange.
 trait IsExchange {
     /// The base URL template that is provided to [IsExchange::get_url].
@@ -341,6 +374,12 @@ trait IsExchange {
 
     fn max_response_bytes(&self) -> u64 {
         3 * ONE_KIB
+    }
+
+    /// The max response size for this exchange's listing outcall. Listings are
+    /// far larger than rate responses, so this overrides [max_response_bytes].
+    fn listing_max_response_bytes(&self) -> u64 {
+        DEFAULT_LISTING_MAX_RESPONSE_BYTES
     }
 }
 

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -204,6 +204,14 @@ pub(crate) enum MetricName {
     PeriodicForexRunLastSeconds,
     #[strum(serialize = "xrc_stablecoin_symbol_rates_received")]
     StablecoinSymbolRatesReceived,
+    #[strum(serialize = "xrc_exchange_listed_usdt_pairs")]
+    ExchangeListedUsdtPairs,
+    #[strum(serialize = "xrc_exchange_listing_total_markets")]
+    ExchangeListingTotalMarkets,
+    #[strum(serialize = "xrc_exchange_listing_last_success_seconds")]
+    ExchangeListingLastSuccessSeconds,
+    #[strum(serialize = "xrc_exchange_listing_rejected_total")]
+    ExchangeListingRejectedTotal,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, strum::IntoStaticStr)]
@@ -477,6 +485,11 @@ fn with_forex_rate_store<R>(f: impl FnOnce(&ForexRateStore) -> R) -> R {
 /// A helper method to mutate the forex rate store.
 fn with_forex_rate_store_mut<R>(f: impl FnOnce(&mut ForexRateStore) -> R) -> R {
     FOREX_RATE_STORE.with(|cell| f(&mut cell.borrow_mut()))
+}
+
+/// A helper method to read from the listing store.
+fn with_listing_store<R>(f: impl FnOnce(&ListingStore) -> R) -> R {
+    LISTING_STORE.with(|cell| f(&cell.borrow()))
 }
 
 /// A helper method to mutate the listing store.

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -10,6 +10,7 @@ mod cache;
 mod exchanges;
 mod forex;
 mod http;
+mod listings;
 mod stablecoin;
 
 mod environment;

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -1103,18 +1103,28 @@ async fn call_forex(forex: &Forex, args: ForexContextArgs) -> Result<ForexRateMa
 
 /// Serializes the state and stores it in stable memory.
 pub fn pre_upgrade() {
-    with_forex_rate_store(|store| ic_cdk::storage::stable_save((store,)))
-        .expect("Saving state must succeed.")
+    with_forex_rate_store(|forex_store| {
+        with_listing_store(|listing_store| {
+            ic_cdk::storage::stable_save((forex_store, listing_store))
+        })
+    })
+    .expect("Saving state must succeed.")
 }
 
 /// Deserializes the state from stable memory and sets the canister state,
 /// then re-initializes ephemeral state via [`init_metrics`].
 pub fn post_upgrade() {
-    let store = ic_cdk::storage::stable_restore::<(ForexRateStore,)>()
-        .expect("Failed to read from stable memory.")
-        .0;
+    // The listing store is decoded as a trailing `Option` so the first upgrade
+    // from a version that saved only `(ForexRateStore,)` decodes it as `None`
+    // (candid fills an absent trailing optional argument) instead of trapping.
+    let (forex_store, listing_store) =
+        ic_cdk::storage::stable_restore::<(ForexRateStore, Option<ListingStore>)>()
+            .expect("Failed to read from stable memory.");
     FOREX_RATE_STORE.with(|cell| {
-        *cell.borrow_mut() = store;
+        *cell.borrow_mut() = forex_store;
+    });
+    LISTING_STORE.with(|cell| {
+        *cell.borrow_mut() = listing_store.unwrap_or_default();
     });
     init_metrics();
 }
@@ -1392,6 +1402,28 @@ mod test {
             other => panic!("expected JsonDeserialize, got {other:?}"),
         };
         assert_eq!(response.len(), MAX_ERROR_RESPONSE_LEN);
+    }
+
+    /// The post_upgrade migration must tolerate stable memory written by a
+    /// version that persisted only `(ForexRateStore,)`: decoding into
+    /// `(ForexRateStore, Option<ListingStore>)` yields `None` for the listing
+    /// store rather than trapping, and the current 2-store layout decodes as
+    /// `Some`. stable_save/restore round-trip through candid, so exercising the
+    /// candid arg-decoding here covers the upgrade path.
+    #[test]
+    fn post_upgrade_tolerates_legacy_single_store_layout() {
+        use ::candid::{decode_args, encode_args};
+
+        let legacy = encode_args((ForexRateStore::new(),)).expect("encode legacy layout");
+        let (_forex, listing): (ForexRateStore, Option<ListingStore>) =
+            decode_args(&legacy).expect("legacy layout must still decode");
+        assert!(listing.is_none(), "absent listing store must decode as None");
+
+        let current = encode_args((ForexRateStore::new(), ListingStore::default()))
+            .expect("encode current layout");
+        let (_forex, listing): (ForexRateStore, Option<ListingStore>) =
+            decode_args(&current).expect("current layout must decode");
+        assert!(listing.is_some(), "persisted listing store must decode as Some");
     }
 
     /// The function returns sample [QueriedExchangeRate] structs for testing.

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -978,6 +978,14 @@ async fn call_exchange_listing(exchange: &Exchange) -> Result<ListedPairs, CallE
         .get(exchange.listing_url())
         .transform_context("transform_listing_http_response", context)
         .max_response_bytes(exchange.listing_max_response_bytes())
+        // NOTE: cycles() is a flat amount that does not scale with
+        // max_response_bytes, which for listings is much larger (~1.9 MiB) than
+        // for a rate quote (a few KiB). On the feeless production system subnet
+        // this is moot (0 cycles, no minimum). It only matters on a paying
+        // application-subnet build, where this flat amount may under-fund the
+        // larger outcall and the management canister rejects it; that surfaces
+        // as a failed fetch and the last-known-good listing is kept, so it
+        // degrades gracefully rather than breaking gating.
         .cycles(exchange.cycles())
         .send()
         .await

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -52,6 +52,8 @@ pub use api::usdt_asset;
 pub use exchanges::{Exchange, EXCHANGES};
 pub use forex::{Forex, FOREX_SOURCES};
 
+use exchanges::ListedPairs;
+
 /// Rates may not deviate by more than one tenth of the smallest considered rate.
 const RATE_DEVIATION_DIVISOR: u64 = 10;
 
@@ -925,6 +927,37 @@ async fn call_exchange_raw(
     })
 }
 
+/// Fetches an exchange's public spot listing and returns the set of base assets
+/// it currently lists against USDT (plus the total parsed market count). Mirrors
+/// [call_exchange_raw]: the heavy parse happens in `transform_listing_http_response`
+/// so consensus is over the small canonical payload, not the ~1 MiB body.
+// TODO(DEFI-2648): Migrate to non-deprecated.
+#[allow(deprecated)]
+async fn call_exchange_listing(exchange: &Exchange) -> Result<ListedPairs, CallExchangeError> {
+    let context = exchange
+        .encode_context()
+        .map_err(|error| CallExchangeError::Candid {
+            exchange: exchange.to_string(),
+            error: format!("Failure while encoding context: {}", error),
+        })?;
+    let response = CanisterHttpRequest::new()
+        .get(exchange.listing_url())
+        .transform_context("transform_listing_http_response", context)
+        .max_response_bytes(exchange.listing_max_response_bytes())
+        .cycles(exchange.cycles())
+        .send()
+        .await
+        .map_err(|error| CallExchangeError::Http {
+            exchange: exchange.to_string(),
+            error,
+        })?;
+
+    Exchange::decode_listing_response(&response.body).map_err(|error| CallExchangeError::Candid {
+        exchange: exchange.to_string(),
+        error: format!("Failure while decoding listing response: {}", error),
+    })
+}
+
 /// Translates a `call_exchange` result into a `(exchange, kind, outcome)`
 /// observation on the per-exchange metric families. Split out so unit
 /// tests can drive every outcome arm without going through the actual
@@ -1114,6 +1147,46 @@ pub fn transform_exchange_http_response(args: TransformArgs) -> HttpResponse {
         Err(err) => {
             ic_cdk::trap(format!("failed to encode rate ({}): {}", rate, err));
         }
+    };
+
+    // Strip out the headers as these will commonly cause an error to occur.
+    sanitized.headers = vec![];
+    sanitized
+}
+
+/// Transform for the listing outcall: parses the (large) listing body into the
+/// set of USDT-tradable bases and total market count, and replaces the body
+/// with that small canonical payload so the replicas reach consensus on it
+/// rather than on the raw, volatile listing. Mirrors
+/// [transform_exchange_http_response].
+// TODO(DEFI-2648): Migrate to non-deprecated.
+#[allow(deprecated)]
+pub fn transform_listing_http_response(args: TransformArgs) -> HttpResponse {
+    let mut sanitized = args.response;
+
+    let index = match Exchange::decode_context(&args.context) {
+        Ok(index) => index,
+        Err(err) => ic_cdk::trap(format!("Failed to decode context: {}", err)),
+    };
+
+    let exchange = match EXCHANGES.get(index) {
+        Some(exchange) => exchange,
+        None => {
+            ic_cdk::trap(format!(
+                "Provided index {} does not map to any supported exchange.",
+                index
+            ));
+        }
+    };
+
+    let listed = match exchange.extract_listed_usdt_bases(&sanitized.body) {
+        Ok(listed) => listed,
+        Err(err) => ic_cdk::trap(format!("{}", err)),
+    };
+
+    sanitized.body = match Exchange::encode_listing_response(&listed) {
+        Ok(body) => body,
+        Err(err) => ic_cdk::trap(format!("failed to encode listing: {}", err)),
     };
 
     // Strip out the headers as these will commonly cause an error to occur.

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -53,6 +53,7 @@ pub use exchanges::{Exchange, EXCHANGES};
 pub use forex::{Forex, FOREX_SOURCES};
 
 use exchanges::ListedPairs;
+use listings::ListingStore;
 
 /// Rates may not deviate by more than one tenth of the smallest considered rate.
 const RATE_DEVIATION_DIVISOR: u64 = 10;
@@ -142,6 +143,10 @@ thread_local! {
 
     static FOREX_RATE_STORE: RefCell<ForexRateStore> = RefCell::new(ForexRateStore::new());
     static FOREX_RATE_COLLECTOR: RefCell<ForexRatesCollector> = RefCell::new(ForexRatesCollector::new());
+
+    /// Per-exchange discovered USDT listings, refreshed on a timer and persisted
+    /// across upgrades. See [`listings`].
+    static LISTING_STORE: RefCell<ListingStore> = RefCell::new(ListingStore::default());
 
     /// A simple structure to collect privileged canister requests and responses.
     static PRIVILEGED_REQUEST_LOG: RefCell<RequestLog> = RefCell::new(RequestLog::new(MAX_PRIVILEGED_REQUEST_LOG_ENTRIES));
@@ -472,6 +477,11 @@ fn with_forex_rate_store<R>(f: impl FnOnce(&ForexRateStore) -> R) -> R {
 /// A helper method to mutate the forex rate store.
 fn with_forex_rate_store_mut<R>(f: impl FnOnce(&mut ForexRateStore) -> R) -> R {
     FOREX_RATE_STORE.with(|cell| f(&mut cell.borrow_mut()))
+}
+
+/// A helper method to mutate the listing store.
+fn with_listing_store_mut<R>(f: impl FnOnce(&mut ListingStore) -> R) -> R {
+    LISTING_STORE.with(|cell| f(&mut cell.borrow_mut()))
 }
 
 /// A helper method to read from the forex rate collector.

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -226,6 +226,8 @@ pub(crate) enum LabelKey {
     Outcome,
     #[strum(serialize = "symbol")]
     Symbol,
+    #[strum(serialize = "reason")]
+    Reason,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, strum::IntoStaticStr)]

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -355,6 +355,15 @@ fn init_at(now_secs: u64) {
                 now,
             );
         }
+        // Seed the listing staleness gauge too, so an exchange whose listing has
+        // never been accepted has a (recent) series rather than none at all -
+        // the A3 staleness alert can then fire on an old value instead of having
+        // to special-case an absent series.
+        set_labeled_gauge(
+            MetricName::ExchangeListingLastSuccessSeconds,
+            &[(LabelKey::Exchange, name)],
+            now,
+        );
     }
 }
 
@@ -2177,6 +2186,37 @@ mod test {
                             kind
                         );
                     }
+                }
+            });
+        }
+
+        #[test]
+        fn init_at_seeds_listing_last_success_for_every_exchange() {
+            reset();
+            let now = 1_700_000_000_u64;
+            init_at(now);
+
+            with_labeled_gauges(|m| {
+                let listing_gauges = m
+                    .keys()
+                    .filter(|(name, _)| *name == MetricName::ExchangeListingLastSuccessSeconds)
+                    .count();
+                assert_eq!(
+                    listing_gauges,
+                    EXCHANGES.len(),
+                    "expected one ExchangeListingLastSuccessSeconds gauge per exchange"
+                );
+                for exchange in EXCHANGES {
+                    let key = make_metric_key(
+                        MetricName::ExchangeListingLastSuccessSeconds,
+                        &[(LabelKey::Exchange, exchange.name())],
+                    );
+                    assert_eq!(
+                        m.get(&key).copied(),
+                        Some(now as f64),
+                        "missing or wrong-valued listing gauge for {}",
+                        exchange.name()
+                    );
                 }
             });
         }

--- a/src/xrc/src/listings.rs
+++ b/src/xrc/src/listings.rs
@@ -84,7 +84,10 @@ impl ListingStore {
             // Guard on TOTAL markets, not the USDT subset: a venue migrating
             // USDT->USD keeps total roughly stable (accepted) while its USDT
             // bases collapse, whereas a parser break collapses total (rejected).
-            let min_total = (previous.total_markets as f64 * MIN_RETAINED_FRACTION) as u64;
+            // Round the floor up: truncating would let an odd previous total
+            // accept a refresh just under the retained fraction (e.g. previous
+            // 101 -> floor 50, and 50/101 < 0.5 would slip through).
+            let min_total = (previous.total_markets as f64 * MIN_RETAINED_FRACTION).ceil() as u64;
             if total < min_total {
                 return AcceptOutcome::RejectedTotalDrop {
                     total,
@@ -241,6 +244,28 @@ mod test {
                 total: 99,
                 previous: 200
             }
+        );
+    }
+
+    /// For an odd previous total the floor is rounded up, so a refresh strictly
+    /// below half is rejected rather than slipping through a truncated floor
+    /// (previous 101 -> floor 51, so 50/101 < 0.5 is rejected, 51/101 accepted).
+    #[test]
+    fn retained_fraction_floor_rounds_up_for_odd_previous() {
+        let mut store = ListingStore::default();
+        store.accept("Mexc", fetched(&["BTC"], 101), 1);
+        assert_eq!(
+            store.accept("Mexc", fetched(&["BTC"], 50), 2),
+            AcceptOutcome::RejectedTotalDrop {
+                total: 50,
+                previous: 101
+            }
+        );
+
+        store.accept("Mexc", fetched(&["BTC"], 101), 3);
+        assert_eq!(
+            store.accept("Mexc", fetched(&["BTC"], 51), 4),
+            AcceptOutcome::Accepted
         );
     }
 }

--- a/src/xrc/src/listings.rs
+++ b/src/xrc/src/listings.rs
@@ -1,0 +1,246 @@
+//! Per-exchange discovered listings: the set of base assets each exchange
+//! currently lists against USDT, refreshed on a timer and persisted across
+//! upgrades. The crypto path will (in a later change) query an exchange for an
+//! asset only if its listing contains that base.
+//!
+//! A freshly fetched listing replaces the stored one only if it passes the
+//! structural acceptance guard ([`ListingStore::accept`]); otherwise the
+//! last-known-good listing is kept. The guard is judged on the TOTAL parsed
+//! market count (across all quotes), never the USDT subset: a USDT->USD
+//! migration collapses the USDT subset while leaving total markets roughly
+//! unchanged, and must be accepted (so dead pairs stop being queried) rather
+//! than rejected as if the response were broken.
+
+use candid::{CandidType, Deserialize};
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::exchanges::ListedPairs;
+
+/// A refresh is rejected unless it parses to at least this many total markets.
+/// Guards against a structurally valid but near-empty/garbage response.
+pub(crate) const MIN_TOTAL_MARKETS: u64 = 50;
+
+/// A refresh is rejected if its total market count falls below this fraction of
+/// the previously accepted total — catching a parser break or truncated body,
+/// while still accepting legitimate shrinkage (delistings, USDT->USD migration).
+pub(crate) const MIN_RETAINED_FRACTION: f64 = 0.5;
+
+/// The last accepted listing for a single exchange.
+///
+/// This is persisted to stable memory via candid across upgrades, so it must
+/// evolve compatibly: any field added later has to be `Option<T>` (candid
+/// `opt`), otherwise decoding records persisted by an earlier version traps in
+/// `post_upgrade`.
+#[derive(CandidType, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct ExchangeListing {
+    /// Base assets tradable against USDT, uppercased and deduplicated. A
+    /// `BTreeSet` so the gating read can test membership in O(log n) without
+    /// maintaining a separate sorted-order invariant.
+    pub bases: BTreeSet<String>,
+    /// Total spot markets (across all quotes) in the last accepted refresh — the
+    /// structural-health signal the acceptance guard is judged on.
+    pub total_markets: u64,
+    /// Timestamp (seconds) of the last accepted refresh.
+    pub last_success_secs: u64,
+}
+
+/// Maps each exchange (by [`crate::Exchange::name`]) to its last accepted
+/// listing. Persisted in stable memory across upgrades.
+#[derive(CandidType, Deserialize, Clone, Debug, Default)]
+pub(crate) struct ListingStore {
+    by_exchange: BTreeMap<String, ExchangeListing>,
+}
+
+/// The result of offering a freshly fetched listing to the store.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum AcceptOutcome {
+    /// Stored as the new last-known-good listing.
+    Accepted,
+    /// Fewer than [`MIN_TOTAL_MARKETS`] markets parsed; previous listing kept.
+    RejectedTooFewMarkets { total: u64 },
+    /// Total markets dropped below [`MIN_RETAINED_FRACTION`] of the previous
+    /// accepted total; previous listing kept.
+    RejectedTotalDrop { total: u64, previous: u64 },
+}
+
+impl ListingStore {
+    /// Offers a freshly fetched listing for `exchange` to the store. On a pass
+    /// of the structural guard it becomes the new last-known-good listing and
+    /// the function returns [`AcceptOutcome::Accepted`]; otherwise the existing
+    /// listing (if any) is left untouched and a `Rejected*` variant is returned.
+    pub(crate) fn accept(
+        &mut self,
+        exchange: &str,
+        fetched: ListedPairs,
+        now_secs: u64,
+    ) -> AcceptOutcome {
+        let total = fetched.total_markets as u64;
+
+        if total < MIN_TOTAL_MARKETS {
+            return AcceptOutcome::RejectedTooFewMarkets { total };
+        }
+
+        if let Some(previous) = self.by_exchange.get(exchange) {
+            // Guard on TOTAL markets, not the USDT subset: a venue migrating
+            // USDT->USD keeps total roughly stable (accepted) while its USDT
+            // bases collapse, whereas a parser break collapses total (rejected).
+            let min_total = (previous.total_markets as f64 * MIN_RETAINED_FRACTION) as u64;
+            if total < min_total {
+                return AcceptOutcome::RejectedTotalDrop {
+                    total,
+                    previous: previous.total_markets,
+                };
+            }
+        }
+
+        self.by_exchange.insert(
+            exchange.to_string(),
+            ExchangeListing {
+                bases: fetched.bases,
+                total_markets: total,
+                last_success_secs: now_secs,
+            },
+        );
+        AcceptOutcome::Accepted
+    }
+
+    /// Returns the last accepted listing for `exchange`, if any.
+    pub(crate) fn get(&self, exchange: &str) -> Option<&ExchangeListing> {
+        self.by_exchange.get(exchange)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// Builds a set of base symbols from string literals.
+    fn base_set(bases: &[&str]) -> BTreeSet<String> {
+        bases.iter().map(|s| s.to_string()).collect()
+    }
+
+    /// Builds a [`ListedPairs`] from a base list and an explicit total.
+    fn fetched(bases: &[&str], total_markets: usize) -> ListedPairs {
+        ListedPairs {
+            bases: base_set(bases),
+            total_markets,
+        }
+    }
+
+    /// Scenario 1/2: a valid refresh with no prior is accepted and stored, and a
+    /// later single delisting is accepted without complaint.
+    #[test]
+    fn first_valid_refresh_is_accepted_and_stored() {
+        let mut store = ListingStore::default();
+
+        let outcome = store.accept("Okx", fetched(&["BTC", "ETH", "ICP"], 300), 1_000);
+        assert_eq!(outcome, AcceptOutcome::Accepted);
+
+        let listing = store.get("Okx").expect("listing should be stored");
+        assert_eq!(listing.bases, base_set(&["BTC", "ETH", "ICP"]));
+        assert_eq!(listing.total_markets, 300);
+        assert_eq!(listing.last_success_secs, 1_000);
+
+        // One pair delisted: total barely moves, accepted, base set shrinks.
+        let outcome = store.accept("Okx", fetched(&["BTC", "ETH"], 299), 2_000);
+        assert_eq!(outcome, AcceptOutcome::Accepted);
+        assert_eq!(store.get("Okx").unwrap().bases, base_set(&["BTC", "ETH"]));
+        assert_eq!(store.get("Okx").unwrap().last_success_secs, 2_000);
+    }
+
+    /// A structurally valid but near-empty response (below the absolute floor)
+    /// is rejected; an existing good listing is kept.
+    #[test]
+    fn below_floor_is_rejected_and_keeps_previous() {
+        let mut store = ListingStore::default();
+        store.accept("GateIo", fetched(&["BTC", "ETH"], 2_000), 1_000);
+
+        let outcome = store.accept("GateIo", fetched(&["BTC"], 3), 2_000);
+        assert_eq!(outcome, AcceptOutcome::RejectedTooFewMarkets { total: 3 });
+
+        // Previous listing untouched.
+        let listing = store.get("GateIo").unwrap();
+        assert_eq!(listing.total_markets, 2_000);
+        assert_eq!(listing.last_success_secs, 1_000);
+    }
+
+    /// Scenario 4: a parser break / truncated body collapses the total markets;
+    /// the drop below half the previous total is rejected and the last-good
+    /// listing is kept.
+    #[test]
+    fn total_collapse_is_rejected_as_parser_break() {
+        let mut store = ListingStore::default();
+        store.accept("KuCoin", fetched(&["BTC", "ETH"], 1_000), 1_000);
+
+        let outcome = store.accept("KuCoin", fetched(&["BTC", "ETH"], 100), 2_000);
+        assert_eq!(
+            outcome,
+            AcceptOutcome::RejectedTotalDrop {
+                total: 100,
+                previous: 1_000
+            }
+        );
+        assert_eq!(store.get("KuCoin").unwrap().total_markets, 1_000);
+    }
+
+    /// Scenario 3: a USDT->USD migration collapses the USDT subset while total
+    /// markets stay roughly the same, so it is accepted (so the dead USDT pairs
+    /// stop being queried) and the stored base set shrinks accordingly.
+    #[test]
+    fn usdt_to_usd_migration_is_accepted_even_as_bases_collapse() {
+        let mut store = ListingStore::default();
+        store.accept("Bitget", fetched(&["BTC", "ETH", "ICP"], 800), 1_000);
+
+        // Same total markets, but (almost) none quoted in USDT anymore.
+        let outcome = store.accept("Bitget", fetched(&[], 790), 2_000);
+        assert_eq!(outcome, AcceptOutcome::Accepted);
+
+        let listing = store.get("Bitget").unwrap();
+        assert!(listing.bases.is_empty());
+        assert_eq!(listing.total_markets, 790);
+    }
+
+    /// The absolute floor is inclusive: exactly [`MIN_TOTAL_MARKETS`] is
+    /// accepted, one below is rejected.
+    #[test]
+    fn floor_boundary_is_inclusive() {
+        let mut at_floor = ListingStore::default();
+        assert_eq!(
+            at_floor.accept("Mexc", fetched(&["BTC"], MIN_TOTAL_MARKETS as usize), 1),
+            AcceptOutcome::Accepted
+        );
+
+        let mut below_floor = ListingStore::default();
+        assert_eq!(
+            below_floor.accept("Mexc", fetched(&["BTC"], (MIN_TOTAL_MARKETS - 1) as usize), 1),
+            AcceptOutcome::RejectedTooFewMarkets {
+                total: MIN_TOTAL_MARKETS - 1
+            }
+        );
+    }
+
+    /// The retained-fraction guard is inclusive: exactly half the previous total
+    /// (and above the floor) is accepted, just below half is rejected. Uses a
+    /// previous total large enough that half still clears the absolute floor.
+    #[test]
+    fn retained_fraction_boundary_is_inclusive() {
+        let mut store = ListingStore::default();
+        store.accept("Mexc", fetched(&["BTC"], 200), 1);
+
+        // Exactly half of 200 is not below half -> accepted.
+        assert_eq!(
+            store.accept("Mexc", fetched(&["BTC"], 100), 2),
+            AcceptOutcome::Accepted
+        );
+
+        // Restore the previous total to 200, then drop just below half.
+        store.accept("Mexc", fetched(&["BTC"], 200), 3);
+        assert_eq!(
+            store.accept("Mexc", fetched(&["BTC"], 99), 4),
+            AcceptOutcome::RejectedTotalDrop {
+                total: 99,
+                previous: 200
+            }
+        );
+    }
+}

--- a/src/xrc/src/main.rs
+++ b/src/xrc/src/main.rs
@@ -22,6 +22,13 @@ fn transform_forex_http_response(args: TransformArgs) -> HttpResponse {
     xrc::transform_forex_http_response(args)
 }
 
+#[ic_cdk::query]
+// TODO(DEFI-2648): Migrate to non-deprecated.
+#[allow(deprecated)]
+fn transform_listing_http_response(args: TransformArgs) -> HttpResponse {
+    xrc::transform_listing_http_response(args)
+}
+
 #[ic_cdk::init]
 fn init() {
     xrc::init_metrics();

--- a/src/xrc/src/periodic.rs
+++ b/src/xrc/src/periodic.rs
@@ -1,4 +1,7 @@
-use std::{cell::Cell, collections::HashSet};
+use std::{
+    cell::{Cell, RefCell},
+    collections::{BTreeMap, HashSet},
+};
 
 use async_trait::async_trait;
 use chrono::{Datelike, NaiveDateTime, Weekday};
@@ -19,7 +22,14 @@ use crate::{
 thread_local! {
     static NEXT_RUN_SCHEDULED_AT_TIMESTAMP: Cell<u64> = const { Cell::new(0) };
     static IS_UPDATING_FOREX_STORE: Cell<bool> = const { Cell::new(false) };
-    static NEXT_LISTING_RUN_SCHEDULED_AT_TIMESTAMP: Cell<u64> = const { Cell::new(0) };
+    // Each exchange's listing is refreshed on its own schedule (see
+    // `update_listing_store`): the next-attempt timestamp per exchange. A
+    // missing entry means "due now" (treated as 0), so a fresh canister or the
+    // first heartbeat after an upgrade sweeps every exchange once. Exactly one
+    // timestamp per exchange, always overwritten — never a second queued slot —
+    // so a long outage yields one outcall per retry interval, never a pile-up.
+    static NEXT_LISTING_RUN_BY_EXCHANGE: RefCell<BTreeMap<String, u64>> =
+        const { RefCell::new(BTreeMap::new()) };
     static IS_UPDATING_LISTING_STORE: Cell<bool> = const { Cell::new(false) };
 }
 
@@ -292,22 +302,27 @@ fn get_next_run_timestamp(timestamp: u64) -> u64 {
     (timestamp - (timestamp % SIX_HOURS)) + SIX_HOURS
 }
 
-// The per-exchange listings are refreshed roughly once a day.
+// Each exchange's listing is refreshed roughly once a day.
 const LISTING_REFRESH_INTERVAL: u64 = ONE_DAY_SECONDS;
 
-// When a refresh accepts no exchange at all (every fetch failed or was
-// rejected), retry after this much shorter interval instead of waiting a full
-// day, so a transient outage doesn't cost a day of staleness.
+// When an exchange's fetch fails or is rejected, retry it after this much
+// shorter interval instead of waiting a full day, so a transient outage of one
+// exchange doesn't cost a day of staleness for that exchange.
 const LISTING_RETRY_INTERVAL: u64 = ONE_HOUR_SECONDS;
 
-fn get_next_listing_run_scheduled_at_timestamp() -> u64 {
-    NEXT_LISTING_RUN_SCHEDULED_AT_TIMESTAMP.with(|cell| cell.get())
+fn listing_next_attempt_at(exchange: &str) -> u64 {
+    NEXT_LISTING_RUN_BY_EXCHANGE.with(|map| map.borrow().get(exchange).copied().unwrap_or(0))
 }
 
-fn set_next_listing_run_scheduled_at_timestamp(timestamp: u64) {
-    NEXT_LISTING_RUN_SCHEDULED_AT_TIMESTAMP.with(|cell| cell.set(timestamp));
+fn set_listing_next_attempt_at(exchange: &str, timestamp: u64) {
+    NEXT_LISTING_RUN_BY_EXCHANGE.with(|map| {
+        map.borrow_mut().insert(exchange.to_string(), timestamp);
+    });
 }
 
+// The aligned daily boundary strictly after `timestamp`: healthy exchanges all
+// converge to the same daily refresh time regardless of when each last
+// succeeded.
 fn get_next_listing_run_timestamp(timestamp: u64) -> u64 {
     (timestamp - (timestamp % LISTING_REFRESH_INTERVAL)) + LISTING_REFRESH_INTERVAL
 }
@@ -331,22 +346,41 @@ impl Drop for UpdatingListingStoreGuard {
     }
 }
 
-/// Fetches each available exchange's spot listing. Behind a trait so the
-/// refresh logic can be unit-tested without real HTTP outcalls.
+/// Fetches per-exchange spot listings. Behind a trait so the refresh logic can
+/// be unit-tested without real HTTP outcalls.
 #[async_trait]
 trait ListingSources {
-    /// One listing fetch per available exchange: `(exchange name, result)`.
-    async fn call(&self) -> Vec<(String, Result<ListedPairs, CallExchangeError>)>;
+    /// All exchanges this source can fetch — the candidates the scheduler picks
+    /// the due ones from.
+    fn exchange_names(&self) -> Vec<String>;
+
+    /// One listing fetch per requested exchange: `(exchange name, result)`.
+    async fn call(&self, exchanges: &[String])
+        -> Vec<(String, Result<ListedPairs, CallExchangeError>)>;
 }
 
 struct ListingSourcesImpl;
 
 #[async_trait]
 impl ListingSources for ListingSourcesImpl {
-    async fn call(&self) -> Vec<(String, Result<ListedPairs, CallExchangeError>)> {
+    fn exchange_names(&self) -> Vec<String> {
+        EXCHANGES
+            .iter()
+            .filter(|exchange| exchange.is_available())
+            .map(|exchange| exchange.name().to_string())
+            .collect()
+    }
+
+    async fn call(
+        &self,
+        exchanges: &[String],
+    ) -> Vec<(String, Result<ListedPairs, CallExchangeError>)> {
         let mut names = vec![];
         let mut futures = vec![];
-        for exchange in EXCHANGES.iter().filter(|exchange| exchange.is_available()) {
+        for exchange in EXCHANGES
+            .iter()
+            .filter(|exchange| exchange.is_available() && exchanges.iter().any(|e| e == exchange.name()))
+        {
             names.push(exchange.name().to_string());
             futures.push(call_exchange_listing(exchange));
         }
@@ -361,36 +395,60 @@ enum UpdateListingStoreResult {
     Success,
 }
 
-/// Refreshes the per-exchange listing store once the daily interval has
-/// elapsed. Each exchange is independent: an accepted listing replaces the
-/// stored one, while a rejected (guard) or failed (HTTP) fetch leaves the
-/// last-known-good listing in place.
+/// Refreshes the listing store for every exchange whose own next-attempt time
+/// has elapsed. Each exchange is scheduled independently: an accepted listing
+/// replaces the stored one and reschedules that exchange at the next daily
+/// boundary, while a rejected (guard) or failed (HTTP) fetch leaves the
+/// last-known-good listing in place and reschedules that exchange after the
+/// short retry interval — so one exchange's outage is retried hourly without
+/// dragging the healthy ones off their daily cadence.
 async fn update_listing_store(
     timestamp: u64,
     listing_sources: &impl ListingSources,
 ) -> UpdateListingStoreResult {
-    let next_run_at = get_next_listing_run_scheduled_at_timestamp();
-    if next_run_at > 0 && next_run_at > timestamp {
-        return UpdateListingStoreResult::NotReady;
-    }
-
     let _guard = match UpdatingListingStoreGuard::new() {
         Some(guard) => guard,
         None => return UpdateListingStoreResult::AlreadyRunning,
     };
 
-    let mut accepted = 0u32;
-    for (exchange, result) in listing_sources.call().await {
+    // Pick the exchanges due this tick (next-attempt time elapsed, or never
+    // scheduled). Nothing due is the common case on most heartbeats.
+    let due: Vec<String> = listing_sources
+        .exchange_names()
+        .into_iter()
+        .filter(|exchange| listing_next_attempt_at(exchange) <= timestamp)
+        .collect();
+    if due.is_empty() {
+        return UpdateListingStoreResult::NotReady;
+    }
+
+    // Reschedule each due exchange at the retry interval BEFORE the outcalls.
+    // State changes made after an await are rolled back if the logic below
+    // traps; without this a due exchange would re-fire on every heartbeat. As
+    // each exchange holds exactly one next-attempt timestamp that we overwrite
+    // (never a second queued slot), this also guarantees a long outage fires at
+    // most one outcall per retry interval — never two-at-once after a day down.
+    // Accepted exchanges are bumped to the daily boundary once the fetch lands.
+    for exchange in &due {
+        set_listing_next_attempt_at(exchange, timestamp + LISTING_RETRY_INTERVAL);
+    }
+
+    for (exchange, result) in listing_sources.call(&due).await {
         match result {
             Ok(listed) => {
                 let outcome =
                     with_listing_store_mut(|store| store.accept(&exchange, listed, timestamp));
                 match outcome {
                     AcceptOutcome::Accepted => {
-                        accepted += 1;
+                        // Success: rejoin the aligned daily cadence.
+                        set_listing_next_attempt_at(
+                            &exchange,
+                            get_next_listing_run_timestamp(timestamp),
+                        );
                         record_accepted_listing_metrics(&exchange);
                     }
                     rejected => {
+                        // Keep the retry interval scheduled above.
                         increment_labeled_counter(
                             MetricName::ExchangeListingRejectedTotal,
                             &[(LabelKey::Exchange, &exchange), (LabelKey::Reason, "guard")],
@@ -405,7 +463,8 @@ async fn update_listing_store(
                 }
             }
             Err(error) => {
-                // Keep the last-known-good listing on a failed fetch.
+                // Keep the last-known-good listing and the retry interval
+                // scheduled above on a failed fetch.
                 increment_labeled_counter(
                     MetricName::ExchangeListingRejectedTotal,
                     &[(LabelKey::Exchange, &exchange), (LabelKey::Reason, "fetch")],
@@ -415,15 +474,6 @@ async fn update_listing_store(
         }
     }
 
-    // On a total failure (nothing accepted) retry soon rather than waiting for
-    // the next daily boundary; any accepted exchange means the others keep their
-    // last-known-good listing and a daily cadence is fine.
-    let next_run = if accepted == 0 {
-        timestamp + LISTING_RETRY_INTERVAL
-    } else {
-        get_next_listing_run_timestamp(timestamp)
-    };
-    set_next_listing_run_scheduled_at_timestamp(next_run);
     UpdateListingStoreResult::Success
 }
 
@@ -789,6 +839,7 @@ mod test {
     mod listing_refresh {
         use super::*;
         use std::collections::BTreeSet;
+        use std::sync::Mutex;
 
         /// A canned listing fetch outcome for one exchange.
         enum MockResult {
@@ -798,13 +849,40 @@ mod test {
 
         struct MockListingSources {
             results: Vec<(String, MockResult)>,
+            /// The `due` list passed to each `call`, in order — so tests can
+            /// assert exactly which exchanges were fetched on each tick.
+            /// `Mutex` (not `RefCell`) so the boxed future stays `Send`.
+            fetched: Mutex<Vec<Vec<String>>>,
+        }
+
+        impl MockListingSources {
+            fn new(results: Vec<(String, MockResult)>) -> Self {
+                Self {
+                    results,
+                    fetched: Mutex::new(vec![]),
+                }
+            }
+
+            /// The `due` lists recorded across every `call`.
+            fn fetched(&self) -> Vec<Vec<String>> {
+                self.fetched.lock().unwrap().clone()
+            }
         }
 
         #[async_trait]
         impl ListingSources for MockListingSources {
-            async fn call(&self) -> Vec<(String, Result<ListedPairs, CallExchangeError>)> {
+            fn exchange_names(&self) -> Vec<String> {
+                self.results.iter().map(|(name, _)| name.clone()).collect()
+            }
+
+            async fn call(
+                &self,
+                exchanges: &[String],
+            ) -> Vec<(String, Result<ListedPairs, CallExchangeError>)> {
+                self.fetched.lock().unwrap().push(exchanges.to_vec());
                 self.results
                     .iter()
+                    .filter(|(name, _)| exchanges.iter().any(|e| e == name))
                     .map(|(name, result)| {
                         let result = match result {
                             MockResult::Listed(listed) => Ok(listed.clone()),
@@ -830,21 +908,19 @@ mod test {
             bases.iter().map(|s| s.to_string()).collect()
         }
 
-        /// Make the daily gate ready to run.
+        /// Reset every exchange's schedule so all are due to run.
         fn ready() {
-            set_next_listing_run_scheduled_at_timestamp(0);
+            NEXT_LISTING_RUN_BY_EXCHANGE.with(|map| map.borrow_mut().clear());
         }
 
         /// An accepted refresh populates the store with the fetched bases.
         #[test]
         fn accepted_listing_populates_store() {
             ready();
-            let sources = MockListingSources {
-                results: vec![(
-                    "ListingTestAccept".to_string(),
-                    MockResult::Listed(listed(&["BTC", "ICP"], 300)),
-                )],
-            };
+            let sources = MockListingSources::new(vec![(
+                "ListingTestAccept".to_string(),
+                MockResult::Listed(listed(&["BTC", "ICP"], 300)),
+            )]);
             let result = update_listing_store(1_000, &sources)
                 .now_or_never()
                 .expect("should complete");
@@ -862,9 +938,8 @@ mod test {
             ready();
             with_listing_store_mut(|store| store.accept("ListingTestErr", listed(&["BTC"], 500), 1));
 
-            let sources = MockListingSources {
-                results: vec![("ListingTestErr".to_string(), MockResult::HttpError)],
-            };
+            let sources =
+                MockListingSources::new(vec![("ListingTestErr".to_string(), MockResult::HttpError)]);
             update_listing_store(2_000, &sources)
                 .now_or_never()
                 .expect("should complete");
@@ -882,12 +957,10 @@ mod test {
             with_listing_store_mut(|store| store.accept("ListingTestRej", listed(&["BTC"], 500), 1));
 
             // Below the absolute floor -> rejected.
-            let sources = MockListingSources {
-                results: vec![(
-                    "ListingTestRej".to_string(),
-                    MockResult::Listed(listed(&["BTC"], 3)),
-                )],
-            };
+            let sources = MockListingSources::new(vec![(
+                "ListingTestRej".to_string(),
+                MockResult::Listed(listed(&["BTC"], 3)),
+            )]);
             update_listing_store(2_000, &sources)
                 .now_or_never()
                 .expect("should complete");
@@ -897,18 +970,17 @@ mod test {
             assert_eq!(stored.total_markets, 500);
         }
 
-        /// The refresh only runs once the daily interval has elapsed, and then
-        /// (when at least one exchange was accepted) schedules the next run at
-        /// the following daily boundary.
+        /// An exchange is not fetched until its own next-attempt time has
+        /// elapsed, and an accepted refresh reschedules it at the following
+        /// daily boundary.
         #[test]
         fn respects_daily_interval() {
-            set_next_listing_run_scheduled_at_timestamp(1_000_000);
-            let sources = MockListingSources {
-                results: vec![(
-                    "ListingTestDaily".to_string(),
-                    MockResult::Listed(listed(&["BTC", "ETH"], 300)),
-                )],
-            };
+            ready();
+            set_listing_next_attempt_at("ListingTestDaily", 1_000_000);
+            let sources = MockListingSources::new(vec![(
+                "ListingTestDaily".to_string(),
+                MockResult::Listed(listed(&["BTC", "ETH"], 300)),
+            )]);
 
             let result = update_listing_store(999_999, &sources)
                 .now_or_never()
@@ -920,37 +992,117 @@ mod test {
                 .expect("should complete");
             assert_eq!(result, UpdateListingStoreResult::Success);
             assert_eq!(
-                get_next_listing_run_scheduled_at_timestamp(),
+                listing_next_attempt_at("ListingTestDaily"),
                 get_next_listing_run_timestamp(1_000_001)
             );
         }
 
-        /// When no exchange is accepted (every fetch failed or was rejected),
-        /// the next run is scheduled after the short retry interval rather than
-        /// at the next daily boundary.
+        /// A failed fetch reschedules that exchange after the short retry
+        /// interval rather than at the next daily boundary.
         #[test]
-        fn total_failure_schedules_short_retry() {
+        fn failed_fetch_schedules_short_retry() {
             ready();
-            let sources = MockListingSources {
-                results: vec![("ListingTestRetry".to_string(), MockResult::HttpError)],
-            };
+            let sources = MockListingSources::new(vec![(
+                "ListingTestRetry".to_string(),
+                MockResult::HttpError,
+            )]);
 
             let result = update_listing_store(1_000, &sources)
                 .now_or_never()
                 .expect("should complete");
             assert_eq!(result, UpdateListingStoreResult::Success);
             assert_eq!(
-                get_next_listing_run_scheduled_at_timestamp(),
+                listing_next_attempt_at("ListingTestRetry"),
                 1_000 + LISTING_RETRY_INTERVAL
+            );
+        }
+
+        /// Each exchange is scheduled independently: a single exchange's outage
+        /// is retried hourly while the healthy ones keep their daily cadence,
+        /// and the down exchange snaps back to daily once it recovers.
+        #[test]
+        fn down_exchange_retries_hourly_without_dragging_healthy_ones() {
+            ready();
+            let down = "ListingTestDown".to_string();
+            let healthy = "ListingTestHealthy".to_string();
+
+            // First sweep: both due, one fails, one succeeds.
+            let sources = MockListingSources::new(vec![
+                (down.clone(), MockResult::HttpError),
+                (healthy.clone(), MockResult::Listed(listed(&["BTC"], 300))),
+            ]);
+            update_listing_store(1_000, &sources)
+                .now_or_never()
+                .expect("should complete");
+            assert_eq!(listing_next_attempt_at(&down), 1_000 + LISTING_RETRY_INTERVAL);
+            assert_eq!(
+                listing_next_attempt_at(&healthy),
+                get_next_listing_run_timestamp(1_000)
+            );
+
+            // One retry interval later only the down exchange is due, and it
+            // now recovers and rejoins the daily cadence.
+            let later = 1_000 + LISTING_RETRY_INTERVAL;
+            let sources = MockListingSources::new(vec![
+                (down.clone(), MockResult::Listed(listed(&["ETH"], 300))),
+                (healthy.clone(), MockResult::Listed(listed(&["BTC"], 300))),
+            ]);
+            update_listing_store(later, &sources)
+                .now_or_never()
+                .expect("should complete");
+            // Only the down exchange was fetched this tick.
+            assert_eq!(sources.fetched(), vec![vec![down.clone()]]);
+            assert_eq!(
+                listing_next_attempt_at(&down),
+                get_next_listing_run_timestamp(later)
+            );
+        }
+
+        /// A persistently failing exchange fires at most one outcall per retry
+        /// interval — its single next-attempt timestamp is overwritten, never
+        /// queued, so failures can't pile up into multiple simultaneous calls.
+        #[test]
+        fn persistent_failure_fires_once_per_interval_no_pileup() {
+            ready();
+            let exchange = "ListingTestNoPileup".to_string();
+            let sources =
+                MockListingSources::new(vec![(exchange.clone(), MockResult::HttpError)]);
+
+            // Due now -> fires, reschedules one interval out.
+            update_listing_store(1_000, &sources)
+                .now_or_never()
+                .expect("should complete");
+            assert_eq!(listing_next_attempt_at(&exchange), 1_000 + LISTING_RETRY_INTERVAL);
+
+            // Still within the interval -> not due, no fetch.
+            let result = update_listing_store(1_000 + LISTING_RETRY_INTERVAL - 1, &sources)
+                .now_or_never()
+                .expect("should complete");
+            assert_eq!(result, UpdateListingStoreResult::NotReady);
+
+            // Interval elapsed -> fires once more, advancing by exactly one
+            // interval (not two).
+            update_listing_store(1_000 + LISTING_RETRY_INTERVAL, &sources)
+                .now_or_never()
+                .expect("should complete");
+            assert_eq!(
+                listing_next_attempt_at(&exchange),
+                1_000 + 2 * LISTING_RETRY_INTERVAL
+            );
+
+            // Exactly one fetch per due tick, never a pile-up.
+            assert_eq!(
+                sources.fetched(),
+                vec![vec![exchange.clone()], vec![exchange.clone()]]
             );
         }
 
         /// Only one refresh runs at a time.
         #[test]
         fn only_one_update_at_a_time() {
-            set_next_listing_run_scheduled_at_timestamp(0);
+            ready();
             IS_UPDATING_LISTING_STORE.with(|cell| cell.set(true));
-            let sources = MockListingSources { results: vec![] };
+            let sources = MockListingSources::new(vec![]);
 
             let result = update_listing_store(1, &sources)
                 .now_or_never()
@@ -980,19 +1132,17 @@ mod test {
                 store.accept("ListingTestMetricsGuard", listed(&["BTC"], 500), 1)
             });
 
-            let sources = MockListingSources {
-                results: vec![
-                    (
-                        "ListingTestMetrics".to_string(),
-                        MockResult::Listed(listed(&["BTC", "ICP"], 300)),
-                    ),
-                    ("ListingTestMetricsErr".to_string(), MockResult::HttpError),
-                    (
-                        "ListingTestMetricsGuard".to_string(),
-                        MockResult::Listed(listed(&["BTC"], 3)),
-                    ),
-                ],
-            };
+            let sources = MockListingSources::new(vec![
+                (
+                    "ListingTestMetrics".to_string(),
+                    MockResult::Listed(listed(&["BTC", "ICP"], 300)),
+                ),
+                ("ListingTestMetricsErr".to_string(), MockResult::HttpError),
+                (
+                    "ListingTestMetricsGuard".to_string(),
+                    MockResult::Listed(listed(&["BTC"], 3)),
+                ),
+            ]);
             update_listing_store(1_700, &sources)
                 .now_or_never()
                 .expect("should complete");

--- a/src/xrc/src/periodic.rs
+++ b/src/xrc/src/periodic.rs
@@ -295,6 +295,11 @@ fn get_next_run_timestamp(timestamp: u64) -> u64 {
 // The per-exchange listings are refreshed roughly once a day.
 const LISTING_REFRESH_INTERVAL: u64 = ONE_DAY_SECONDS;
 
+// When a refresh accepts no exchange at all (every fetch failed or was
+// rejected), retry after this much shorter interval instead of waiting a full
+// day, so a transient outage doesn't cost a day of staleness.
+const LISTING_RETRY_INTERVAL: u64 = ONE_HOUR_SECONDS;
+
 fn get_next_listing_run_scheduled_at_timestamp() -> u64 {
     NEXT_LISTING_RUN_SCHEDULED_AT_TIMESTAMP.with(|cell| cell.get())
 }
@@ -374,13 +379,17 @@ async fn update_listing_store(
         None => return UpdateListingStoreResult::AlreadyRunning,
     };
 
+    let mut accepted = 0u32;
     for (exchange, result) in listing_sources.call().await {
         match result {
             Ok(listed) => {
                 let outcome =
                     with_listing_store_mut(|store| store.accept(&exchange, listed, timestamp));
                 match outcome {
-                    AcceptOutcome::Accepted => record_accepted_listing_metrics(&exchange),
+                    AcceptOutcome::Accepted => {
+                        accepted += 1;
+                        record_accepted_listing_metrics(&exchange);
+                    }
                     rejected => {
                         increment_labeled_counter(
                             MetricName::ExchangeListingRejectedTotal,
@@ -406,7 +415,15 @@ async fn update_listing_store(
         }
     }
 
-    set_next_listing_run_scheduled_at_timestamp(get_next_listing_run_timestamp(timestamp));
+    // On a total failure (nothing accepted) retry soon rather than waiting for
+    // the next daily boundary; any accepted exchange means the others keep their
+    // last-known-good listing and a daily cadence is fine.
+    let next_run = if accepted == 0 {
+        timestamp + LISTING_RETRY_INTERVAL
+    } else {
+        get_next_listing_run_timestamp(timestamp)
+    };
+    set_next_listing_run_scheduled_at_timestamp(next_run);
     UpdateListingStoreResult::Success
 }
 
@@ -881,11 +898,17 @@ mod test {
         }
 
         /// The refresh only runs once the daily interval has elapsed, and then
-        /// schedules the next run at the following daily boundary.
+        /// (when at least one exchange was accepted) schedules the next run at
+        /// the following daily boundary.
         #[test]
         fn respects_daily_interval() {
             set_next_listing_run_scheduled_at_timestamp(1_000_000);
-            let sources = MockListingSources { results: vec![] };
+            let sources = MockListingSources {
+                results: vec![(
+                    "ListingTestDaily".to_string(),
+                    MockResult::Listed(listed(&["BTC", "ETH"], 300)),
+                )],
+            };
 
             let result = update_listing_store(999_999, &sources)
                 .now_or_never()
@@ -899,6 +922,26 @@ mod test {
             assert_eq!(
                 get_next_listing_run_scheduled_at_timestamp(),
                 get_next_listing_run_timestamp(1_000_001)
+            );
+        }
+
+        /// When no exchange is accepted (every fetch failed or was rejected),
+        /// the next run is scheduled after the short retry interval rather than
+        /// at the next daily boundary.
+        #[test]
+        fn total_failure_schedules_short_retry() {
+            ready();
+            let sources = MockListingSources {
+                results: vec![("ListingTestRetry".to_string(), MockResult::HttpError)],
+            };
+
+            let result = update_listing_store(1_000, &sources)
+                .now_or_never()
+                .expect("should complete");
+            assert_eq!(result, UpdateListingStoreResult::Success);
+            assert_eq!(
+                get_next_listing_run_scheduled_at_timestamp(),
+                1_000 + LISTING_RETRY_INTERVAL
             );
         }
 

--- a/src/xrc/src/periodic.rs
+++ b/src/xrc/src/periodic.rs
@@ -464,12 +464,20 @@ async fn update_listing_store(
             }
             Err(error) => {
                 // Keep the last-known-good listing and the retry interval
-                // scheduled above on a failed fetch.
+                // scheduled above on a failed fetch. Log the structured error
+                // (Debug): the Display impl is worded for rate fetching
+                // ("Failed to retrieve rate from ..."), which would be
+                // misleading for a listing refresh.
                 increment_labeled_counter(
                     MetricName::ExchangeListingRejectedTotal,
                     &[(LabelKey::Exchange, &exchange), (LabelKey::Reason, "fetch")],
                 );
-                ic_cdk::println!("{} [listing] {} {}", LOG_PREFIX, exchange, error);
+                ic_cdk::println!(
+                    "{} [listing] {} refresh fetch failed: {:?}",
+                    LOG_PREFIX,
+                    exchange,
+                    error
+                );
             }
         }
     }

--- a/src/xrc/src/periodic.rs
+++ b/src/xrc/src/periodic.rs
@@ -11,8 +11,9 @@ use crate::{
     increment_labeled_counter,
     listings::AcceptOutcome,
     set_labeled_gauge, with_forex_rate_collector, with_forex_rate_collector_mut,
-    with_forex_rate_store_mut, with_listing_store_mut, CallExchangeError, CallForexError, LabelKey,
-    MetricName, Outcome, EXCHANGES, LOG_PREFIX, ONE_DAY_SECONDS, ONE_HOUR_SECONDS, USD,
+    with_forex_rate_store_mut, with_listing_store, with_listing_store_mut, CallExchangeError,
+    CallForexError, LabelKey, MetricName, Outcome, EXCHANGES, LOG_PREFIX, ONE_DAY_SECONDS,
+    ONE_HOUR_SECONDS, USD,
 };
 
 thread_local! {
@@ -378,17 +379,28 @@ async fn update_listing_store(
             Ok(listed) => {
                 let outcome =
                     with_listing_store_mut(|store| store.accept(&exchange, listed, timestamp));
-                if !matches!(outcome, AcceptOutcome::Accepted) {
-                    ic_cdk::println!(
-                        "{} [listing] {} refresh rejected: {:?}",
-                        LOG_PREFIX,
-                        exchange,
-                        outcome
-                    );
+                match outcome {
+                    AcceptOutcome::Accepted => record_accepted_listing_metrics(&exchange),
+                    rejected => {
+                        increment_labeled_counter(
+                            MetricName::ExchangeListingRejectedTotal,
+                            &[(LabelKey::Exchange, &exchange)],
+                        );
+                        ic_cdk::println!(
+                            "{} [listing] {} refresh rejected: {:?}",
+                            LOG_PREFIX,
+                            exchange,
+                            rejected
+                        );
+                    }
                 }
             }
             Err(error) => {
                 // Keep the last-known-good listing on a failed fetch.
+                increment_labeled_counter(
+                    MetricName::ExchangeListingRejectedTotal,
+                    &[(LabelKey::Exchange, &exchange)],
+                );
                 ic_cdk::println!("{} [listing] {} {}", LOG_PREFIX, exchange, error);
             }
         }
@@ -396,6 +408,29 @@ async fn update_listing_store(
 
     set_next_listing_run_scheduled_at_timestamp(get_next_listing_run_timestamp(timestamp));
     UpdateListingStoreResult::Success
+}
+
+/// Sets the three per-exchange listing gauges from the just-accepted listing.
+fn record_accepted_listing_metrics(exchange: &str) {
+    with_listing_store(|store| {
+        if let Some(listing) = store.get(exchange) {
+            set_labeled_gauge(
+                MetricName::ExchangeListedUsdtPairs,
+                &[(LabelKey::Exchange, exchange)],
+                listing.bases.len() as f64,
+            );
+            set_labeled_gauge(
+                MetricName::ExchangeListingTotalMarkets,
+                &[(LabelKey::Exchange, exchange)],
+                listing.total_markets as f64,
+            );
+            set_labeled_gauge(
+                MetricName::ExchangeListingLastSuccessSeconds,
+                &[(LabelKey::Exchange, exchange)],
+                listing.last_success_secs as f64,
+            );
+        }
+    });
 }
 
 #[cfg(test)]
@@ -881,6 +916,56 @@ mod test {
 
             // Reset so the flag doesn't leak to another test on this thread.
             IS_UPDATING_LISTING_STORE.with(|cell| cell.set(false));
+        }
+
+        /// An accepted refresh sets the three per-exchange gauges; a failed
+        /// fetch increments the rejected counter.
+        #[test]
+        fn records_gauges_on_accept_and_counter_on_failure() {
+            use crate::{
+                make_metric_key, reset_labeled_metrics_for_test, with_labeled_counters,
+                with_labeled_gauges,
+            };
+            reset_labeled_metrics_for_test();
+            ready();
+
+            let sources = MockListingSources {
+                results: vec![
+                    (
+                        "ListingTestMetrics".to_string(),
+                        MockResult::Listed(listed(&["BTC", "ICP"], 300)),
+                    ),
+                    ("ListingTestMetricsErr".to_string(), MockResult::HttpError),
+                ],
+            };
+            update_listing_store(1_700, &sources)
+                .now_or_never()
+                .expect("should complete");
+
+            with_labeled_gauges(|m| {
+                let pairs = make_metric_key(
+                    MetricName::ExchangeListedUsdtPairs,
+                    &[(LabelKey::Exchange, "ListingTestMetrics")],
+                );
+                assert_eq!(m.get(&pairs).copied(), Some(2.0));
+                let total = make_metric_key(
+                    MetricName::ExchangeListingTotalMarkets,
+                    &[(LabelKey::Exchange, "ListingTestMetrics")],
+                );
+                assert_eq!(m.get(&total).copied(), Some(300.0));
+                let last = make_metric_key(
+                    MetricName::ExchangeListingLastSuccessSeconds,
+                    &[(LabelKey::Exchange, "ListingTestMetrics")],
+                );
+                assert_eq!(m.get(&last).copied(), Some(1_700.0));
+            });
+            with_labeled_counters(|m| {
+                let rejected = make_metric_key(
+                    MetricName::ExchangeListingRejectedTotal,
+                    &[(LabelKey::Exchange, "ListingTestMetricsErr")],
+                );
+                assert_eq!(m.get(&rejected).copied(), Some(1));
+            });
         }
     }
 

--- a/src/xrc/src/periodic.rs
+++ b/src/xrc/src/periodic.rs
@@ -393,7 +393,7 @@ async fn update_listing_store(
                     rejected => {
                         increment_labeled_counter(
                             MetricName::ExchangeListingRejectedTotal,
-                            &[(LabelKey::Exchange, &exchange)],
+                            &[(LabelKey::Exchange, &exchange), (LabelKey::Reason, "guard")],
                         );
                         ic_cdk::println!(
                             "{} [listing] {} refresh rejected: {:?}",
@@ -408,7 +408,7 @@ async fn update_listing_store(
                 // Keep the last-known-good listing on a failed fetch.
                 increment_labeled_counter(
                     MetricName::ExchangeListingRejectedTotal,
-                    &[(LabelKey::Exchange, &exchange)],
+                    &[(LabelKey::Exchange, &exchange), (LabelKey::Reason, "fetch")],
                 );
                 ic_cdk::println!("{} [listing] {} {}", LOG_PREFIX, exchange, error);
             }
@@ -961,8 +961,10 @@ mod test {
             IS_UPDATING_LISTING_STORE.with(|cell| cell.set(false));
         }
 
-        /// An accepted refresh sets the three per-exchange gauges; a failed
-        /// fetch increments the rejected counter.
+        /// An accepted refresh sets the three per-exchange gauges; a rejected
+        /// refresh increments the rejected counter under a `reason` label that
+        /// distinguishes an HTTP failure (`fetch`) from a guard rejection
+        /// (`guard`).
         #[test]
         fn records_gauges_on_accept_and_counter_on_failure() {
             use crate::{
@@ -972,6 +974,12 @@ mod test {
             reset_labeled_metrics_for_test();
             ready();
 
+            // Seed a last-known-good listing so the undersized refresh below is
+            // rejected by the structural guard rather than accepted.
+            with_listing_store_mut(|store| {
+                store.accept("ListingTestMetricsGuard", listed(&["BTC"], 500), 1)
+            });
+
             let sources = MockListingSources {
                 results: vec![
                     (
@@ -979,6 +987,10 @@ mod test {
                         MockResult::Listed(listed(&["BTC", "ICP"], 300)),
                     ),
                     ("ListingTestMetricsErr".to_string(), MockResult::HttpError),
+                    (
+                        "ListingTestMetricsGuard".to_string(),
+                        MockResult::Listed(listed(&["BTC"], 3)),
+                    ),
                 ],
             };
             update_listing_store(1_700, &sources)
@@ -1003,11 +1015,22 @@ mod test {
                 assert_eq!(m.get(&last).copied(), Some(1_700.0));
             });
             with_labeled_counters(|m| {
-                let rejected = make_metric_key(
+                let fetch_failed = make_metric_key(
                     MetricName::ExchangeListingRejectedTotal,
-                    &[(LabelKey::Exchange, "ListingTestMetricsErr")],
+                    &[
+                        (LabelKey::Exchange, "ListingTestMetricsErr"),
+                        (LabelKey::Reason, "fetch"),
+                    ],
                 );
-                assert_eq!(m.get(&rejected).copied(), Some(1));
+                assert_eq!(m.get(&fetch_failed).copied(), Some(1));
+                let guard_rejected = make_metric_key(
+                    MetricName::ExchangeListingRejectedTotal,
+                    &[
+                        (LabelKey::Exchange, "ListingTestMetricsGuard"),
+                        (LabelKey::Reason, "guard"),
+                    ],
+                );
+                assert_eq!(m.get(&guard_rejected).copied(), Some(1));
             });
         }
     }

--- a/src/xrc/src/periodic.rs
+++ b/src/xrc/src/periodic.rs
@@ -5,16 +5,21 @@ use chrono::{Datelike, NaiveDateTime, Weekday};
 use futures::future::join_all;
 
 use crate::{
-    call_forex,
+    call_exchange_listing, call_forex,
+    exchanges::ListedPairs,
     forex::{Forex, ForexContextArgs, ForexRateMap, FOREX_SOURCES},
-    increment_labeled_counter, set_labeled_gauge, with_forex_rate_collector,
-    with_forex_rate_collector_mut, with_forex_rate_store_mut, CallForexError, LabelKey,
-    MetricName, Outcome, LOG_PREFIX, ONE_DAY_SECONDS, ONE_HOUR_SECONDS, USD,
+    increment_labeled_counter,
+    listings::AcceptOutcome,
+    set_labeled_gauge, with_forex_rate_collector, with_forex_rate_collector_mut,
+    with_forex_rate_store_mut, with_listing_store_mut, CallExchangeError, CallForexError, LabelKey,
+    MetricName, Outcome, EXCHANGES, LOG_PREFIX, ONE_DAY_SECONDS, ONE_HOUR_SECONDS, USD,
 };
 
 thread_local! {
     static NEXT_RUN_SCHEDULED_AT_TIMESTAMP: Cell<u64> = const { Cell::new(0) };
     static IS_UPDATING_FOREX_STORE: Cell<bool> = const { Cell::new(false) };
+    static NEXT_LISTING_RUN_SCHEDULED_AT_TIMESTAMP: Cell<u64> = const { Cell::new(0) };
+    static IS_UPDATING_LISTING_STORE: Cell<bool> = const { Cell::new(false) };
 }
 
 // 6 hours in seconds
@@ -179,6 +184,9 @@ fn get_forexes_with_timestamps_and_context(
 pub async fn run_tasks(timestamp: u64) {
     let forex_sources = ForexSourcesImpl;
     update_forex_store(timestamp, &forex_sources).await;
+
+    let listing_sources = ListingSourcesImpl;
+    update_listing_store(timestamp, &listing_sources).await;
 }
 
 #[derive(Debug)]
@@ -281,6 +289,113 @@ fn record_per_forex_metrics(
 
 fn get_next_run_timestamp(timestamp: u64) -> u64 {
     (timestamp - (timestamp % SIX_HOURS)) + SIX_HOURS
+}
+
+// The per-exchange listings are refreshed roughly once a day.
+const LISTING_REFRESH_INTERVAL: u64 = ONE_DAY_SECONDS;
+
+fn get_next_listing_run_scheduled_at_timestamp() -> u64 {
+    NEXT_LISTING_RUN_SCHEDULED_AT_TIMESTAMP.with(|cell| cell.get())
+}
+
+fn set_next_listing_run_scheduled_at_timestamp(timestamp: u64) {
+    NEXT_LISTING_RUN_SCHEDULED_AT_TIMESTAMP.with(|cell| cell.set(timestamp));
+}
+
+fn get_next_listing_run_timestamp(timestamp: u64) -> u64 {
+    (timestamp - (timestamp % LISTING_REFRESH_INTERVAL)) + LISTING_REFRESH_INTERVAL
+}
+
+struct UpdatingListingStoreGuard;
+
+impl UpdatingListingStoreGuard {
+    fn new() -> Option<Self> {
+        if IS_UPDATING_LISTING_STORE.with(|cell| cell.get()) {
+            return None;
+        }
+
+        IS_UPDATING_LISTING_STORE.with(|cell| cell.set(true));
+        Some(Self)
+    }
+}
+
+impl Drop for UpdatingListingStoreGuard {
+    fn drop(&mut self) {
+        IS_UPDATING_LISTING_STORE.with(|cell| cell.set(false));
+    }
+}
+
+/// Fetches each available exchange's spot listing. Behind a trait so the
+/// refresh logic can be unit-tested without real HTTP outcalls.
+#[async_trait]
+trait ListingSources {
+    /// One listing fetch per available exchange: `(exchange name, result)`.
+    async fn call(&self) -> Vec<(String, Result<ListedPairs, CallExchangeError>)>;
+}
+
+struct ListingSourcesImpl;
+
+#[async_trait]
+impl ListingSources for ListingSourcesImpl {
+    async fn call(&self) -> Vec<(String, Result<ListedPairs, CallExchangeError>)> {
+        let mut names = vec![];
+        let mut futures = vec![];
+        for exchange in EXCHANGES.iter().filter(|exchange| exchange.is_available()) {
+            names.push(exchange.name().to_string());
+            futures.push(call_exchange_listing(exchange));
+        }
+        names.into_iter().zip(join_all(futures).await).collect()
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum UpdateListingStoreResult {
+    AlreadyRunning,
+    NotReady,
+    Success,
+}
+
+/// Refreshes the per-exchange listing store once the daily interval has
+/// elapsed. Each exchange is independent: an accepted listing replaces the
+/// stored one, while a rejected (guard) or failed (HTTP) fetch leaves the
+/// last-known-good listing in place.
+async fn update_listing_store(
+    timestamp: u64,
+    listing_sources: &impl ListingSources,
+) -> UpdateListingStoreResult {
+    let next_run_at = get_next_listing_run_scheduled_at_timestamp();
+    if next_run_at > 0 && next_run_at > timestamp {
+        return UpdateListingStoreResult::NotReady;
+    }
+
+    let _guard = match UpdatingListingStoreGuard::new() {
+        Some(guard) => guard,
+        None => return UpdateListingStoreResult::AlreadyRunning,
+    };
+
+    for (exchange, result) in listing_sources.call().await {
+        match result {
+            Ok(listed) => {
+                let outcome =
+                    with_listing_store_mut(|store| store.accept(&exchange, listed, timestamp));
+                if !matches!(outcome, AcceptOutcome::Accepted) {
+                    ic_cdk::println!(
+                        "{} [listing] {} refresh rejected: {:?}",
+                        LOG_PREFIX,
+                        exchange,
+                        outcome
+                    );
+                }
+            }
+            Err(error) => {
+                // Keep the last-known-good listing on a failed fetch.
+                ic_cdk::println!("{} [listing] {} {}", LOG_PREFIX, exchange, error);
+            }
+        }
+    }
+
+    set_next_listing_run_scheduled_at_timestamp(get_next_listing_run_timestamp(timestamp));
+    UpdateListingStoreResult::Success
 }
 
 #[cfg(test)]
@@ -617,6 +732,156 @@ mod test {
             forexes_with_timestamps_and_context[9].2.timestamp,
             1680134400
         );
+    }
+
+    mod listing_refresh {
+        use super::*;
+        use std::collections::BTreeSet;
+
+        /// A canned listing fetch outcome for one exchange.
+        enum MockResult {
+            Listed(ListedPairs),
+            HttpError,
+        }
+
+        struct MockListingSources {
+            results: Vec<(String, MockResult)>,
+        }
+
+        #[async_trait]
+        impl ListingSources for MockListingSources {
+            async fn call(&self) -> Vec<(String, Result<ListedPairs, CallExchangeError>)> {
+                self.results
+                    .iter()
+                    .map(|(name, result)| {
+                        let result = match result {
+                            MockResult::Listed(listed) => Ok(listed.clone()),
+                            MockResult::HttpError => Err(CallExchangeError::Http {
+                                exchange: name.clone(),
+                                error: "boom".to_string(),
+                            }),
+                        };
+                        (name.clone(), result)
+                    })
+                    .collect()
+            }
+        }
+
+        fn listed(bases: &[&str], total_markets: usize) -> ListedPairs {
+            ListedPairs {
+                bases: bases.iter().map(|s| s.to_string()).collect::<BTreeSet<_>>(),
+                total_markets,
+            }
+        }
+
+        fn base_set(bases: &[&str]) -> BTreeSet<String> {
+            bases.iter().map(|s| s.to_string()).collect()
+        }
+
+        /// Make the daily gate ready to run.
+        fn ready() {
+            set_next_listing_run_scheduled_at_timestamp(0);
+        }
+
+        /// An accepted refresh populates the store with the fetched bases.
+        #[test]
+        fn accepted_listing_populates_store() {
+            ready();
+            let sources = MockListingSources {
+                results: vec![(
+                    "ListingTestAccept".to_string(),
+                    MockResult::Listed(listed(&["BTC", "ICP"], 300)),
+                )],
+            };
+            let result = update_listing_store(1_000, &sources)
+                .now_or_never()
+                .expect("should complete");
+            assert_eq!(result, UpdateListingStoreResult::Success);
+
+            let stored = with_listing_store_mut(|store| store.get("ListingTestAccept").cloned())
+                .expect("listing should be stored");
+            assert_eq!(stored.bases, base_set(&["BTC", "ICP"]));
+            assert_eq!(stored.total_markets, 300);
+        }
+
+        /// A failed (HTTP) fetch leaves the last-known-good listing untouched.
+        #[test]
+        fn failed_fetch_keeps_last_good() {
+            ready();
+            with_listing_store_mut(|store| store.accept("ListingTestErr", listed(&["BTC"], 500), 1));
+
+            let sources = MockListingSources {
+                results: vec![("ListingTestErr".to_string(), MockResult::HttpError)],
+            };
+            update_listing_store(2_000, &sources)
+                .now_or_never()
+                .expect("should complete");
+
+            let stored = with_listing_store_mut(|store| store.get("ListingTestErr").cloned())
+                .expect("listing should still be stored");
+            assert_eq!(stored.total_markets, 500);
+            assert_eq!(stored.last_success_secs, 1);
+        }
+
+        /// A refresh rejected by the structural guard keeps the last-good listing.
+        #[test]
+        fn rejected_refresh_keeps_last_good() {
+            ready();
+            with_listing_store_mut(|store| store.accept("ListingTestRej", listed(&["BTC"], 500), 1));
+
+            // Below the absolute floor -> rejected.
+            let sources = MockListingSources {
+                results: vec![(
+                    "ListingTestRej".to_string(),
+                    MockResult::Listed(listed(&["BTC"], 3)),
+                )],
+            };
+            update_listing_store(2_000, &sources)
+                .now_or_never()
+                .expect("should complete");
+
+            let stored = with_listing_store_mut(|store| store.get("ListingTestRej").cloned())
+                .expect("listing should still be stored");
+            assert_eq!(stored.total_markets, 500);
+        }
+
+        /// The refresh only runs once the daily interval has elapsed, and then
+        /// schedules the next run at the following daily boundary.
+        #[test]
+        fn respects_daily_interval() {
+            set_next_listing_run_scheduled_at_timestamp(1_000_000);
+            let sources = MockListingSources { results: vec![] };
+
+            let result = update_listing_store(999_999, &sources)
+                .now_or_never()
+                .expect("should complete");
+            assert_eq!(result, UpdateListingStoreResult::NotReady);
+
+            let result = update_listing_store(1_000_001, &sources)
+                .now_or_never()
+                .expect("should complete");
+            assert_eq!(result, UpdateListingStoreResult::Success);
+            assert_eq!(
+                get_next_listing_run_scheduled_at_timestamp(),
+                get_next_listing_run_timestamp(1_000_001)
+            );
+        }
+
+        /// Only one refresh runs at a time.
+        #[test]
+        fn only_one_update_at_a_time() {
+            set_next_listing_run_scheduled_at_timestamp(0);
+            IS_UPDATING_LISTING_STORE.with(|cell| cell.set(true));
+            let sources = MockListingSources { results: vec![] };
+
+            let result = update_listing_store(1, &sources)
+                .now_or_never()
+                .expect("should complete");
+            assert_eq!(result, UpdateListingStoreResult::AlreadyRunning);
+
+            // Reset so the flag doesn't leak to another test on this thread.
+            IS_UPDATING_LISTING_STORE.with(|cell| cell.set(false));
+        }
     }
 
     mod per_forex_metrics {


### PR DESCRIPTION
## DEFI-2868 PR series

Part of the **DEFI-2868** series — *discover tradable pairs per exchange and gate crypto queries by listed pairs*. The PRs land in order, with the behaviour change deliberately last, after the discovered sets have been observed populating correctly in production:

1. **#330 — listing parsers** (pure, no wiring)
2. **#331 — canbench benchmarks + regression gate** (stacked on #330)
3. **#332 — store + daily refresh + metrics** (populate the sets, still no gating) ← *you are here*
4. **#337 — gate crypto queries on the discovered sets** (the behaviour change; draft — merge/deploy only after #330–#332 are in prod and observed healthy)

---

## Purpose

Stacked on #330. Second step of DEFI-2868: populate and expose the per-exchange USDT listings discovered by #330's parsers, **without changing query behaviour yet**. Gating the crypto path on the discovered sets is the next PR, **#337 (PR3)** — this one lets the sets be watched in prod first.

> Review/merge #330 first; this targets that branch and will be retargeted to `main` once #330 lands.

## What it adds

- **`ListingStore`** (`exchange → { bases, total_markets, last_success_secs }`) with a **structural acceptance guard**: a fetched listing replaces the stored one only if it has at least a floor of total markets and at least half the previously accepted total; otherwise the last-known-good listing is kept. The guard is judged on *total* markets, never the USDT subset, so a USDT→USD migration is accepted while a parser break is rejected.
- **Listing outcall + consensus transform** — the transform parses the (up to ~1.2 MiB) body and replaces it with a small canonical `(sorted bases, total)` payload, so replicas reach consensus on that, not the raw listing.
- **Daily refresh task** on the heartbeat (mirrors the forex update): one outcall per available exchange, each result run through the guard into the store.
- **Four metrics** — `xrc_exchange_listed_usdt_pairs`, `xrc_exchange_listing_total_markets`, `xrc_exchange_listing_last_success_seconds` (gauges) and `xrc_exchange_listing_rejected_total` (counter) — backing the A1/A2/A3 alerts.
- **Stable-memory persistence** — `pre_upgrade`/`post_upgrade` save/restore the store; the listing store is decoded as a trailing `Option` so the first upgrade from the old single-`ForexRateStore` layout doesn't trap.

## Not in this PR

- **No gating.** `get_cryptocurrency_usdt_rate` is unchanged; the store is populated and observable only. The gating read (with fail-open on a missing/stale listing) is **#337**. Once this PR is in production, the four metrics above are how reviewers confirm the discovered sets are correct and refreshing before gating is enabled in #337.

## Verification

clippy `-D warnings` clean; 247 lib unit tests (incl. the guard's worked scenarios, the refresh task with a mock source, the metrics, and the upgrade-migration decode); candid-compat green; production Wasm builds.
