### PR TITLE
feat: DEFI-2602: replace forex heartbeat with a recurring timer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,6 +710,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-cdk-timers"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6852b9c1d4a82ff50fc7318599298aee8bfb082bd7e9fe7e5c1420692b2170f7"
+dependencies = [
+ "ic-cdk-executor",
+ "ic0",
+ "slotmap",
+]
+
+[[package]]
 name = "ic-error-types"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2019,6 +2030,7 @@ dependencies = [
  "futures",
  "hex",
  "ic-cdk",
+ "ic-cdk-timers",
  "ic-xrc-types 1.2.0",
  "lru",
  "maplit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ chrono = { version = "0.4.33", default-features = false, features = [
     "alloc",
 ] }
 ic-cdk = "0.19.0"
+ic-cdk-timers = "1.0.0"
 serde = { version = "1.0.228", features = ["derive"] }
 strum = { version = "0.26", features = ["derive"] }
 

--- a/src/xrc/Cargo.toml
+++ b/src/xrc/Cargo.toml
@@ -13,6 +13,7 @@ async-trait = "0.1.89"
 candid = { workspace = true }
 chrono = { workspace = true }
 ic-cdk = { workspace = true }
+ic-cdk-timers = { workspace = true }
 ic-xrc-types = { path = "../ic-xrc-types" }
 futures = "0.3.31"
 lru = "0.16.3"

--- a/src/xrc/hidden_endpoints.conf
+++ b/src/xrc/hidden_endpoints.conf
@@ -3,8 +3,10 @@ canister_query:http_request
 # Transform functions for HTTP outcalls to exchanges and forex sources
 canister_query:transform_exchange_http_response
 canister_query:transform_forex_http_response
+# Periodic forex-fetch timer (both endpoints exported by ic-cdk-timers)
+canister_global_timer
+canister_update:<ic-cdk internal> timer_executor
 # Canister lifecycle
-canister_heartbeat
 canister_init
 canister_inspect_message
 canister_post_upgrade

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -317,6 +317,13 @@ pub fn init_metrics() {
     init_at(utils::time_secs());
 }
 
+/// Arms the recurring forex-fetch schedule. Called from the `init` and
+/// `post_upgrade` lifecycle hooks (timers do not survive upgrades, so they
+/// must be re-armed on every upgrade).
+pub fn start_periodic_tasks() {
+    periodic::start();
+}
+
 fn init_at(now_secs: u64) {
     let now = now_secs as f64;
     for forex in FOREX_SOURCES {
@@ -1060,14 +1067,7 @@ pub fn post_upgrade() {
         *cell.borrow_mut() = store;
     });
     init_metrics();
-}
-
-/// Called by the canister's heartbeat so periodic tasks can be executed.
-pub fn heartbeat() {
-    let timestamp = utils::time_secs();
-    let future = periodic::run_tasks(timestamp);
-    // TODO(DEFI-2648): Migrate to `ic_cdk::futures::spawn`.
-    ic_cdk::futures::spawn_017_compat(future);
+    start_periodic_tasks();
 }
 
 /// This function sanitizes the [HttpResponse] as requests must be idempotent.

--- a/src/xrc/src/main.rs
+++ b/src/xrc/src/main.rs
@@ -25,6 +25,7 @@ fn transform_forex_http_response(args: TransformArgs) -> HttpResponse {
 #[ic_cdk::init]
 fn init() {
     xrc::init_metrics();
+    xrc::start_periodic_tasks();
 }
 
 #[ic_cdk::pre_upgrade]
@@ -35,11 +36,6 @@ fn pre_upgrade() {
 #[ic_cdk::post_upgrade]
 fn post_upgrade() {
     xrc::post_upgrade();
-}
-
-#[ic_cdk::heartbeat]
-fn heartbeat() {
-    xrc::heartbeat()
 }
 
 #[ic_cdk::query]

--- a/src/xrc/src/periodic.rs
+++ b/src/xrc/src/periodic.rs
@@ -1,8 +1,9 @@
-use std::{cell::Cell, collections::HashSet};
+use std::{cell::Cell, collections::HashSet, time::Duration};
 
 use async_trait::async_trait;
 use chrono::{Datelike, NaiveDateTime, Weekday};
 use futures::future::join_all;
+use ic_cdk_timers::{set_timer, set_timer_interval};
 
 use crate::{
     call_forex,
@@ -175,7 +176,35 @@ fn get_forexes_with_timestamps_and_context(
         .collect()
 }
 
-/// Entrypoint for background tasks that need to be executed in the heartbeat.
+/// Arms the recurring forex-fetch schedule. Called from `init` and
+/// `post_upgrade` (timers do not survive upgrades, so they must be re-armed).
+///
+/// This reproduces the previous heartbeat behavior:
+///  - A catch-up run is scheduled to fire as soon as possible after start. The
+///    previous heartbeat ran on the first round after install/upgrade (the
+///    `NEXT_RUN_SCHEDULED_AT_TIMESTAMP` guard starts at zero), and the forex
+///    collector is ephemeral, so it must be repopulated after every upgrade. A
+///    timer is used rather than spawning directly because outcalls cannot be
+///    made from the `init`/`post_upgrade` context.
+///  - A one-shot timer to the next 6-hour UTC boundary then installs the
+///    recurring 6-hour interval, preserving the historical
+///    00:00/06:00/12:00/18:00 UTC run schedule.
+pub fn start() {
+    set_timer(Duration::ZERO, async {
+        run_tasks(crate::utils::time_secs()).await;
+    });
+
+    let now = crate::utils::time_secs();
+    let delay = Duration::from_secs(get_next_run_timestamp(now).saturating_sub(now));
+    set_timer(delay, async {
+        set_timer_interval(Duration::from_secs(SIX_HOURS), || {
+            run_tasks(crate::utils::time_secs())
+        });
+        run_tasks(crate::utils::time_secs()).await;
+    });
+}
+
+/// Entrypoint for background tasks that need to be executed periodically.
 pub async fn run_tasks(timestamp: u64) {
     let forex_sources = ForexSourcesImpl;
     update_forex_store(timestamp, &forex_sources).await;


### PR DESCRIPTION
Drives the periodic forex fetch from an ic-cdk-timers timer instead of the canister heartbeat, so the canister is woken only at the scheduled times rather than on every execution round (~86,400 wake-ups/day for 4 real runs). The schedule preserves today's behaviour: an immediate catch-up run on install/upgrade, then runs aligned to the 00:00/06:00/12:00/18:00 UTC boundaries. The existing idempotency and reentrancy guards are kept.

ic-cdk-timers 1.0.0 (the only version compatible with ic-cdk 0.19) uses the `ic0.canister_liquid_cycle_balance128` system API, which the old dfx 0.16 e2e replica did not support — the canister trapped on install in e2e while mainnet was always fine. This PR is therefore **stacked on #338** (e2e harness on dfx 0.32, a current PocketIC-backed replica) and should be retargeted to `main` once that merges.

All six e2e scenarios pass on this branch, confirming the install trap is gone and that the timer's catch-up run populates the forex store exactly as the heartbeat did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)