### PR TITLE
test: DEFI-2881: run dfx 0.32.0 in the e2e harness container

### DIFF
--- a/src/xrc-tests/docker/base.Dockerfile
+++ b/src/xrc-tests/docker/base.Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.20.0 AS minica
 RUN apt-get update && apt-get install -y git
 RUN go install github.com/jsha/minica@latest
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y \
     curl \
     gnupg \
     && curl -fsSL https://openresty.org/package/pubkey.gpg | gpg --dearmor -o /usr/share/keyrings/openresty.gpg \
-    && echo "deb [signed-by=/usr/share/keyrings/openresty.gpg] http://openresty.org/package/ubuntu jammy main" \
+    && echo "deb [signed-by=/usr/share/keyrings/openresty.gpg] http://openresty.org/package/ubuntu noble main" \
        > /etc/apt/sources.list.d/openresty.list \
     && apt-get update \
     && apt-get install -y \
@@ -33,7 +33,14 @@ ADD /src/xrc/xrc.did /work/src/xrc/xrc.did
 ADD /dfx.json /work/dfx.json
 
 ENV PATH="/root/.local/share/dfx/bin:${PATH}"
-RUN DFXVM_INIT_YES=true DFX_VERSION="$(jq -cr .dfx dfx.json)" sh -c "$(curl -fsSL https://sdk.dfinity.org/install.sh)" && dfx --version
+# The e2e container deliberately runs a newer dfx than the project default in
+# dfx.json: its PocketIC-backed local network provides a current replica,
+# while the release build (top-level Dockerfile) keeps the pinned dfx. The
+# DFX_VERSION variable overrides dfx.json for every dfx invocation in here.
+ENV DFX_VERSION=0.32.0
+# Keep dfx's stderr clean: the harness treats unexpected stderr output as an error.
+ENV DFX_WARNING=-deprecation
+RUN DFXVM_INIT_YES=true sh -c "$(curl -fsSL https://sdk.dfinity.org/install.sh)" && dfx --version
 # Make a default identity
 RUN dfx identity get-principal
 

--- a/src/xrc-tests/src/container.rs
+++ b/src/xrc-tests/src/container.rs
@@ -160,6 +160,7 @@ impl Container {
     {
         let (stdout, stderr) =
             compose_exec(self, "dfx identity get-wallet").map_err(CallCanisterError::Io)?;
+        let stderr = without_warnings(&stderr);
         if !stderr.is_empty() {
             return Err(CallCanisterError::Canister(format!(
                 "Error while getting wallet ID: {}",
@@ -178,6 +179,7 @@ impl Container {
             payload
         );
         let (stdout, stderr) = compose_exec(self, &cmd).map_err(CallCanisterError::Io)?;
+        let stderr = without_warnings(&stderr);
         if !stderr.is_empty() {
             return Err(CallCanisterError::Canister(stderr));
         }
@@ -187,6 +189,17 @@ impl Container {
 
         candid::decode_one(&bytes).map_err(CallCanisterError::Candid)
     }
+}
+
+/// Strips dfx advisory output (e.g. "WARNING: Cannot fetch Candid interface
+/// for http_request" when calling endpoints hidden from xrc.did) so that only
+/// genuine errors on stderr fail a canister call.
+fn without_warnings(stderr: &str) -> String {
+    stderr
+        .lines()
+        .filter(|line| !line.starts_with("WARNING:"))
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 /// Used to ensure the that there is at least 1 attempt to stop the actual container process.

--- a/src/xrc-tests/src/container/utils.rs
+++ b/src/xrc-tests/src/container/utils.rs
@@ -266,7 +266,7 @@ enum PingReplicaError {
 /// Pings the replica inside of the container to check the replica's status.
 fn ping_replica(container: &Container) -> Result<(), PingReplicaError> {
     let (stdout, _) = compose_exec(container, "dfx ping").map_err(PingReplicaError::Io)?;
-    if !stdout.contains("ic_api_version") {
+    if !stdout.contains(r#""replica_health_status": "healthy""#) {
         return Err(PingReplicaError::FailedStatusCheck);
     }
 
@@ -304,7 +304,7 @@ pub fn install_canister(container: &Container) -> Result<(), InstallCanisterErro
     )
     .map_err(InstallCanisterError::Io)?;
 
-    if !stderr.contains("Installing code for canister xrc") {
+    if !stderr.contains("Installed code for canister xrc") {
         return Err(InstallCanisterError::FailedToInstallCanister(
             stderr.replace('\n', " "),
         ));


### PR DESCRIPTION
Runs the e2e harness container on dfx 0.32.0, replacing its January-2024 replica with a current PocketIC-backed one.

The old replica predates system APIs that newer dependencies need — concretely `ic0.canister_liquid_cycle_balance128`, required by ic-cdk-timers 1.0.0, which blocked the heartbeat-to-timer migration (DEFI-2602). It also meant every e2e scenario validated against ~2-year-old replica behaviour, a fidelity risk for the upcoming ic-cdk bump (DEFI-2878) and canhttp adoption (DEFI-2603).

The bump turned out to be small because dfx ≥ 0.27 runs PocketIC under the hood, embedding the production HTTPS-outcalls adapter: it reads the OS trust store, so the harness's minica/nginx TLS interception keeps working unchanged, and `subnet_type: "system"` maps to an II-kind (system) subnet — the XRC's production subnet kind — so outcalls remain cycle-free.

The bump is **scoped to the e2e container** via `DFX_VERSION`, which overrides the project default in dfx.json. The dfx.json pin stays at 0.16.0 so the reproducible release build (top-level Dockerfile) and host-side wasm build keep their toolchain — bumping those would change the released artifact (newer bundled ic-wasm) and belongs in its own change.

Compatibility changes:
- e2e base image ubuntu 22.04 → 24.04 (dfx 0.32 needs glibc ≥ 2.38) and OpenResty apt repo `jammy` → `noble`
- `DFX_WARNING=-deprecation`, keeping dfx's stderr clean for the harness's stderr-must-be-empty checks
- `dfx ping` health check now matches `replica_health_status: "healthy"` and the install check matches the new past-tense "Installed code" message — both strictly stronger than the old checks
- `call_canister` strips `WARNING:` lines from stderr (dfx 0.32 warns when calling endpoints hidden from xrc.did, e.g. the `/metrics` scrape via `http_request`)

All six e2e scenarios pass (~96 s, unchanged from dfx 0.16). This removes the urgency from DEFI-2600 (PocketIC test migration) without replacing it: the Docker/nginx machinery stays, but now runs a current replica.

🤖 Generated with [Claude Code](https://claude.com/claude-code)