### PR TITLE
feat: DEFI-2897: distinct error for crypto rates below representable resolution

### DIFF
--- a/src/xrc-tests/src/tests/misbehavior.rs
+++ b/src/xrc-tests/src/tests/misbehavior.rs
@@ -167,10 +167,11 @@ fn misbehavior() {
                 decimals: 9,
                 base_asset_num_queried_sources: NUM_EXCHANGES,
                 // KuCoin quotes ICP at 0.0000000001, which scales below the
-                // representable resolution: it is rejected at parse and never
-                // counted as a received rate, so one fewer than the other ICP
-                // sources. The rate and std-dev are unchanged because that quote
-                // was excluded from the median either way.
+                // representable resolution: extract_rate classifies it as a
+                // below-resolution quote (not a rate), so it is dropped before
+                // aggregation and not counted as a received rate — one fewer than
+                // the other ICP sources. The rate and std-dev are unchanged
+                // because that quote was excluded from the median either way.
                 base_asset_num_received_rates: NUM_EXCHANGES - 1,
                 quote_asset_num_queried_sources: NUM_EXCHANGES,
                 quote_asset_num_received_rates: NUM_EXCHANGES,

--- a/src/xrc-tests/src/tests/misbehavior.rs
+++ b/src/xrc-tests/src/tests/misbehavior.rs
@@ -166,7 +166,12 @@ fn misbehavior() {
             metadata: ExchangeRateMetadata {
                 decimals: 9,
                 base_asset_num_queried_sources: NUM_EXCHANGES,
-                base_asset_num_received_rates: NUM_EXCHANGES,
+                // KuCoin quotes ICP at 0.0000000001, which scales below the
+                // representable resolution (DEFI-2897): it is rejected at parse
+                // and never counted as a received rate, so one fewer than the
+                // other ICP sources. The rate and std-dev are unchanged because
+                // that quote was excluded from the median either way.
+                base_asset_num_received_rates: NUM_EXCHANGES - 1,
                 quote_asset_num_queried_sources: NUM_EXCHANGES,
                 quote_asset_num_received_rates: NUM_EXCHANGES,
                 standard_deviation: 3_644_799,

--- a/src/xrc-tests/src/tests/misbehavior.rs
+++ b/src/xrc-tests/src/tests/misbehavior.rs
@@ -167,10 +167,10 @@ fn misbehavior() {
                 decimals: 9,
                 base_asset_num_queried_sources: NUM_EXCHANGES,
                 // KuCoin quotes ICP at 0.0000000001, which scales below the
-                // representable resolution (DEFI-2897): it is rejected at parse
-                // and never counted as a received rate, so one fewer than the
-                // other ICP sources. The rate and std-dev are unchanged because
-                // that quote was excluded from the median either way.
+                // representable resolution: it is rejected at parse and never
+                // counted as a received rate, so one fewer than the other ICP
+                // sources. The rate and std-dev are unchanged because that quote
+                // was excluded from the median either way.
                 base_asset_num_received_rates: NUM_EXCHANGES - 1,
                 quote_asset_num_queried_sources: NUM_EXCHANGES,
                 quote_asset_num_received_rates: NUM_EXCHANGES,

--- a/src/xrc/canbench_results.yml
+++ b/src/xrc/canbench_results.yml
@@ -2,63 +2,63 @@ benches:
   listing_parse_bitget:
     total:
       calls: 1
-      instructions: 28670209
+      instructions: 28676964
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   listing_parse_coinbase:
     total:
       calls: 1
-      instructions: 24001975
+      instructions: 24002224
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   listing_parse_cryptocom:
     total:
       calls: 1
-      instructions: 29066105
+      instructions: 29267552
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   listing_parse_digifinex:
     total:
       calls: 1
-      instructions: 14574176
+      instructions: 14579506
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   listing_parse_gateio:
     total:
       calls: 1
-      instructions: 78368408
+      instructions: 78385082
       heap_increase: 6
       stable_memory_increase: 0
     scopes: {}
   listing_parse_kucoin:
     total:
       calls: 1
-      instructions: 42051962
+      instructions: 42043370
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   listing_parse_mexc:
     total:
       calls: 1
-      instructions: 10777702
+      instructions: 10479975
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   listing_parse_okx:
     total:
       calls: 1
-      instructions: 84874330
+      instructions: 84874597
       heap_increase: 3
       stable_memory_increase: 0
     scopes: {}
   listing_parse_poloniex:
     total:
       calls: 1
-      instructions: 30555250
+      instructions: 30555723
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}

--- a/src/xrc/canbench_results.yml
+++ b/src/xrc/canbench_results.yml
@@ -9,7 +9,7 @@ benches:
   listing_parse_coinbase:
     total:
       calls: 1
-      instructions: 24002224
+      instructions: 24002226
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
@@ -44,7 +44,7 @@ benches:
   listing_parse_mexc:
     total:
       calls: 1
-      instructions: 10479975
+      instructions: 10792043
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}

--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -168,38 +168,39 @@ fn aggregate_cryptocurrency_usdt_rates(
         }
     }
 
-    if !rates.is_empty() {
-        let queried_exchange_rate = QueriedExchangeRate::new(
-            asset.clone(),
-            usdt_asset(),
-            timestamp,
-            &rates,
-            exchanges.len(),
-            rates.len(),
-            None,
-        );
+    // No representable rate was collected. If that is because every usable quote
+    // was below the representable resolution, report it distinctly; otherwise it
+    // is missing data.
+    if rates.is_empty() {
+        return Err(if saw_below_resolution {
+            CallExchangeError::RateBelowResolution
+        } else {
+            CallExchangeError::NoRatesFound
+        });
+    }
 
-        // The collected rates may all be filtered out (e.g. inconsistent or
-        // out-of-range), leaving an empty post-filter rate. Such a rate must
-        // never be cached or returned: its median is zero, so a later
-        // cache-only request could otherwise be served a successful zero rate.
-        if !queried_exchange_rate.rates.is_empty() {
-            return Ok(QueriedExchangeRateWithFailedExchanges {
-                queried_exchange_rate,
-                failed_exchanges,
-            });
-        }
+    let queried_exchange_rate = QueriedExchangeRate::new(
+        asset.clone(),
+        usdt_asset(),
+        timestamp,
+        &rates,
+        exchanges.len(),
+        rates.len(),
+        None,
+    );
 
+    // The collected rates may all be filtered out (e.g. inconsistent or
+    // out-of-range), leaving an empty post-filter rate. Such a rate must never
+    // be cached or returned: its median is zero, so a later cache-only request
+    // could otherwise be served a successful zero rate.
+    if queried_exchange_rate.rates.is_empty() {
         return Err(CallExchangeError::NoRatesFound);
     }
 
-    // No representable rate was collected. If that is because every usable quote
-    // was below the representable resolution, report it distinctly.
-    if saw_below_resolution {
-        return Err(CallExchangeError::RateBelowResolution);
-    }
-
-    Err(CallExchangeError::NoRatesFound)
+    Ok(QueriedExchangeRateWithFailedExchanges {
+        queried_exchange_rate,
+        failed_exchanges,
+    })
 }
 
 /// Provides an [Asset] that corresponds to the USDT cryptocurrency stablecoin.

--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -197,6 +197,12 @@ fn aggregate_cryptocurrency_usdt_rates(
     // out-of-range), leaving an empty post-filter rate. Such a rate must never
     // be cached or returned: its median is zero, so a later cache-only request
     // could otherwise be served a successful zero rate.
+    //
+    // This is deliberately NoRatesFound even if a below-resolution quote was
+    // also seen: reaching here means at least one representable rate was
+    // collected, so the pair is not below resolution — the representable rates
+    // merely failed to agree. Below-resolution is reported only when it is the
+    // sole reason no rate could be produced (the raw-empty branch above).
     if queried_exchange_rate.rates.is_empty() {
         return Err(CallExchangeError::NoRatesFound);
     }

--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -129,7 +129,10 @@ fn aggregate_cryptocurrency_usdt_rates(
 ) -> Result<QueriedExchangeRateWithFailedExchanges, CallExchangeError> {
     let mut rates = vec![];
     let mut failed_exchanges = vec![];
-    let mut saw_below_resolution = false;
+    // The exchange of the first below-resolution quote seen, if any. Kept so the
+    // aggregate error names a concrete source (the per-exchange metric records
+    // every such source individually).
+    let mut below_resolution_exchange: Option<String> = None;
     for result in results {
         match result {
             Ok(rate) => rates.push(rate),
@@ -143,7 +146,9 @@ fn aggregate_cryptocurrency_usdt_rates(
                 );
 
                 match err {
-                    CallExchangeError::RateBelowResolution => saw_below_resolution = true,
+                    CallExchangeError::RateBelowResolution { exchange } => {
+                        below_resolution_exchange.get_or_insert(exchange);
+                    }
                     CallExchangeError::Http { exchange, error: _ } => {
                         if let Some(exchange) = exchanges.iter().find(|e| e.name() == exchange) {
                             failed_exchanges.push((*exchange).clone());
@@ -172,10 +177,9 @@ fn aggregate_cryptocurrency_usdt_rates(
     // was below the representable resolution, report it distinctly; otherwise it
     // is missing data.
     if rates.is_empty() {
-        return Err(if saw_below_resolution {
-            CallExchangeError::RateBelowResolution
-        } else {
-            CallExchangeError::NoRatesFound
+        return Err(match below_resolution_exchange {
+            Some(exchange) => CallExchangeError::RateBelowResolution { exchange },
+            None => CallExchangeError::NoRatesFound,
         });
     }
 
@@ -620,7 +624,7 @@ fn crypto_leg_error(
     asset_not_found: ExchangeRateError,
 ) -> ExchangeRateError {
     match err {
-        CallExchangeError::RateBelowResolution => errors::rate_below_resolution_error(),
+        CallExchangeError::RateBelowResolution { .. } => errors::rate_below_resolution_error(),
         _ => asset_not_found,
     }
 }

--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -59,6 +59,96 @@ trait CallExchanges {
 
 struct CallExchangesImpl;
 
+/// Aggregates the per-exchange crypto/USDT call results into a single
+/// [QueriedExchangeRate]. Pulled out of
+/// [CallExchanges::get_cryptocurrency_usdt_rate] so the rate-collection and
+/// error-classification logic can be unit-tested without performing HTTP
+/// outcalls.
+///
+/// Returns an error when no usable rate can be produced:
+/// * [CallExchangeError::RateBelowResolution] when no representable rate was
+///   collected but at least one source quoted a price below the representable
+///   resolution (so the caller can report a precise error), and
+/// * [CallExchangeError::NoRatesFound] otherwise (no rates, or the collected
+///   rates were all dropped by the post-filter).
+///
+/// An empty post-filter rate is never returned, so it can never be cached or
+/// served as a successful zero rate.
+fn aggregate_cryptocurrency_usdt_rates(
+    asset: &Asset,
+    exchanges: &[&Exchange],
+    timestamp: u64,
+    results: Vec<Result<u64, CallExchangeError>>,
+) -> Result<QueriedExchangeRateWithFailedExchanges, CallExchangeError> {
+    let mut rates = vec![];
+    let mut failed_exchanges = vec![];
+    let mut saw_below_resolution = false;
+    for result in results {
+        match result {
+            Ok(rate) => rates.push(rate),
+            Err(err) => {
+                ic_cdk::println!(
+                    "{} Timestamp: {}, Asset: {:?}, Error: {}",
+                    LOG_PREFIX,
+                    timestamp,
+                    asset,
+                    err,
+                );
+
+                match err {
+                    CallExchangeError::RateBelowResolution => saw_below_resolution = true,
+                    CallExchangeError::Http { exchange, error: _ } => {
+                        if let Some(exchange) = exchanges.iter().find(|e| e.name() == exchange) {
+                            failed_exchanges.push((*exchange).clone());
+                        } else {
+                            ic_cdk::println!(
+                                "{} Exchange not found for failed exchanges: {} @ {}",
+                                LOG_PREFIX,
+                                exchange,
+                                timestamp
+                            );
+                        }
+                    }
+                    CallExchangeError::Candid { .. } | CallExchangeError::NoRatesFound => {}
+                }
+            }
+        }
+    }
+
+    if !rates.is_empty() {
+        let queried_exchange_rate = QueriedExchangeRate::new(
+            asset.clone(),
+            usdt_asset(),
+            timestamp,
+            &rates,
+            exchanges.len(),
+            rates.len(),
+            None,
+        );
+
+        // The collected rates may all be filtered out (e.g. inconsistent or
+        // out-of-range), leaving an empty post-filter rate. Such a rate must
+        // never be cached or returned: its median is zero, so a later
+        // cache-only request could otherwise be served a successful zero rate.
+        if !queried_exchange_rate.rates.is_empty() {
+            return Ok(QueriedExchangeRateWithFailedExchanges {
+                queried_exchange_rate,
+                failed_exchanges,
+            });
+        }
+
+        return Err(CallExchangeError::NoRatesFound);
+    }
+
+    // No representable rate was collected. If that is because every usable quote
+    // was below the representable resolution, report it distinctly.
+    if saw_below_resolution {
+        return Err(CallExchangeError::RateBelowResolution);
+    }
+
+    Err(CallExchangeError::NoRatesFound)
+}
+
 #[async_trait]
 impl CallExchanges for CallExchangesImpl {
     async fn get_cryptocurrency_usdt_rate(
@@ -86,64 +176,9 @@ impl CallExchanges for CallExchangesImpl {
             )
         });
         let results = join_all(futures).await;
-
-        let mut rates = vec![];
-        let mut failed_exchanges = vec![];
-        for result in results {
-            match result {
-                Ok(rate) => rates.push(rate),
-                Err(err) => {
-                    ic_cdk::println!(
-                        "{} Timestamp: {}, Asset: {:?}, Error: {}",
-                        LOG_PREFIX,
-                        timestamp,
-                        asset,
-                        err,
-                    );
-
-                    if let CallExchangeError::Http { exchange, error: _ } = err {
-                        if let Some(exchange) = exchanges.iter().find(|e| e.name() == exchange) {
-                            failed_exchanges.push((*exchange).clone());
-                        } else {
-                            ic_cdk::println!(
-                                "{} Exchange not found for failed exchanges: {} @ {}",
-                                LOG_PREFIX,
-                                exchange,
-                                timestamp
-                            );
-                        }
-                    }
-                }
-            }
-        }
-
-        if rates.is_empty() {
-            return Err(CallExchangeError::NoRatesFound);
-        }
-
-        let queried_exchange_rate = QueriedExchangeRate::new(
-            asset.clone(),
-            usdt_asset(),
-            timestamp,
-            &rates,
-            queried.len(),
-            rates.len(),
-            None,
-        );
-
-        // The raw rates may all be filtered out (e.g. every source reported a
-        // zero or otherwise invalid price), leaving an empty post-filter rate.
-        // Such a rate must never be cached or returned: its median is zero, so a
-        // later cache-only request could otherwise be served a successful zero
-        // rate.
-        if queried_exchange_rate.rates.is_empty() {
-            return Err(CallExchangeError::NoRatesFound);
-        }
-
-        Ok(QueriedExchangeRateWithFailedExchanges {
-            queried_exchange_rate,
-            failed_exchanges,
-        })
+        // Pass `queried` (not the full `exchanges`) so the reported
+        // queried-source count excludes exchanges skipped by the listing gate.
+        aggregate_cryptocurrency_usdt_rates(asset, &queried, timestamp, results)
     }
 
     async fn get_stablecoin_rates(
@@ -555,6 +590,20 @@ fn charge_cycles(
     env.charge_cycles(charge_cycles_option)
 }
 
+/// Maps a crypto/USDT fetch error for one leg of a pair to the public error.
+/// A below-resolution rate is surfaced as its own error so callers can tell it
+/// apart from missing market data; every other error maps to the provided
+/// asset-not-found error.
+fn crypto_leg_error(
+    err: CallExchangeError,
+    asset_not_found: ExchangeRateError,
+) -> ExchangeRateError {
+    match err {
+        CallExchangeError::RateBelowResolution => errors::rate_below_resolution_error(),
+        _ => asset_not_found,
+    }
+}
+
 async fn handle_cryptocurrency_pair(
     env: &impl Environment,
     call_exchanges_impl: &impl CallExchanges,
@@ -624,7 +673,9 @@ async fn handle_cryptocurrency_pair(
                             requested_timestamp.value,
                         )
                         .await
-                        .map_err(|_| ExchangeRateError::CryptoBaseAssetNotFound)?;
+                        .map_err(|err| {
+                            crypto_leg_error(err, ExchangeRateError::CryptoBaseAssetNotFound)
+                        })?;
                     with_cache_mut(|cache| {
                         cache.insert(&response.queried_exchange_rate);
                     });
@@ -644,7 +695,9 @@ async fn handle_cryptocurrency_pair(
                             requested_timestamp.value,
                         )
                         .await
-                        .map_err(|_| ExchangeRateError::CryptoQuoteAssetNotFound)?;
+                        .map_err(|err| {
+                            crypto_leg_error(err, ExchangeRateError::CryptoQuoteAssetNotFound)
+                        })?;
                     with_cache_mut(|cache| {
                         cache.insert(&response.queried_exchange_rate);
                     });
@@ -778,7 +831,9 @@ async fn handle_crypto_base_fiat_quote_pair(
                             requested_timestamp.value,
                         )
                         .await
-                        .map_err(|_| ExchangeRateError::CryptoBaseAssetNotFound)?;
+                        .map_err(|err| {
+                            crypto_leg_error(err, ExchangeRateError::CryptoBaseAssetNotFound)
+                        })?;
                     with_cache_mut(|cache| {
                         cache.insert(&response.queried_exchange_rate);
                     });

--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -976,8 +976,7 @@ async fn get_stablecoin_rate(
 /// as usable" — `QueriedExchangeRate::new`'s zero-filter and the
 /// stablecoin invert step both drop them, so counting them here would
 /// inflate the signal without contributing to the aggregate. The
-/// per-exchange `extracted_zero` outcome captures the same observation
-/// per-call.
+/// per-exchange fetch outcomes capture the same observation per-call.
 ///
 /// An empty (or all-zero) input is a valid call: it adds zero to the
 /// counter, which materialises the series so alerts like

--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -311,6 +311,14 @@ pub async fn get_exchange_rate(request: GetExchangeRateRequest) -> GetExchangeRa
             ExchangeRateError::InconsistentRatesReceived => {
                 MetricCounter::InconsistentRatesErrorsReturned.increment()
             }
+            // Below-resolution is surfaced to callers as `Other` with a distinct
+            // code; count it separately rather than letting it vanish into the
+            // generic errors-returned total (the only signal `Other(_)` gets).
+            ExchangeRateError::Other(error)
+                if error.code == errors::RATE_BELOW_RESOLUTION_ERROR_CODE =>
+            {
+                MetricCounter::RateBelowResolutionErrorsReturned.increment()
+            }
             ExchangeRateError::AnonymousPrincipalNotAllowed | ExchangeRateError::Other(_) => {}
         };
     }

--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -59,6 +59,53 @@ trait CallExchanges {
 
 struct CallExchangesImpl;
 
+#[async_trait]
+impl CallExchanges for CallExchangesImpl {
+    async fn get_cryptocurrency_usdt_rate(
+        &self,
+        exchanges: &[&Exchange],
+        asset: &Asset,
+        timestamp: u64,
+    ) -> Result<QueriedExchangeRateWithFailedExchanges, CallExchangeError> {
+        // Query only the exchanges that currently list this base against USDT,
+        // per the discovered listings (fail-open on a missing/stale listing).
+        // This avoids querying delisted/unlisted pairs that would only error,
+        // and keeps the reported queried-source count honest by excluding the
+        // skipped exchanges from `num_queried_sources` below.
+        let now_secs = utils::time_secs();
+        let queried = exchanges_listing_base_against_usdt(exchanges, &asset.symbol, now_secs);
+        let futures = queried.iter().map(|exchange| {
+            call_exchange(
+                exchange,
+                CallExchangeArgs {
+                    timestamp,
+                    quote_asset: usdt_asset(),
+                    base_asset: asset.clone(),
+                },
+                ExchangeCallKind::Crypto,
+            )
+        });
+        let results = join_all(futures).await;
+        // Pass `queried` (not the full `exchanges`) so the reported
+        // queried-source count excludes exchanges skipped by the listing gate.
+        aggregate_cryptocurrency_usdt_rates(asset, &queried, timestamp, results)
+    }
+
+    async fn get_stablecoin_rates(
+        &self,
+        exchanges: &[&Exchange],
+        symbols: &[&str],
+        timestamp: u64,
+    ) -> Vec<Result<QueriedExchangeRateWithFailedExchanges, CallExchangeError>> {
+        join_all(
+            symbols
+                .iter()
+                .map(|symbol| get_stablecoin_rate(exchanges, symbol, timestamp)),
+        )
+        .await
+    }
+}
+
 /// Aggregates the per-exchange crypto/USDT call results into a single
 /// [QueriedExchangeRate]. Pulled out of
 /// [CallExchanges::get_cryptocurrency_usdt_rate] so the rate-collection and
@@ -153,53 +200,6 @@ fn aggregate_cryptocurrency_usdt_rates(
     }
 
     Err(CallExchangeError::NoRatesFound)
-}
-
-#[async_trait]
-impl CallExchanges for CallExchangesImpl {
-    async fn get_cryptocurrency_usdt_rate(
-        &self,
-        exchanges: &[&Exchange],
-        asset: &Asset,
-        timestamp: u64,
-    ) -> Result<QueriedExchangeRateWithFailedExchanges, CallExchangeError> {
-        // Query only the exchanges that currently list this base against USDT,
-        // per the discovered listings (fail-open on a missing/stale listing).
-        // This avoids querying delisted/unlisted pairs that would only error,
-        // and keeps the reported queried-source count honest by excluding the
-        // skipped exchanges from `num_queried_sources` below.
-        let now_secs = utils::time_secs();
-        let queried = exchanges_listing_base_against_usdt(exchanges, &asset.symbol, now_secs);
-        let futures = queried.iter().map(|exchange| {
-            call_exchange(
-                exchange,
-                CallExchangeArgs {
-                    timestamp,
-                    quote_asset: usdt_asset(),
-                    base_asset: asset.clone(),
-                },
-                ExchangeCallKind::Crypto,
-            )
-        });
-        let results = join_all(futures).await;
-        // Pass `queried` (not the full `exchanges`) so the reported
-        // queried-source count excludes exchanges skipped by the listing gate.
-        aggregate_cryptocurrency_usdt_rates(asset, &queried, timestamp, results)
-    }
-
-    async fn get_stablecoin_rates(
-        &self,
-        exchanges: &[&Exchange],
-        symbols: &[&str],
-        timestamp: u64,
-    ) -> Vec<Result<QueriedExchangeRateWithFailedExchanges, CallExchangeError>> {
-        join_all(
-            symbols
-                .iter()
-                .map(|symbol| get_stablecoin_rate(exchanges, symbol, timestamp)),
-        )
-        .await
-    }
 }
 
 /// Provides an [Asset] that corresponds to the USDT cryptocurrency stablecoin.

--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -245,6 +245,41 @@ fn exchanges_listing_base_against_usdt<'a>(
     })
 }
 
+/// Maps a returned error to the per-class counter that should be incremented,
+/// or `None` for errors that are not tracked individually (an anonymous-caller
+/// rejection, and a generic `Other` without a recognized code). Below-resolution
+/// is surfaced as `Other` with a distinct code, so it gets its own counter
+/// rather than being lost in the generic errors-returned total.
+fn error_metric_counter(error: &ExchangeRateError) -> Option<MetricCounter> {
+    Some(match error {
+        ExchangeRateError::Pending => MetricCounter::PendingErrorsReturned,
+        ExchangeRateError::CryptoBaseAssetNotFound
+        | ExchangeRateError::CryptoQuoteAssetNotFound => {
+            MetricCounter::CryptoAssetRelatedErrorsReturned
+        }
+        ExchangeRateError::StablecoinRateNotFound
+        | ExchangeRateError::StablecoinRateTooFewRates
+        | ExchangeRateError::StablecoinRateZeroRate => MetricCounter::StablecoinErrorsReturned,
+        ExchangeRateError::ForexInvalidTimestamp
+        | ExchangeRateError::ForexBaseAssetNotFound
+        | ExchangeRateError::ForexQuoteAssetNotFound
+        | ExchangeRateError::ForexAssetsNotFound => MetricCounter::ForexAssetRelatedErrorsReturned,
+        ExchangeRateError::RateLimited => MetricCounter::RateLimitedErrors,
+        ExchangeRateError::NotEnoughCycles => MetricCounter::CycleRelatedErrors,
+        ExchangeRateError::InconsistentRatesReceived => {
+            MetricCounter::InconsistentRatesErrorsReturned
+        }
+        ExchangeRateError::Other(error)
+            if error.code == errors::RATE_BELOW_RESOLUTION_ERROR_CODE =>
+        {
+            MetricCounter::RateBelowResolutionErrorsReturned
+        }
+        ExchangeRateError::AnonymousPrincipalNotAllowed | ExchangeRateError::Other(_) => {
+            return None
+        }
+    })
+}
+
 /// This function retrieves the requested rate from the exchanges. The median rate of all collected
 /// rates is used as the exchange rate and a set of metadata is returned giving information on
 /// how the rate was retrieved.
@@ -289,38 +324,9 @@ pub async fn get_exchange_rate(request: GetExchangeRateRequest) -> GetExchangeRa
             MetricCounter::ErrorsReturnedToCmc.increment();
         }
 
-        match error {
-            ExchangeRateError::Pending => MetricCounter::PendingErrorsReturned.increment(),
-            ExchangeRateError::CryptoBaseAssetNotFound
-            | ExchangeRateError::CryptoQuoteAssetNotFound => {
-                MetricCounter::CryptoAssetRelatedErrorsReturned.increment()
-            }
-            ExchangeRateError::StablecoinRateNotFound
-            | ExchangeRateError::StablecoinRateTooFewRates
-            | ExchangeRateError::StablecoinRateZeroRate => {
-                MetricCounter::StablecoinErrorsReturned.increment()
-            }
-            ExchangeRateError::ForexInvalidTimestamp
-            | ExchangeRateError::ForexBaseAssetNotFound
-            | ExchangeRateError::ForexQuoteAssetNotFound
-            | ExchangeRateError::ForexAssetsNotFound => {
-                MetricCounter::ForexAssetRelatedErrorsReturned.increment()
-            }
-            ExchangeRateError::RateLimited => MetricCounter::RateLimitedErrors.increment(),
-            ExchangeRateError::NotEnoughCycles => MetricCounter::CycleRelatedErrors.increment(),
-            ExchangeRateError::InconsistentRatesReceived => {
-                MetricCounter::InconsistentRatesErrorsReturned.increment()
-            }
-            // Below-resolution is surfaced to callers as `Other` with a distinct
-            // code; count it separately rather than letting it vanish into the
-            // generic errors-returned total (the only signal `Other(_)` gets).
-            ExchangeRateError::Other(error)
-                if error.code == errors::RATE_BELOW_RESOLUTION_ERROR_CODE =>
-            {
-                MetricCounter::RateBelowResolutionErrorsReturned.increment()
-            }
-            ExchangeRateError::AnonymousPrincipalNotAllowed | ExchangeRateError::Other(_) => {}
-        };
+        if let Some(counter) = error_metric_counter(error) {
+            counter.increment();
+        }
     }
 
     result

--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -113,16 +113,27 @@ impl CallExchanges for CallExchangesImpl {
             return Err(CallExchangeError::NoRatesFound);
         }
 
+        let queried_exchange_rate = QueriedExchangeRate::new(
+            asset.clone(),
+            usdt_asset(),
+            timestamp,
+            &rates,
+            exchanges.len(),
+            rates.len(),
+            None,
+        );
+
+        // The raw rates may all be filtered out (e.g. every source reported a
+        // zero or otherwise invalid price), leaving an empty post-filter rate.
+        // Such a rate must never be cached or returned: its median is zero, so a
+        // later cache-only request could otherwise be served a successful zero
+        // rate.
+        if queried_exchange_rate.rates.is_empty() {
+            return Err(CallExchangeError::NoRatesFound);
+        }
+
         Ok(QueriedExchangeRateWithFailedExchanges {
-            queried_exchange_rate: QueriedExchangeRate::new(
-                asset.clone(),
-                usdt_asset(),
-                timestamp,
-                &rates,
-                exchanges.len(),
-                rates.len(),
-                None,
-            ),
+            queried_exchange_rate,
             failed_exchanges,
         })
     }
@@ -562,9 +573,12 @@ async fn handle_cryptocurrency_pair(
     }
 
     // We have all of the necessary rates in the cache return the result.
+    // Validate the composed result here too, mirroring the fresh path, so a
+    // cache-only response can never bypass the validation boundary.
     if num_rates_needed == 0 {
-        return Ok(maybe_base_rate.expect("rate should exist")
-            / maybe_quote_rate.expect("rate should exist"));
+        return (maybe_base_rate.expect("rate should exist")
+            / maybe_quote_rate.expect("rate should exist"))
+        .validate();
     }
 
     with_inflight_tracking(

--- a/src/xrc/src/api/metrics.rs
+++ b/src/xrc/src/api/metrics.rs
@@ -112,6 +112,14 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
     )?;
 
     w.encode_counter(
+        "xrc_rate_below_resolution_errors",
+        MetricCounter::RateBelowResolutionErrorsReturned.get() as u64,
+        "The number of requests that failed because the crypto rate was below \
+         the representable resolution (see the below_resolution outcome in \
+         xrc_exchange_fetch_total for the per-exchange signal).",
+    )?;
+
+    w.encode_counter(
         "xrc_forex_asset_errors",
         MetricCounter::ForexAssetRelatedErrorsReturned.get() as u64,
         "The number of forex asset related errors returned (aggregate; \

--- a/src/xrc/src/api/test.rs
+++ b/src/xrc/src/api/test.rs
@@ -309,6 +309,84 @@ fn failed_validation_does_not_poison_cache_with_zero_rate() {
     );
 }
 
+/// End-to-end check that the cache-only path can never replay a zero rate.
+/// Because the empty post-filter intermediate is no longer cached, a second
+/// request for the same asset and timestamp re-fetches instead of being served
+/// from cache; with no data available it errors again rather than returning
+/// Ok(rate = 0).
+#[test]
+fn cache_only_request_never_returns_zero_rate_after_failed_validation() {
+    set_request_counter(0);
+
+    let timestamp: u64 = 12_345_660;
+    let empty_post_filter_rate = QueriedExchangeRate::new(
+        icp_asset(),
+        usdt_asset(),
+        timestamp,
+        &[0],
+        EXCHANGES.len(),
+        1,
+        None,
+    );
+
+    let call_exchanges_impl = TestCallExchangesImpl::builder()
+        .with_get_cryptocurrency_usdt_rate_responses(btreemap! {
+            "ICP".to_string() => Ok(QueriedExchangeRateWithFailedExchanges {
+                queried_exchange_rate: empty_post_filter_rate,
+                failed_exchanges: vec![],
+            })
+        })
+        .build();
+    let request = GetExchangeRateRequest {
+        base_asset: icp_asset(),
+        quote_asset: usdt_asset(),
+        timestamp: Some(timestamp),
+    };
+
+    let first_env = TestEnvironment::builder()
+        .with_time_secs(timestamp)
+        .with_cycles_available(XRC_REQUEST_CYCLES_COST)
+        .with_accepted_cycles(XRC_BASE_CYCLES_COST + XRC_OUTBOUND_HTTP_CALL_CYCLES_COST)
+        .build();
+    let first_result = get_exchange_rate_internal(&first_env, &call_exchanges_impl, &request)
+        .now_or_never()
+        .expect("future should complete");
+    assert!(first_result.is_err());
+
+    // Nothing was cached, so the second request must re-fetch (one outbound
+    // call) rather than be served the previously-poisoned cache entry.
+    let second_call_exchanges_impl = TestCallExchangesImpl::builder().build();
+    let second_env = TestEnvironment::builder()
+        .with_time_secs(timestamp)
+        .with_cycles_available(XRC_REQUEST_CYCLES_COST)
+        .with_accepted_cycles(XRC_BASE_CYCLES_COST + XRC_OUTBOUND_HTTP_CALL_CYCLES_COST)
+        .build();
+    let second_result =
+        get_exchange_rate_internal(&second_env, &second_call_exchanges_impl, &request)
+            .now_or_never()
+            .expect("future should complete");
+
+    assert!(
+        !matches!(second_result, Ok(ref rate) if rate.rate == 0),
+        "cache-only request must not return a successful zero rate, got: {:#?}",
+        second_result
+    );
+    assert!(
+        matches!(second_result, Err(ExchangeRateError::CryptoBaseAssetNotFound)),
+        "expected the re-fetch to fail with CryptoBaseAssetNotFound, got: {:#?}",
+        second_result
+    );
+    assert_eq!(
+        second_call_exchanges_impl
+            .get_cryptocurrency_usdt_rate_calls
+            .read()
+            .unwrap()
+            .len(),
+        1,
+        "the second request should have re-fetched rather than hit a poisoned cache"
+    );
+}
+
 fn stablecoin_mock(symbol: &str, rates: &[u64]) -> QueriedExchangeRate {
     QueriedExchangeRate::new(
         Asset {

--- a/src/xrc/src/api/test.rs
+++ b/src/xrc/src/api/test.rs
@@ -396,7 +396,8 @@ fn empty_post_filter_rate_is_not_cached_and_forces_refetch() {
 /// reports it distinctly rather than as missing data.
 #[test]
 fn aggregate_all_below_resolution_reports_below_resolution() {
-    let exchanges: Vec<&Exchange> = EXCHANGES.iter().collect();
+    // Match the queried-exchange count to the number of results, as in production.
+    let exchanges: Vec<&Exchange> = EXCHANGES.iter().take(2).collect();
     let results = vec![
         Err(CallExchangeError::RateBelowResolution),
         Err(CallExchangeError::RateBelowResolution),
@@ -409,7 +410,8 @@ fn aggregate_all_below_resolution_reports_below_resolution() {
 /// representable rate; the below-resolution source is simply dropped.
 #[test]
 fn aggregate_mixed_below_resolution_and_rate_yields_rate() {
-    let exchanges: Vec<&Exchange> = EXCHANGES.iter().collect();
+    // Match the queried-exchange count to the number of results, as in production.
+    let exchanges: Vec<&Exchange> = EXCHANGES.iter().take(2).collect();
     let results = vec![
         Ok(4 * RATE_UNIT),
         Err(CallExchangeError::RateBelowResolution),
@@ -426,7 +428,8 @@ fn aggregate_mixed_below_resolution_and_rate_yields_rate() {
 /// post-filter; that is missing data, not a below-resolution condition.
 #[test]
 fn aggregate_inconsistent_rates_report_no_rates_found() {
-    let exchanges: Vec<&Exchange> = EXCHANGES.iter().collect();
+    // Match the queried-exchange count to the number of results, as in production.
+    let exchanges: Vec<&Exchange> = EXCHANGES.iter().take(2).collect();
     let results = vec![Ok(RATE_UNIT), Ok(1000 * RATE_UNIT)];
     let result = aggregate_cryptocurrency_usdt_rates(&icp_asset(), &exchanges, 0, results);
     assert!(matches!(result, Err(CallExchangeError::NoRatesFound)));
@@ -435,7 +438,8 @@ fn aggregate_inconsistent_rates_report_no_rates_found() {
 /// No results at all is missing data.
 #[test]
 fn aggregate_no_results_reports_no_rates_found() {
-    let exchanges: Vec<&Exchange> = EXCHANGES.iter().collect();
+    // No results, so no exchanges were queried.
+    let exchanges: Vec<&Exchange> = vec![];
     let result = aggregate_cryptocurrency_usdt_rates(&icp_asset(), &exchanges, 0, vec![]);
     assert!(matches!(result, Err(CallExchangeError::NoRatesFound)));
 }
@@ -444,7 +448,9 @@ fn aggregate_no_results_reports_no_rates_found() {
 /// rate) is still reported as below-resolution.
 #[test]
 fn aggregate_below_resolution_with_http_failure_reports_below_resolution() {
-    let exchanges: Vec<&Exchange> = EXCHANGES.iter().collect();
+    // Match the queried-exchange count to the number of results, as in production.
+    // Coinbase is first in EXCHANGES, so the Http failure below resolves to it.
+    let exchanges: Vec<&Exchange> = EXCHANGES.iter().take(2).collect();
     let results = vec![
         Err(CallExchangeError::RateBelowResolution),
         Err(CallExchangeError::Http {

--- a/src/xrc/src/api/test.rs
+++ b/src/xrc/src/api/test.rs
@@ -5,7 +5,7 @@ use std::{
 
 use async_trait::async_trait;
 use futures::FutureExt;
-use ic_xrc_types::{Asset, AssetClass, ExchangeRateError, GetExchangeRateRequest};
+use ic_xrc_types::{Asset, AssetClass, ExchangeRateError, GetExchangeRateRequest, OtherError};
 use maplit::btreemap;
 
 use crate::{
@@ -15,15 +15,15 @@ use crate::{
     inflight::test::set_inflight_tracking,
     rate_limiting::test::{set_request_counter, REQUEST_COUNTER_TRIGGER_RATE_LIMIT},
     usdt_asset, with_cache_mut, with_forex_rate_store_mut, with_listing_store_mut,
-    CallExchangeError, Exchange,
+    CallExchangeError, Exchange, MetricCounter,
     QueriedExchangeRate, EXCHANGES, PRIVILEGED_CANISTER_IDS, RATE_UNIT, USDC, USDS,
     XRC_BASE_CYCLES_COST, XRC_IMMEDIATE_REFUND_CYCLES, XRC_MINIMUM_FEE_COST,
     XRC_OUTBOUND_HTTP_CALL_CYCLES_COST, XRC_REQUEST_CYCLES_COST,
 };
 
 use super::{
-    aggregate_cryptocurrency_usdt_rates, get_exchange_rate_internal, usd_asset, CallExchanges,
-    QueriedExchangeRateWithFailedExchanges,
+    aggregate_cryptocurrency_usdt_rates, error_metric_counter, get_exchange_rate_internal,
+    usd_asset, CallExchanges, QueriedExchangeRateWithFailedExchanges,
 };
 
 /// The function returns the Euro asset.
@@ -462,6 +462,21 @@ fn aggregate_below_resolution_with_http_failure_reports_below_resolution() {
     assert!(matches!(result, Err(CallExchangeError::RateBelowResolution)));
 }
 
+/// Asserts a result is the distinct below-resolution `Other` error. Generic over
+/// the `Ok` type so it serves both the internal (`QueriedExchangeRate`) and
+/// public (`ExchangeRate`) result shapes.
+fn assert_below_resolution_error<T: std::fmt::Debug>(result: &Result<T, ExchangeRateError>) {
+    assert!(
+        matches!(
+            result,
+            Err(ExchangeRateError::Other(e))
+                if e.code == crate::errors::RATE_BELOW_RESOLUTION_ERROR_CODE
+        ),
+        "expected the below-resolution Other error, got: {:#?}",
+        result
+    );
+}
+
 /// A crypto/USDT request whose base leg is below resolution returns the distinct
 /// below-resolution Other error, not a generic asset-not-found error.
 #[test]
@@ -488,15 +503,7 @@ fn below_resolution_base_leg_returns_below_resolution_error() {
     let result = get_exchange_rate_internal(&env, &call_exchanges_impl, &request)
         .now_or_never()
         .expect("future should complete");
-    assert!(
-        matches!(
-            result,
-            Err(ExchangeRateError::Other(ref e))
-                if e.code == crate::errors::RATE_BELOW_RESOLUTION_ERROR_CODE
-        ),
-        "expected the below-resolution Other error, got: {:#?}",
-        result
-    );
+    assert_below_resolution_error(&result);
 }
 
 /// A crypto/crypto request whose quote leg is below resolution surfaces the
@@ -526,15 +533,87 @@ fn below_resolution_quote_leg_returns_below_resolution_error() {
     let result = get_exchange_rate_internal(&env, &call_exchanges_impl, &request)
         .now_or_never()
         .expect("future should complete");
-    assert!(
-        matches!(
-            result,
-            Err(ExchangeRateError::Other(ref e))
-                if e.code == crate::errors::RATE_BELOW_RESOLUTION_ERROR_CODE
-        ),
-        "expected the below-resolution Other error, got: {:#?}",
-        result
-    );
+    assert_below_resolution_error(&result);
+}
+
+/// A crypto/fiat request whose crypto base leg is below resolution surfaces the
+/// distinct below-resolution Other error rather than a generic asset-not-found,
+/// so the below-resolution reason propagates through the forex path too.
+#[test]
+fn below_resolution_crypto_fiat_pair_returns_below_resolution_error() {
+    let call_exchanges_impl = TestCallExchangesImpl::builder()
+        .with_get_cryptocurrency_usdt_rate_responses(btreemap! {
+            "ICP".to_string() => Err(CallExchangeError::RateBelowResolution)
+        })
+        .with_get_stablecoin_rates_responses(btreemap! {
+            USDS.to_string() => Ok(stablecoin_mock_with_failed_exchanges(USDS, &[RATE_UNIT], vec![])),
+            USDC.to_string() => Ok(stablecoin_mock_with_failed_exchanges(USDC, &[RATE_UNIT], vec![])),
+        })
+        .build();
+    let env = TestEnvironment::builder()
+        .with_cycles_available(XRC_REQUEST_CYCLES_COST)
+        .with_accepted_cycles(XRC_REQUEST_CYCLES_COST - XRC_IMMEDIATE_REFUND_CYCLES)
+        .build();
+    let request = GetExchangeRateRequest {
+        base_asset: icp_asset(),
+        quote_asset: usd_asset(),
+        timestamp: Some(0),
+    };
+    let result = get_exchange_rate_internal(&env, &call_exchanges_impl, &request)
+        .now_or_never()
+        .expect("future should complete");
+    assert_below_resolution_error(&result);
+}
+
+/// The fiat/crypto (inverted) direction likewise surfaces the below-resolution
+/// error: the request is inverted to crypto/fiat, whose below-resolution leg
+/// yields the Other error, which is passed through unchanged by the inversion.
+#[test]
+fn below_resolution_fiat_crypto_pair_returns_below_resolution_error() {
+    let call_exchanges_impl = TestCallExchangesImpl::builder()
+        .with_get_cryptocurrency_usdt_rate_responses(btreemap! {
+            "ICP".to_string() => Err(CallExchangeError::RateBelowResolution)
+        })
+        .with_get_stablecoin_rates_responses(btreemap! {
+            USDS.to_string() => Ok(stablecoin_mock_with_failed_exchanges(USDS, &[RATE_UNIT], vec![])),
+            USDC.to_string() => Ok(stablecoin_mock_with_failed_exchanges(USDC, &[RATE_UNIT], vec![])),
+        })
+        .build();
+    let env = TestEnvironment::builder()
+        .with_cycles_available(XRC_REQUEST_CYCLES_COST)
+        .with_accepted_cycles(XRC_REQUEST_CYCLES_COST - XRC_IMMEDIATE_REFUND_CYCLES)
+        .build();
+    let request = GetExchangeRateRequest {
+        base_asset: usd_asset(),
+        quote_asset: icp_asset(),
+        timestamp: Some(0),
+    };
+    let result = get_exchange_rate_internal(&env, &call_exchanges_impl, &request)
+        .now_or_never()
+        .expect("future should complete");
+    assert_below_resolution_error(&result);
+}
+
+/// A below-resolution error (surfaced as `Other` with the dedicated code) is
+/// classified into its own request counter, not lost in the generic `Other`
+/// bucket; unrelated `Other` codes stay uncounted.
+#[test]
+fn below_resolution_error_maps_to_its_own_counter() {
+    assert!(matches!(
+        error_metric_counter(&crate::errors::rate_below_resolution_error()),
+        Some(MetricCounter::RateBelowResolutionErrorsReturned)
+    ));
+    // A generic Other (a different code) is not individually counted.
+    assert!(error_metric_counter(&ExchangeRateError::Other(OtherError {
+        code: crate::errors::INVALID_RATE_ERROR_CODE,
+        description: "x".to_string(),
+    }))
+    .is_none());
+    // Sanity: an existing classification is unaffected by the new arm.
+    assert!(matches!(
+        error_metric_counter(&ExchangeRateError::CryptoBaseAssetNotFound),
+        Some(MetricCounter::CryptoAssetRelatedErrorsReturned)
+    ));
 }
 
 /// Builds a crypto/USDT rate whose post-filter rate vector is internally

--- a/src/xrc/src/api/test.rs
+++ b/src/xrc/src/api/test.rs
@@ -462,6 +462,25 @@ fn aggregate_below_resolution_with_http_failure_reports_below_resolution() {
     assert!(matches!(result, Err(CallExchangeError::RateBelowResolution { .. })));
 }
 
+/// A below-resolution quote alongside representable rates that then fail the
+/// post-filter (they disagree) is NoRatesFound, not below-resolution: a
+/// representable rate was collected, so the pair is not below resolution — the
+/// representable rates merely failed to agree.
+#[test]
+fn aggregate_below_resolution_with_inconsistent_rates_reports_no_rates_found() {
+    // Match the queried-exchange count to the number of results, as in production.
+    let exchanges: Vec<&Exchange> = EXCHANGES.iter().take(3).collect();
+    // The two representable rates disagree far beyond the allowed deviation, so
+    // QueriedExchangeRate::new drops both, leaving an empty post-filter rate.
+    let results = vec![
+        Err(rate_below_resolution_err()),
+        Ok(RATE_UNIT),
+        Ok(1000 * RATE_UNIT),
+    ];
+    let result = aggregate_cryptocurrency_usdt_rates(&icp_asset(), &exchanges, 0, results);
+    assert!(matches!(result, Err(CallExchangeError::NoRatesFound)));
+}
+
 /// A below-resolution fetch error for tests. The exchange label is not asserted
 /// on anywhere, so a fixed placeholder keeps the call sites terse.
 fn rate_below_resolution_err() -> CallExchangeError {

--- a/src/xrc/src/api/test.rs
+++ b/src/xrc/src/api/test.rs
@@ -399,11 +399,11 @@ fn aggregate_all_below_resolution_reports_below_resolution() {
     // Match the queried-exchange count to the number of results, as in production.
     let exchanges: Vec<&Exchange> = EXCHANGES.iter().take(2).collect();
     let results = vec![
-        Err(CallExchangeError::RateBelowResolution),
-        Err(CallExchangeError::RateBelowResolution),
+        Err(rate_below_resolution_err()),
+        Err(rate_below_resolution_err()),
     ];
     let result = aggregate_cryptocurrency_usdt_rates(&icp_asset(), &exchanges, 0, results);
-    assert!(matches!(result, Err(CallExchangeError::RateBelowResolution)));
+    assert!(matches!(result, Err(CallExchangeError::RateBelowResolution { .. })));
 }
 
 /// A below-resolution quote alongside a representable one yields the
@@ -414,7 +414,7 @@ fn aggregate_mixed_below_resolution_and_rate_yields_rate() {
     let exchanges: Vec<&Exchange> = EXCHANGES.iter().take(2).collect();
     let results = vec![
         Ok(4 * RATE_UNIT),
-        Err(CallExchangeError::RateBelowResolution),
+        Err(rate_below_resolution_err()),
     ];
     let result = aggregate_cryptocurrency_usdt_rates(&icp_asset(), &exchanges, 0, results);
     assert!(
@@ -452,14 +452,22 @@ fn aggregate_below_resolution_with_http_failure_reports_below_resolution() {
     // Coinbase is first in EXCHANGES, so the Http failure below resolves to it.
     let exchanges: Vec<&Exchange> = EXCHANGES.iter().take(2).collect();
     let results = vec![
-        Err(CallExchangeError::RateBelowResolution),
+        Err(rate_below_resolution_err()),
         Err(CallExchangeError::Http {
             exchange: "Coinbase".to_string(),
             error: "boom".to_string(),
         }),
     ];
     let result = aggregate_cryptocurrency_usdt_rates(&icp_asset(), &exchanges, 0, results);
-    assert!(matches!(result, Err(CallExchangeError::RateBelowResolution)));
+    assert!(matches!(result, Err(CallExchangeError::RateBelowResolution { .. })));
+}
+
+/// A below-resolution fetch error for tests. The exchange label is not asserted
+/// on anywhere, so a fixed placeholder keeps the call sites terse.
+fn rate_below_resolution_err() -> CallExchangeError {
+    CallExchangeError::RateBelowResolution {
+        exchange: "TestExchange".to_string(),
+    }
 }
 
 /// Asserts a result is the distinct below-resolution `Other` error. Generic over
@@ -486,7 +494,7 @@ fn below_resolution_base_leg_returns_below_resolution_error() {
     let timestamp: u64 = 12_345_720;
     let call_exchanges_impl = TestCallExchangesImpl::builder()
         .with_get_cryptocurrency_usdt_rate_responses(btreemap! {
-            "ICP".to_string() => Err(CallExchangeError::RateBelowResolution)
+            "ICP".to_string() => Err(rate_below_resolution_err())
         })
         .build();
     let env = TestEnvironment::builder()
@@ -516,7 +524,7 @@ fn below_resolution_quote_leg_returns_below_resolution_error() {
     let call_exchanges_impl = TestCallExchangesImpl::builder()
         .with_get_cryptocurrency_usdt_rate_responses(btreemap! {
             "BTC".to_string() => Ok(btc_queried_exchange_rate_with_failed_exchanges_mock(vec![])),
-            "ICP".to_string() => Err(CallExchangeError::RateBelowResolution)
+            "ICP".to_string() => Err(rate_below_resolution_err())
         })
         .build();
     let env = TestEnvironment::builder()
@@ -543,7 +551,7 @@ fn below_resolution_quote_leg_returns_below_resolution_error() {
 fn below_resolution_crypto_fiat_pair_returns_below_resolution_error() {
     let call_exchanges_impl = TestCallExchangesImpl::builder()
         .with_get_cryptocurrency_usdt_rate_responses(btreemap! {
-            "ICP".to_string() => Err(CallExchangeError::RateBelowResolution)
+            "ICP".to_string() => Err(rate_below_resolution_err())
         })
         .with_get_stablecoin_rates_responses(btreemap! {
             USDS.to_string() => Ok(stablecoin_mock_with_failed_exchanges(USDS, &[RATE_UNIT], vec![])),
@@ -572,7 +580,7 @@ fn below_resolution_crypto_fiat_pair_returns_below_resolution_error() {
 fn below_resolution_fiat_crypto_pair_returns_below_resolution_error() {
     let call_exchanges_impl = TestCallExchangesImpl::builder()
         .with_get_cryptocurrency_usdt_rate_responses(btreemap! {
-            "ICP".to_string() => Err(CallExchangeError::RateBelowResolution)
+            "ICP".to_string() => Err(rate_below_resolution_err())
         })
         .with_get_stablecoin_rates_responses(btreemap! {
             USDS.to_string() => Ok(stablecoin_mock_with_failed_exchanges(USDS, &[RATE_UNIT], vec![])),

--- a/src/xrc/src/api/test.rs
+++ b/src/xrc/src/api/test.rs
@@ -22,7 +22,8 @@ use crate::{
 };
 
 use super::{
-    get_exchange_rate_internal, usd_asset, CallExchanges, QueriedExchangeRateWithFailedExchanges,
+    aggregate_cryptocurrency_usdt_rates, get_exchange_rate_internal, usd_asset, CallExchanges,
+    QueriedExchangeRateWithFailedExchanges,
 };
 
 /// The function returns the Euro asset.
@@ -388,6 +389,145 @@ fn cache_only_request_never_returns_zero_rate_after_failed_validation() {
             .len(),
         1,
         "the second request should have re-fetched rather than hit a poisoned cache"
+    );
+}
+
+/// When every usable quote is below the representable resolution, the aggregator
+/// reports it distinctly rather than as missing data.
+#[test]
+fn aggregate_all_below_resolution_reports_below_resolution() {
+    let exchanges: Vec<&Exchange> = EXCHANGES.iter().collect();
+    let results = vec![
+        Err(CallExchangeError::RateBelowResolution),
+        Err(CallExchangeError::RateBelowResolution),
+    ];
+    let result = aggregate_cryptocurrency_usdt_rates(&icp_asset(), &exchanges, 0, results);
+    assert!(matches!(result, Err(CallExchangeError::RateBelowResolution)));
+}
+
+/// A below-resolution quote alongside a representable one yields the
+/// representable rate; the below-resolution source is simply dropped.
+#[test]
+fn aggregate_mixed_below_resolution_and_rate_yields_rate() {
+    let exchanges: Vec<&Exchange> = EXCHANGES.iter().collect();
+    let results = vec![
+        Ok(4 * RATE_UNIT),
+        Err(CallExchangeError::RateBelowResolution),
+    ];
+    let result = aggregate_cryptocurrency_usdt_rates(&icp_asset(), &exchanges, 0, results);
+    assert!(
+        matches!(result, Ok(ref r) if r.queried_exchange_rate.rates == vec![4 * RATE_UNIT]),
+        "got: {:#?}",
+        result
+    );
+}
+
+/// Representable but mutually inconsistent rates are all dropped by the
+/// post-filter; that is missing data, not a below-resolution condition.
+#[test]
+fn aggregate_inconsistent_rates_report_no_rates_found() {
+    let exchanges: Vec<&Exchange> = EXCHANGES.iter().collect();
+    let results = vec![Ok(RATE_UNIT), Ok(1000 * RATE_UNIT)];
+    let result = aggregate_cryptocurrency_usdt_rates(&icp_asset(), &exchanges, 0, results);
+    assert!(matches!(result, Err(CallExchangeError::NoRatesFound)));
+}
+
+/// No results at all is missing data.
+#[test]
+fn aggregate_no_results_reports_no_rates_found() {
+    let exchanges: Vec<&Exchange> = EXCHANGES.iter().collect();
+    let result = aggregate_cryptocurrency_usdt_rates(&icp_asset(), &exchanges, 0, vec![]);
+    assert!(matches!(result, Err(CallExchangeError::NoRatesFound)));
+}
+
+/// A below-resolution quote mixed only with HTTP failures (no representable
+/// rate) is still reported as below-resolution.
+#[test]
+fn aggregate_below_resolution_with_http_failure_reports_below_resolution() {
+    let exchanges: Vec<&Exchange> = EXCHANGES.iter().collect();
+    let results = vec![
+        Err(CallExchangeError::RateBelowResolution),
+        Err(CallExchangeError::Http {
+            exchange: "Coinbase".to_string(),
+            error: "boom".to_string(),
+        }),
+    ];
+    let result = aggregate_cryptocurrency_usdt_rates(&icp_asset(), &exchanges, 0, results);
+    assert!(matches!(result, Err(CallExchangeError::RateBelowResolution)));
+}
+
+/// A crypto/USDT request whose base leg is below resolution returns the distinct
+/// below-resolution Other error, not a generic asset-not-found error.
+#[test]
+fn below_resolution_base_leg_returns_below_resolution_error() {
+    set_request_counter(0);
+
+    let timestamp: u64 = 12_345_720;
+    let call_exchanges_impl = TestCallExchangesImpl::builder()
+        .with_get_cryptocurrency_usdt_rate_responses(btreemap! {
+            "ICP".to_string() => Err(CallExchangeError::RateBelowResolution)
+        })
+        .build();
+    let env = TestEnvironment::builder()
+        .with_time_secs(timestamp)
+        .with_cycles_available(XRC_REQUEST_CYCLES_COST)
+        .with_accepted_cycles(XRC_BASE_CYCLES_COST + XRC_OUTBOUND_HTTP_CALL_CYCLES_COST)
+        .build();
+    let request = GetExchangeRateRequest {
+        base_asset: icp_asset(),
+        quote_asset: usdt_asset(),
+        timestamp: Some(timestamp),
+    };
+
+    let result = get_exchange_rate_internal(&env, &call_exchanges_impl, &request)
+        .now_or_never()
+        .expect("future should complete");
+    assert!(
+        matches!(
+            result,
+            Err(ExchangeRateError::Other(ref e))
+                if e.code == crate::errors::RATE_BELOW_RESOLUTION_ERROR_CODE
+        ),
+        "expected the below-resolution Other error, got: {:#?}",
+        result
+    );
+}
+
+/// A crypto/crypto request whose quote leg is below resolution surfaces the
+/// below-resolution Other error rather than CryptoQuoteAssetNotFound.
+#[test]
+fn below_resolution_quote_leg_returns_below_resolution_error() {
+    set_request_counter(0);
+
+    let timestamp: u64 = 12_345_780;
+    let call_exchanges_impl = TestCallExchangesImpl::builder()
+        .with_get_cryptocurrency_usdt_rate_responses(btreemap! {
+            "BTC".to_string() => Ok(btc_queried_exchange_rate_with_failed_exchanges_mock(vec![])),
+            "ICP".to_string() => Err(CallExchangeError::RateBelowResolution)
+        })
+        .build();
+    let env = TestEnvironment::builder()
+        .with_time_secs(timestamp)
+        .with_cycles_available(XRC_REQUEST_CYCLES_COST)
+        .with_accepted_cycles(XRC_BASE_CYCLES_COST + 2 * XRC_OUTBOUND_HTTP_CALL_CYCLES_COST)
+        .build();
+    let request = GetExchangeRateRequest {
+        base_asset: btc_asset(),
+        quote_asset: icp_asset(),
+        timestamp: Some(timestamp),
+    };
+
+    let result = get_exchange_rate_internal(&env, &call_exchanges_impl, &request)
+        .now_or_never()
+        .expect("future should complete");
+    assert!(
+        matches!(
+            result,
+            Err(ExchangeRateError::Other(ref e))
+                if e.code == crate::errors::RATE_BELOW_RESOLUTION_ERROR_CODE
+        ),
+        "expected the below-resolution Other error, got: {:#?}",
+        result
     );
 }
 

--- a/src/xrc/src/api/test.rs
+++ b/src/xrc/src/api/test.rs
@@ -251,6 +251,64 @@ fn icp_queried_exchange_rate_with_one_rate_mock() -> QueriedExchangeRate {
     )
 }
 
+/// Regression test for the cache-poisoning issue: a fresh crypto request whose
+/// post-filter rate set is empty must fail *and* must not leave an invalid
+/// intermediate in the cache. Otherwise a later cache-only request for the same
+/// asset and timestamp would be served a successful zero rate.
+#[test]
+fn failed_validation_does_not_poison_cache_with_zero_rate() {
+    set_request_counter(0);
+
+    let timestamp: u64 = 12_345_600;
+    // A single raw rate of 0 becomes an empty vector once
+    // QueriedExchangeRate::new filters out the invalid (zero) rate.
+    let empty_post_filter_rate = QueriedExchangeRate::new(
+        icp_asset(),
+        usdt_asset(),
+        timestamp,
+        &[0],
+        EXCHANGES.len(),
+        1,
+        None,
+    );
+    assert!(empty_post_filter_rate.rates.is_empty());
+
+    let call_exchanges_impl = TestCallExchangesImpl::builder()
+        .with_get_cryptocurrency_usdt_rate_responses(btreemap! {
+            "ICP".to_string() => Ok(QueriedExchangeRateWithFailedExchanges {
+                queried_exchange_rate: empty_post_filter_rate,
+                failed_exchanges: vec![],
+            })
+        })
+        .build();
+    let env = TestEnvironment::builder()
+        .with_time_secs(timestamp)
+        .with_cycles_available(XRC_REQUEST_CYCLES_COST)
+        .with_accepted_cycles(XRC_BASE_CYCLES_COST + XRC_OUTBOUND_HTTP_CALL_CYCLES_COST)
+        .build();
+    let request = GetExchangeRateRequest {
+        base_asset: icp_asset(),
+        quote_asset: usdt_asset(),
+        timestamp: Some(timestamp),
+    };
+
+    let result = get_exchange_rate_internal(&env, &call_exchanges_impl, &request)
+        .now_or_never()
+        .expect("future should complete");
+    assert!(
+        result.is_err(),
+        "a request with an empty post-filter rate must fail, got: {:#?}",
+        result
+    );
+
+    let cached_rate = with_cache_mut(|cache| cache.get("ICP", timestamp));
+    assert!(
+        cached_rate.is_none(),
+        "the invalid intermediate must not be cached, got: {:#?}",
+        cached_rate
+    );
+}
+
 fn stablecoin_mock(symbol: &str, rates: &[u64]) -> QueriedExchangeRate {
     QueriedExchangeRate::new(
         Asset {

--- a/src/xrc/src/cache.rs
+++ b/src/xrc/src/cache.rs
@@ -21,9 +21,12 @@ impl ExchangeRateCache {
 
     /// The function inserts the given exchange rate.
     /// The base asset must be a cryptocurrency that is not USDT and the quote asset must be USDT.
+    /// The rate must also have at least one (post-filter) rate; an empty rate is invalid and is
+    /// never cached, otherwise a later cache-only request could be served a successful zero rate.
     /// If one of these conditions does not hold, the rate is not cached.
     pub(crate) fn insert(&mut self, rate: &QueriedExchangeRate) {
-        if rate.base_asset.symbol.to_uppercase() != USDT
+        if !rate.rates.is_empty()
+            && rate.base_asset.symbol.to_uppercase() != USDT
             && rate.base_asset.class == Cryptocurrency
             && rate.quote_asset == usdt_asset()
         {

--- a/src/xrc/src/errors.rs
+++ b/src/xrc/src/errors.rs
@@ -4,10 +4,13 @@ pub(crate) const TIMESTAMP_IS_IN_FUTURE_ERROR_CODE: u32 = 1;
 pub(crate) const BASE_ASSET_INVALID_SYMBOL_ERROR_CODE: u32 = 2;
 pub(crate) const QUOTE_ASSET_INVALID_SYMBOL_ERROR_CODE: u32 = 3;
 pub(crate) const INVALID_RATE_ERROR_CODE: u32 = 4;
+pub(crate) const RATE_BELOW_RESOLUTION_ERROR_CODE: u32 = 5;
 
 pub(crate) const BASE_ASSET_INVALID_SYMBOL_ERROR_MESSAGE: &str = "Base asset symbol is invalid";
 pub(crate) const QUOTE_ASSET_INVALID_SYMBOL_ERROR_MESSAGE: &str = "Quote asset symbol is invalid";
 pub(crate) const INVALID_RATE_ERROR_MESSAGE: &str = "The computed rate is invalid";
+pub(crate) const RATE_BELOW_RESOLUTION_ERROR_MESSAGE: &str =
+    "The rate is below the representable resolution";
 
 pub(crate) fn timestamp_is_in_future_error(
     requested_timestamp: u64,
@@ -33,5 +36,12 @@ pub(crate) fn quote_asset_symbol_invalid_error() -> ExchangeRateError {
     ExchangeRateError::Other(OtherError {
         code: QUOTE_ASSET_INVALID_SYMBOL_ERROR_CODE,
         description: QUOTE_ASSET_INVALID_SYMBOL_ERROR_MESSAGE.to_string(),
+    })
+}
+
+pub(crate) fn rate_below_resolution_error() -> ExchangeRateError {
+    ExchangeRateError::Other(OtherError {
+        code: RATE_BELOW_RESOLUTION_ERROR_CODE,
+        description: RATE_BELOW_RESOLUTION_ERROR_MESSAGE.to_string(),
     })
 }

--- a/src/xrc/src/exchanges.rs
+++ b/src/xrc/src/exchanges.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
 
-use candid::{decode_args, encode_args, Deserialize, Error as CandidError};
+use candid::{decode_args, encode_args, CandidType, Deserialize, Error as CandidError};
 
 use ic_xrc_types::Asset;
 use serde::de::DeserializeOwned;
@@ -66,7 +66,7 @@ macro_rules! exchanges {
             }
 
             /// This method extracts the rate encoded in the given input.
-            pub fn extract_rate(&self, bytes: &[u8]) -> Result<u64, ExtractError> {
+            pub fn extract_rate(&self, bytes: &[u8]) -> Result<ExtractedRate, ExtractError> {
                 match self {
                     $(Exchange::$name(exchange) => exchange.extract_rate(bytes)),*,
                 }
@@ -122,13 +122,13 @@ macro_rules! exchanges {
             }
 
             /// Encodes the response in the exchange transform method.
-            pub fn encode_response(rate: u64) -> Result<Vec<u8>, CandidError> {
+            pub fn encode_response(rate: ExtractedRate) -> Result<Vec<u8>, CandidError> {
                 encode_args((rate,))
             }
 
             /// Decodes the response from the exchange transform method.
-            pub fn decode_response(bytes: &[u8]) -> Result<u64, CandidError> {
-                decode_args::<(u64,)>(bytes).map(|decoded| decoded.0)
+            pub fn decode_response(bytes: &[u8]) -> Result<ExtractedRate, CandidError> {
+                decode_args::<(ExtractedRate,)>(bytes).map(|decoded| decoded.0)
             }
 
             /// Encodes a parsed listing as the listing transform's output — the
@@ -197,11 +197,25 @@ enum ExtractedValue {
     Float(f64),
 }
 
+/// The outcome of parsing a single exchange response into a rate. This is the
+/// payload the HTTP transform encodes for consensus, so it round-trips through
+/// candid; it is an internal transform-to-canister type and is not part of the
+/// public canister interface.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, CandidType, Deserialize)]
+pub enum ExtractedRate {
+    /// A representable rate, scaled by [RATE_UNIT].
+    Rate(u64),
+    /// The exchange quoted a positive price below the canister's representable
+    /// resolution (it would scale to 0 in fixed point). Surfaced distinctly so
+    /// the caller can return a precise error rather than dropping a zero.
+    BelowResolution,
+}
+
 /// This function provides a generic way to extract a rate out of the provided bytes.
 fn extract_rate<R: DeserializeOwned>(
     bytes: &[u8],
     extract_fn: impl FnOnce(R) -> Option<ExtractedValue>,
-) -> Result<u64, ExtractError> {
+) -> Result<ExtractedRate, ExtractError> {
     let response = serde_json::from_slice::<R>(bytes)
         .map_err(|err| ExtractError::json_deserialize(bytes, err.to_string()))?;
     let extracted_value = extract_fn(response).ok_or_else(|| ExtractError::extract(bytes))?;
@@ -212,7 +226,22 @@ fn extract_rate<R: DeserializeOwned>(
         ExtractedValue::Float(value) => value,
     };
 
-    Ok((rate * RATE_UNIT as f64) as u64)
+    // Reject values that cannot represent a valid rate: non-finite, non-positive
+    // (a zero or negative price is invalid market data), or so large the scaled
+    // value would exceed the representable range. These are treated as a failed
+    // extraction so the exchange contributes no rate.
+    let scaled = rate * RATE_UNIT as f64;
+    if !rate.is_finite() || rate <= 0.0 || scaled > (RATE_UNIT as f64) * (RATE_UNIT as f64) {
+        return Err(ExtractError::extract(bytes));
+    }
+
+    // A positive price below the representable resolution would truncate to 0.
+    // Surface it distinctly instead of silently dropping a zero into the rates.
+    if scaled < 1.0 {
+        return Ok(ExtractedRate::BelowResolution);
+    }
+
+    Ok(ExtractedRate::Rate(scaled as u64))
 }
 
 /// A single spot market parsed from an exchange's listing endpoint, normalized
@@ -345,7 +374,7 @@ trait IsExchange {
     }
 
     /// The implementation to extract the rate from the response's body.
-    fn extract_rate(&self, bytes: &[u8]) -> Result<u64, ExtractError>;
+    fn extract_rate(&self, bytes: &[u8]) -> Result<ExtractedRate, ExtractError>;
 
     /// The URL of the exchange's public spot-listing endpoint. Unlike
     /// [IsExchange::get_base_url] this takes no placeholders — the listing is
@@ -441,7 +470,7 @@ impl IsExchange for Coinbase {
             .to_string()
     }
 
-    fn extract_rate(&self, bytes: &[u8]) -> Result<u64, ExtractError> {
+    fn extract_rate(&self, bytes: &[u8]) -> Result<ExtractedRate, ExtractError> {
         extract_rate(bytes, |response: CoinbaseResponse| {
             response.first().map(|kline| ExtractedValue::Float(kline.3))
         })
@@ -524,7 +553,7 @@ impl IsExchange for KuCoin {
             .to_string()
     }
 
-    fn extract_rate(&self, bytes: &[u8]) -> Result<u64, ExtractError> {
+    fn extract_rate(&self, bytes: &[u8]) -> Result<ExtractedRate, ExtractError> {
         extract_rate(bytes, |response: KuCoinResponse| {
             response
                 .data
@@ -617,7 +646,7 @@ impl IsExchange for Okx {
         timestamp.saturating_mul(1000).saturating_add(1).to_string()
     }
 
-    fn extract_rate(&self, bytes: &[u8]) -> Result<u64, ExtractError> {
+    fn extract_rate(&self, bytes: &[u8]) -> Result<ExtractedRate, ExtractError> {
         extract_rate(bytes, |response: OkxResponse| {
             response
                 .data
@@ -672,7 +701,7 @@ impl IsExchange for GateIo {
         "https://api.gateio.ws/api/v4/spot/candlesticks?currency_pair=BASE_ASSET_QUOTE_ASSET&interval=1m&from=START_TIME&to=END_TIME"
     }
 
-    fn extract_rate(&self, bytes: &[u8]) -> Result<u64, ExtractError> {
+    fn extract_rate(&self, bytes: &[u8]) -> Result<ExtractedRate, ExtractError> {
         extract_rate(bytes, |response: GateIoResponse| {
             response
                 .first()
@@ -728,7 +757,7 @@ impl IsExchange for Mexc {
         "https://api.mexc.com/api/v3/klines?symbol=BASE_ASSETQUOTE_ASSET&interval=1m&startTime=START_TIME&limit=1"
     }
 
-    fn extract_rate(&self, bytes: &[u8]) -> Result<u64, ExtractError> {
+    fn extract_rate(&self, bytes: &[u8]) -> Result<ExtractedRate, ExtractError> {
         extract_rate(bytes, |response: MexcResponse| {
             response
                 .first()
@@ -798,7 +827,7 @@ impl IsExchange for Poloniex {
         timestamp.saturating_mul(1000).saturating_add(1).to_string()
     }
 
-    fn extract_rate(&self, bytes: &[u8]) -> Result<u64, ExtractError> {
+    fn extract_rate(&self, bytes: &[u8]) -> Result<ExtractedRate, ExtractError> {
         extract_rate(bytes, |response: PoloniexResponse| {
             response
                 .first()
@@ -879,7 +908,7 @@ impl IsExchange for CryptoCom {
         timestamp.saturating_mul(1000).to_string()
     }
 
-    fn extract_rate(&self, bytes: &[u8]) -> Result<u64, ExtractError> {
+    fn extract_rate(&self, bytes: &[u8]) -> Result<ExtractedRate, ExtractError> {
         extract_rate(bytes, |response: CryptoResponse| {
             response
                 .result
@@ -961,7 +990,7 @@ impl IsExchange for Bitget {
             .to_string()
     }
 
-    fn extract_rate(&self, bytes: &[u8]) -> Result<u64, ExtractError> {
+    fn extract_rate(&self, bytes: &[u8]) -> Result<ExtractedRate, ExtractError> {
         extract_rate(bytes, |response: BitgetResponse| {
             response
                 .data
@@ -1016,7 +1045,7 @@ impl IsExchange for Digifinex {
         "https://openapi.digifinex.com/v3/kline?symbol=BASE_ASSET_QUOTE_ASSET&period=1&start_time=START_TIME&end_time=END_TIME"
     }
 
-    fn extract_rate(&self, bytes: &[u8]) -> Result<u64, ExtractError> {
+    fn extract_rate(&self, bytes: &[u8]) -> Result<ExtractedRate, ExtractError> {
         extract_rate(bytes, |response: DigifinexResponse| {
             response
                 .data
@@ -1219,7 +1248,29 @@ mod test {
         // the first entry (49.18), not an older candle.
         let query_response = load_file("test-data/exchanges/coinbase.json");
         let extracted_rate = coinbase.extract_rate(&query_response);
-        assert!(matches!(extracted_rate, Ok(rate) if rate == 49_180_000_000));
+        assert!(matches!(extracted_rate, Ok(ExtractedRate::Rate(rate)) if rate == 49_180_000_000));
+    }
+
+    /// A zero (or otherwise invalid) price is rejected by the parser rather than
+    /// scaled to a rate of 0, so an invalid sample never enters the rate set.
+    #[test]
+    fn extract_rate_rejects_zero_value() {
+        let coinbase = Coinbase;
+        let query_response = br#"[[1678752000,0.0,0.0,0.0,0.0,0.0]]"#;
+        assert!(coinbase.extract_rate(query_response).is_err());
+    }
+
+    /// A positive price below the representable resolution (it would scale to 0)
+    /// is reported as [ExtractedRate::BelowResolution], not dropped as a zero.
+    #[test]
+    fn extract_rate_reports_below_resolution_for_sub_unit_price() {
+        let coinbase = Coinbase;
+        // 1e-11 USDT scales to 1e-11 * RATE_UNIT = 0.01, which truncates to 0.
+        let query_response = br#"[[1678752000,1e-11,1e-11,1e-11,1e-11,0.0]]"#;
+        assert!(matches!(
+            coinbase.extract_rate(query_response),
+            Ok(ExtractedRate::BelowResolution)
+        ));
     }
 
     /// The function tests if the KuCoin struct returns the correct exchange rate.
@@ -1228,7 +1279,7 @@ mod test {
         let kucoin = KuCoin;
         let query_response = load_file("test-data/exchanges/kucoin.json");
         let extracted_rate = kucoin.extract_rate(&query_response);
-        assert!(matches!(extracted_rate, Ok(rate) if rate == 345_426_000_000));
+        assert!(matches!(extracted_rate, Ok(ExtractedRate::Rate(rate)) if rate == 345_426_000_000));
     }
 
     /// KuCoin returns candles newest-first, so when the closed-minute window
@@ -1241,7 +1292,7 @@ mod test {
             ["1620296760","340.000","339.000","341.000","338.000","100.0","34000.0"]
         ]}"#;
         let extracted_rate = kucoin.extract_rate(response);
-        assert!(matches!(extracted_rate, Ok(rate) if rate == 345_426_000_000));
+        assert!(matches!(extracted_rate, Ok(ExtractedRate::Rate(rate)) if rate == 345_426_000_000));
     }
 
     /// The function tests if the OKX struct returns the correct exchange rate.
@@ -1250,7 +1301,7 @@ mod test {
         let okx = Okx;
         let query_response = load_file("test-data/exchanges/okx.json");
         let extracted_rate = okx.extract_rate(&query_response);
-        assert!(matches!(extracted_rate, Ok(rate) if rate == 41_960_000_000));
+        assert!(matches!(extracted_rate, Ok(ExtractedRate::Rate(rate)) if rate == 41_960_000_000));
     }
 
     /// The function tests if the GateIo struct returns the correct exchange rate.
@@ -1259,7 +1310,7 @@ mod test {
         let gate_io = GateIo;
         let query_response = load_file("test-data/exchanges/gateio.json");
         let extracted_rate = gate_io.extract_rate(&query_response);
-        assert!(matches!(extracted_rate, Ok(rate) if rate == 42_640_000_000));
+        assert!(matches!(extracted_rate, Ok(ExtractedRate::Rate(rate)) if rate == 42_640_000_000));
     }
 
     /// The function tests if the Mexc struct returns the correct exchange rate.
@@ -1268,7 +1319,7 @@ mod test {
         let mexc = Mexc;
         let query_response = load_file("test-data/exchanges/mexc.json");
         let extracted_rate = mexc.extract_rate(&query_response);
-        assert!(matches!(extracted_rate, Ok(rate) if rate == 46_101_000_000));
+        assert!(matches!(extracted_rate, Ok(ExtractedRate::Rate(rate)) if rate == 46_101_000_000));
     }
 
     /// The function tests if the Poloniex struct returns the correct exchange rate.
@@ -1277,7 +1328,7 @@ mod test {
         let poloniex = Poloniex;
         let query_response = load_file("test-data/exchanges/poloniex.json");
         let extracted_rate = poloniex.extract_rate(&query_response);
-        assert!(matches!(extracted_rate, Ok(rate) if rate == 46_022_000_000));
+        assert!(matches!(extracted_rate, Ok(ExtractedRate::Rate(rate)) if rate == 46_022_000_000));
     }
 
     /// The function tests if the Crypto struct returns the correct exchange rate.
@@ -1286,7 +1337,7 @@ mod test {
         let crypto = CryptoCom;
         let query_response = load_file("test-data/exchanges/crypto.json");
         let extracted_rate = crypto.extract_rate(&query_response);
-        assert!(matches!(extracted_rate, Ok(rate) if rate == 47_328_300_000));
+        assert!(matches!(extracted_rate, Ok(ExtractedRate::Rate(rate)) if rate == 47_328_300_000));
     }
 
     /// The function tests if the Bitget struct returns the correct exchange rate.
@@ -1295,7 +1346,7 @@ mod test {
         let bitget = Bitget;
         let query_response = load_file("test-data/exchanges/bitget.json");
         let extracted_rate = bitget.extract_rate(&query_response);
-        assert!(matches!(extracted_rate, Ok(rate) if rate == 13_123_000_000));
+        assert!(matches!(extracted_rate, Ok(ExtractedRate::Rate(rate)) if rate == 13_123_000_000));
     }
 
     /// The function tests if the Digifinex struct returns the correct exchange rate.
@@ -1304,7 +1355,7 @@ mod test {
         let digifinex = Digifinex;
         let query_response = load_file("test-data/exchanges/digifinex.json");
         let extracted_rate = digifinex.extract_rate(&query_response);
-        assert!(matches!(extracted_rate, Ok(rate) if rate == 11_357_000_000));
+        assert!(matches!(extracted_rate, Ok(ExtractedRate::Rate(rate)) if rate == 11_357_000_000));
     }
 
     /// Asserts the common shape of every listing fixture: each holds four spot
@@ -1427,9 +1478,10 @@ mod test {
     /// exchange transform function.
     #[test]
     fn encode_response() {
-        let bytes = Exchange::encode_response(100).expect("should be able to encode value");
-        let hex_string = hex::encode(bytes);
-        assert_eq!(hex_string, "4449444c0001786400000000000000");
+        let bytes = Exchange::encode_response(ExtractedRate::Rate(100))
+            .expect("should be able to encode value");
+        let decoded = Exchange::decode_response(&bytes).expect("should be able to decode value");
+        assert_eq!(decoded, ExtractedRate::Rate(100));
     }
 
     /// The function tests the ability of [Exchange] to decode a context in the exchange
@@ -1446,10 +1498,10 @@ mod test {
     /// exchange transform function.
     #[test]
     fn decode_response() {
-        let hex_string = "4449444c0001786400000000000000";
-        let bytes = hex::decode(hex_string).expect("should be able to decode");
+        let bytes = Exchange::encode_response(ExtractedRate::BelowResolution)
+            .expect("should be able to encode value");
         let result = Exchange::decode_response(&bytes);
-        assert!(matches!(result, Ok(rate) if rate == 100));
+        assert!(matches!(result, Ok(ExtractedRate::BelowResolution)));
     }
 
     #[test]

--- a/src/xrc/src/exchanges.rs
+++ b/src/xrc/src/exchanges.rs
@@ -7,7 +7,7 @@ use serde::de::DeserializeOwned;
 
 use crate::api::usd_asset;
 use crate::{usdt_asset, utils, ONE_KIB};
-use crate::{ExtractError, RATE_UNIT};
+use crate::{ExtractError, MAX_REPRESENTABLE_RATE, RATE_UNIT};
 use crate::{USDC, USDS, USDT};
 
 /// This macro generates the necessary boilerplate when adding an exchange to this module.
@@ -243,7 +243,7 @@ fn extract_rate<R: DeserializeOwned>(
     // `ExtractError::extract`, which the transform maps to the benign no-data
     // outcome.
     let scaled = rate * RATE_UNIT as f64;
-    if !rate.is_finite() || rate <= 0.0 || scaled > (RATE_UNIT as f64) * (RATE_UNIT as f64) {
+    if !rate.is_finite() || rate <= 0.0 || scaled > MAX_REPRESENTABLE_RATE as f64 {
         return Err(ExtractError::json_deserialize(
             bytes,
             format!("{} is not a valid, representable rate", rate),

--- a/src/xrc/src/exchanges.rs
+++ b/src/xrc/src/exchanges.rs
@@ -1296,6 +1296,36 @@ mod test {
         ));
     }
 
+    /// A non-finite price is rejected as InvalidValue. This is the string path's
+    /// hazard: seven exchanges parse the price from a JSON string via
+    /// `value.parse::<f64>()`, and Rust parses "NaN"/"inf" to a finite-looking
+    /// `Ok(f64)` — so a venue emitting those would flow straight through were it
+    /// not for the `is_finite` guard (it must not become a bogus rate, nor the
+    /// benign no-data outcome).
+    #[test]
+    fn extract_rate_rejects_non_finite_value() {
+        let kucoin = KuCoin;
+        // KuCoin extracts the price from index 1 of the candle, as a string.
+        let query_response =
+            br#"{"data":[["1620296700","NaN","2.0","3.0","1.0","100.0","34000.0"]]}"#;
+        assert!(matches!(
+            kucoin.extract_rate(query_response),
+            Err(ExtractError::InvalidValue(_))
+        ));
+    }
+
+    /// A negative price is invalid market data, rejected as InvalidValue rather
+    /// than scaled into a (nonsensical) rate.
+    #[test]
+    fn extract_rate_rejects_negative_value() {
+        let coinbase = Coinbase;
+        let query_response = br#"[[1678752000,0.0,0.0,-1.0,0.0,0.0]]"#;
+        assert!(matches!(
+            coinbase.extract_rate(query_response),
+            Err(ExtractError::InvalidValue(_))
+        ));
+    }
+
     /// A positive price below the representable resolution (it would scale to 0)
     /// is reported as [ExtractedRate::BelowResolution], not dropped as a zero.
     #[test]

--- a/src/xrc/src/exchanges.rs
+++ b/src/xrc/src/exchanges.rs
@@ -237,17 +237,16 @@ fn extract_rate<R: DeserializeOwned>(
 
     // Reject values that cannot represent a valid rate: non-finite, non-positive
     // (a zero or negative price is invalid market data), or so large the scaled
-    // value would exceed the representable range. This is malformed market data,
-    // not an empty window, so surface it as a deserialize-style failure (which
-    // the transform traps and records as an error outcome) rather than
+    // value would exceed the representable range. This is a bad value, not an
+    // empty window, so surface it as `ExtractError::InvalidValue` (which the
+    // transform traps and records as an error outcome) rather than
     // `ExtractError::extract`, which the transform maps to the benign no-data
     // outcome.
     let scaled = rate * RATE_UNIT as f64;
     if !rate.is_finite() || rate <= 0.0 || scaled > MAX_REPRESENTABLE_RATE as f64 {
-        return Err(ExtractError::json_deserialize(
-            bytes,
-            format!("{} is not a valid, representable rate", rate),
-        ));
+        return Err(ExtractError::InvalidValue(format!(
+            "{rate} is not a valid, representable rate"
+        )));
     }
 
     // A positive price below the representable resolution would truncate to 0.
@@ -1274,13 +1273,26 @@ mod test {
     fn extract_rate_rejects_zero_value() {
         let coinbase = Coinbase;
         let query_response = br#"[[1678752000,0.0,0.0,0.0,0.0,0.0]]"#;
-        // A zero (invalid) price is malformed market data, not an empty window,
-        // so it must surface as a JsonDeserialize-style failure (which the
-        // transform traps -> http_error), never ExtractError::Extract (which the
-        // transform maps to the benign no-data outcome).
+        // A zero (invalid) price is a bad value, not an empty window, so it must
+        // surface as ExtractError::InvalidValue (which the transform traps ->
+        // http_error), never ExtractError::Extract (which the transform maps to
+        // the benign no-data outcome).
         assert!(matches!(
             coinbase.extract_rate(query_response),
-            Err(ExtractError::JsonDeserialize { .. })
+            Err(ExtractError::InvalidValue(_))
+        ));
+    }
+
+    /// A price whose scaled value exceeds the representable range is a bad value,
+    /// rejected as InvalidValue (traps -> http_error), not passed through.
+    #[test]
+    fn extract_rate_rejects_over_range_value() {
+        let coinbase = Coinbase;
+        // open = 2e9 scales to 2e18 > MAX_REPRESENTABLE_RATE (1e18).
+        let query_response = br#"[[1678752000,0.0,0.0,2000000000.0,0.0,0.0]]"#;
+        assert!(matches!(
+            coinbase.extract_rate(query_response),
+            Err(ExtractError::InvalidValue(_))
         ));
     }
 

--- a/src/xrc/src/exchanges.rs
+++ b/src/xrc/src/exchanges.rs
@@ -237,11 +237,17 @@ fn extract_rate<R: DeserializeOwned>(
 
     // Reject values that cannot represent a valid rate: non-finite, non-positive
     // (a zero or negative price is invalid market data), or so large the scaled
-    // value would exceed the representable range. These are treated as a failed
-    // extraction so the exchange contributes no rate.
+    // value would exceed the representable range. This is malformed market data,
+    // not an empty window, so surface it as a deserialize-style failure (which
+    // the transform traps and records as an error outcome) rather than
+    // `ExtractError::extract`, which the transform maps to the benign no-data
+    // outcome.
     let scaled = rate * RATE_UNIT as f64;
     if !rate.is_finite() || rate <= 0.0 || scaled > (RATE_UNIT as f64) * (RATE_UNIT as f64) {
-        return Err(ExtractError::extract(bytes));
+        return Err(ExtractError::json_deserialize(
+            bytes,
+            format!("{} is not a valid, representable rate", rate),
+        ));
     }
 
     // A positive price below the representable resolution would truncate to 0.
@@ -1268,7 +1274,14 @@ mod test {
     fn extract_rate_rejects_zero_value() {
         let coinbase = Coinbase;
         let query_response = br#"[[1678752000,0.0,0.0,0.0,0.0,0.0]]"#;
-        assert!(coinbase.extract_rate(query_response).is_err());
+        // A zero (invalid) price is malformed market data, not an empty window,
+        // so it must surface as a JsonDeserialize-style failure (which the
+        // transform traps -> http_error), never ExtractError::Extract (which the
+        // transform maps to the benign no-data outcome).
+        assert!(matches!(
+            coinbase.extract_rate(query_response),
+            Err(ExtractError::JsonDeserialize { .. })
+        ));
     }
 
     /// A positive price below the representable resolution (it would scale to 0)

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -120,6 +120,12 @@ const DECIMALS: u32 = 9;
 /// The rate unit is 10^DECIMALS.
 const RATE_UNIT: u64 = 10u64.saturating_pow(DECIMALS);
 
+/// The largest representable rate (scaled by [RATE_UNIT]); a larger value cannot
+/// be inverted without overflow. Both the exchange parser (`extract_rate`) and
+/// [QueriedExchangeRate::new]/`validate` use this single bound to reject or
+/// filter out-of-range rates, so the two stay in sync.
+const MAX_REPRESENTABLE_RATE: u64 = RATE_UNIT * RATE_UNIT;
+
 /// Used for setting the max response bytes for the exchanges and forexes.
 const ONE_KIB: u64 = 1_024;
 
@@ -781,7 +787,7 @@ impl QueriedExchangeRate {
         // which cannot be inverted, or deviate too much from the median rate.
         rates.retain(|rate| {
             *rate > 0
-                && *rate <= RATE_UNIT * RATE_UNIT
+                && *rate <= MAX_REPRESENTABLE_RATE
                 && (*rate).abs_diff(median_rate) <= median_rate / MAX_RELATIVE_DIFFERENCE_DIVISOR
         });
         rates.sort();
@@ -852,7 +858,7 @@ impl QueriedExchangeRate {
         // Verify that there are sufficiently many rates greater than zero but not greater than
         // `RATE_UNIT * RATE_UNIT`, which is close to the largest 64-bit integer for `RATE_UNIT = 10^9`.
         let median_rate = median(&self.rates);
-        if median_rate == 0 || median_rate > RATE_UNIT * RATE_UNIT {
+        if median_rate == 0 || median_rate > MAX_REPRESENTABLE_RATE {
             return Err(ExchangeRateError::Other(OtherError {
                 code: INVALID_RATE_ERROR_CODE,
                 description: INVALID_RATE_ERROR_MESSAGE.to_string(),

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -173,6 +173,7 @@ thread_local! {
     static STABLECOIN_ERRORS_RETURNED_COUNTER: Cell<usize> = const { Cell::new(0) };
     static INCONSISTENT_RATES_ERROR_COUNTER: Cell<usize> = const { Cell::new(0) };
     static CRYPTO_ASSET_RELATED_ERRORS_COUNTER: Cell<usize> = const { Cell::new(0) };
+    static RATE_BELOW_RESOLUTION_ERRORS_COUNTER: Cell<usize> = const { Cell::new(0) };
     static FOREX_ASSET_RELATED_ERRORS_COUNTER: Cell<usize> = const { Cell::new(0) };
 
     /// Per-(metric-name, label-set) labeled metrics. Populated by recording
@@ -417,6 +418,8 @@ enum MetricCounter {
     InconsistentRatesErrorsReturned,
     /// Maps to the [CRYPTO_ASSET_RELATED_ERRORS_COUNTER].
     CryptoAssetRelatedErrorsReturned,
+    /// Maps to the [RATE_BELOW_RESOLUTION_ERRORS_COUNTER].
+    RateBelowResolutionErrorsReturned,
     /// Maps to the [FOREX_ASSET_RELATED_ERRORS_COUNTER].
     ForexAssetRelatedErrorsReturned,
     /// Maps to the [ERRORS_RETURNED_TO_CMC_COUNTER].
@@ -449,6 +452,9 @@ impl MetricCounter {
             }
             MetricCounter::CryptoAssetRelatedErrorsReturned => {
                 CRYPTO_ASSET_RELATED_ERRORS_COUNTER.with(|c| c.get())
+            }
+            MetricCounter::RateBelowResolutionErrorsReturned => {
+                RATE_BELOW_RESOLUTION_ERRORS_COUNTER.with(|c| c.get())
             }
             MetricCounter::ForexAssetRelatedErrorsReturned => {
                 FOREX_ASSET_RELATED_ERRORS_COUNTER.with(|c| c.get())
@@ -488,6 +494,9 @@ impl MetricCounter {
             }
             MetricCounter::CryptoAssetRelatedErrorsReturned => {
                 CRYPTO_ASSET_RELATED_ERRORS_COUNTER.with(|c| c.set(c.get().saturating_add(1)))
+            }
+            MetricCounter::RateBelowResolutionErrorsReturned => {
+                RATE_BELOW_RESOLUTION_ERRORS_COUNTER.with(|c| c.set(c.get().saturating_add(1)))
             }
             MetricCounter::ForexAssetRelatedErrorsReturned => {
                 FOREX_ASSET_RELATED_ERRORS_COUNTER.with(|c| c.set(c.get().saturating_add(1)))
@@ -2498,6 +2507,27 @@ mod test {
                     "last_success gauge must not advance on a below-resolution quote"
                 );
             });
+        }
+
+        /// The below-resolution request counter is wired to its own storage,
+        /// independent of the crypto-asset counter it sits next to (guards the
+        /// hand-wiring across the enum/get/increment sites).
+        #[test]
+        fn rate_below_resolution_error_counter_is_independent() {
+            let before_below = MetricCounter::RateBelowResolutionErrorsReturned.get();
+            let before_crypto = MetricCounter::CryptoAssetRelatedErrorsReturned.get();
+
+            MetricCounter::RateBelowResolutionErrorsReturned.increment();
+
+            assert_eq!(
+                MetricCounter::RateBelowResolutionErrorsReturned.get(),
+                before_below + 1
+            );
+            assert_eq!(
+                MetricCounter::CryptoAssetRelatedErrorsReturned.get(),
+                before_crypto,
+                "below-resolution counter must not alias the crypto-asset counter"
+            );
         }
 
         #[test]

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -919,9 +919,12 @@ pub enum CallExchangeError {
     },
     /// Error used when no rates have been found at all for an asset.
     NoRatesFound,
-    /// The asset trades but every usable quote is below the canister's
-    /// representable resolution (the price would scale to 0 in fixed point).
-    RateBelowResolution,
+    /// The asset trades but the quote is below the canister's representable
+    /// resolution (the price would scale to 0 in fixed point).
+    RateBelowResolution {
+        /// The exchange that is associated with the error.
+        exchange: String,
+    },
     /// The upstream returned a well-formed response with no datapoint (an empty
     /// candle window). Distinct from [`CallExchangeError::Http`] so it is
     /// recorded as `no_data` rather than `http_error`.
@@ -940,8 +943,11 @@ impl core::fmt::Display for CallExchangeError {
             CallExchangeError::Candid { exchange, error } => {
                 write!(f, "Failed to encode/decode {exchange}: {error}")
             }
-            CallExchangeError::RateBelowResolution => {
-                write!(f, "The rate is below the representable resolution")
+            CallExchangeError::RateBelowResolution { exchange } => {
+                write!(
+                    f,
+                    "The rate from {exchange} is below the representable resolution"
+                )
             }
             CallExchangeError::NoRatesFound => {
                 write!(f, "Failed to retrieve rates for asset")
@@ -1021,7 +1027,9 @@ async fn call_exchange_raw(
         // The asset trades but its price is below the canister's representable
         // resolution. Report it distinctly so the caller can return a precise
         // error instead of treating it as missing data.
-        ExtractedRate::BelowResolution => Err(CallExchangeError::RateBelowResolution),
+        ExtractedRate::BelowResolution => Err(CallExchangeError::RateBelowResolution {
+            exchange: exchange.to_string(),
+        }),
         // The transform signalled an empty/no-datapoint response (an empty candle
         // window; see `transform_exchange_http_response`). Surface it as its own
         // error so it is recorded as `no_data`, not `http_error`.
@@ -1086,7 +1094,7 @@ fn record_exchange_outcome(
         Err(CallExchangeError::Candid { .. }) => Outcome::CandidError,
         // The upstream is up but quoted a price below the representable
         // resolution (it would scale to zero); surfaced as its own outcome.
-        Err(CallExchangeError::RateBelowResolution) => Outcome::BelowResolution,
+        Err(CallExchangeError::RateBelowResolution { .. }) => Outcome::BelowResolution,
         Err(CallExchangeError::NoRatesFound) => Outcome::NoRatesFound,
         Err(CallExchangeError::NoData { .. }) => Outcome::NoData,
     };
@@ -2486,7 +2494,9 @@ mod test {
             record_exchange_outcome(
                 "Mexc",
                 ExchangeCallKind::Crypto,
-                &Err(CallExchangeError::RateBelowResolution),
+                &Err(CallExchangeError::RateBelowResolution {
+                    exchange: "Mexc".to_string(),
+                }),
                 1_700_000_000,
             );
 

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -2509,27 +2509,6 @@ mod test {
             });
         }
 
-        /// The below-resolution request counter is wired to its own storage,
-        /// independent of the crypto-asset counter it sits next to (guards the
-        /// hand-wiring across the enum/get/increment sites).
-        #[test]
-        fn rate_below_resolution_error_counter_is_independent() {
-            let before_below = MetricCounter::RateBelowResolutionErrorsReturned.get();
-            let before_crypto = MetricCounter::CryptoAssetRelatedErrorsReturned.get();
-
-            MetricCounter::RateBelowResolutionErrorsReturned.increment();
-
-            assert_eq!(
-                MetricCounter::RateBelowResolutionErrorsReturned.get(),
-                before_below + 1
-            );
-            assert_eq!(
-                MetricCounter::CryptoAssetRelatedErrorsReturned.get(),
-                before_crypto,
-                "below-resolution counter must not alias the crypto-asset counter"
-            );
-        }
-
         #[test]
         fn no_rates_found_is_recorded_as_its_own_outcome() {
             reset();

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -124,7 +124,7 @@ const RATE_UNIT: u64 = 10u64.saturating_pow(DECIMALS);
 /// be inverted without overflow. Both the exchange parser (`extract_rate`) and
 /// [QueriedExchangeRate::new]/`validate` use this single bound to reject or
 /// filter out-of-range rates, so the two stay in sync.
-const MAX_REPRESENTABLE_RATE: u64 = RATE_UNIT * RATE_UNIT;
+const MAX_REPRESENTABLE_RATE: u64 = RATE_UNIT.saturating_mul(RATE_UNIT);
 
 /// Used for setting the max response bytes for the exchanges and forexes.
 const ONE_KIB: u64 = 1_024;

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -120,9 +120,11 @@ const DECIMALS: u32 = 9;
 /// The rate unit is 10^DECIMALS.
 const RATE_UNIT: u64 = 10u64.saturating_pow(DECIMALS);
 
-/// The largest representable rate (scaled by [RATE_UNIT]); a larger value cannot
-/// be inverted without overflow. Both the exchange parser (`extract_rate`) and
-/// [QueriedExchangeRate::new]/`validate` use this single bound to reject or
+/// The largest representable rate (scaled by [RATE_UNIT]); a larger value has no
+/// representable inverse. Inversion computes `RATE_UNIT^2 / rate` (see
+/// [utils::checked_invert_rate]), so a rate above this bound inverts to a value
+/// below one that rounds down to zero. Both the exchange parser (`extract_rate`)
+/// and [QueriedExchangeRate::new]/`validate` use this single bound to reject or
 /// filter out-of-range rates, so the two stay in sync.
 const MAX_REPRESENTABLE_RATE: u64 = RATE_UNIT.saturating_mul(RATE_UNIT);
 

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -1258,8 +1258,8 @@ pub fn transform_exchange_http_response(args: TransformArgs) -> HttpResponse {
         // calls). That is "no data this minute", not a transport or parse
         // failure, so signal it as `NoData` instead of trapping; the caller
         // records it as a distinct `no_data` outcome rather than `http_error`.
-        // Genuine parse failures
-        // (malformed JSON, unconvertible numbers) still trap.
+        // Genuine failures — malformed JSON (JsonDeserialize) and bad values
+        // (InvalidValue: non-finite/non-positive/over-range) — still trap.
         Err(ExtractError::Extract(_)) => ExtractedRate::NoData,
         Err(err) => {
             if let Exchange::KuCoin(_) = exchange {
@@ -1409,6 +1409,13 @@ pub enum ExtractError {
     /// (which surfaces as [ExtractError::JsonDeserialize]); the rate transform
     /// treats it as a no-data outcome rather than trapping.
     Extract(String),
+    /// The JSON parsed and a numeric price was extracted, but the value itself is
+    /// not a valid, representable rate: non-finite, non-positive, or larger than
+    /// [MAX_REPRESENTABLE_RATE]. Distinct from [ExtractError::Extract] (no data)
+    /// so the rate transform traps and records it as an error outcome rather than
+    /// the benign no-data outcome, and distinct from [ExtractError::JsonDeserialize]
+    /// so the error taxonomy does not conflate bad JSON with a bad value.
+    InvalidValue(String),
     /// The filter found a rate, but it could not be converted to a valid form.
     InvalidNumericRate {
         /// The filter that was used when the error occurred.
@@ -1432,6 +1439,9 @@ impl core::fmt::Display for ExtractError {
             }
             ExtractError::Extract(response) => {
                 write!(f, "Failed to extract rate from response: {}", response)
+            }
+            ExtractError::InvalidValue(value) => {
+                write!(f, "Extracted rate is not a valid, representable value: {value}")
             }
             ExtractError::JsonDeserialize { error, response } => {
                 write!(

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -52,7 +52,7 @@ pub use api::usdt_asset;
 pub use exchanges::{Exchange, EXCHANGES};
 pub use forex::{Forex, FOREX_SOURCES};
 
-use exchanges::ListedPairs;
+use exchanges::{ExtractedRate, ListedPairs};
 use listings::ListingStore;
 
 /// Rates may not deviate by more than one tenth of the smallest considered rate.
@@ -880,6 +880,9 @@ pub enum CallExchangeError {
     },
     /// Error used when no rates have been found at all for an asset.
     NoRatesFound,
+    /// The asset trades but every usable quote is below the canister's
+    /// representable resolution (the price would scale to 0 in fixed point).
+    RateBelowResolution,
 }
 
 impl core::fmt::Display for CallExchangeError {
@@ -890,6 +893,9 @@ impl core::fmt::Display for CallExchangeError {
             }
             CallExchangeError::Candid { exchange, error } => {
                 write!(f, "Failed to encode/decode {exchange}: {error}")
+            }
+            CallExchangeError::RateBelowResolution => {
+                write!(f, "The rate is below the representable resolution")
             }
             CallExchangeError::NoRatesFound => {
                 write!(f, "Failed to retrieve rates for asset")
@@ -955,10 +961,19 @@ async fn call_exchange_raw(
             error,
         })?;
 
-    Exchange::decode_response(&response.body).map_err(|error| CallExchangeError::Candid {
-        exchange: exchange.to_string(),
-        error: format!("Failure while decoding response: {}", error),
-    })
+    let extracted =
+        Exchange::decode_response(&response.body).map_err(|error| CallExchangeError::Candid {
+            exchange: exchange.to_string(),
+            error: format!("Failure while decoding response: {}", error),
+        })?;
+
+    match extracted {
+        ExtractedRate::Rate(rate) => Ok(rate),
+        // The asset trades but its price is below the canister's representable
+        // resolution. Report it distinctly so the caller can return a precise
+        // error instead of treating it as missing data.
+        ExtractedRate::BelowResolution => Err(CallExchangeError::RateBelowResolution),
+    }
 }
 
 /// Fetches an exchange's public spot listing and returns the set of base assets
@@ -1015,6 +1030,9 @@ fn record_exchange_outcome(
         Ok(_) => Outcome::Success,
         Err(CallExchangeError::Http { .. }) => Outcome::HttpError,
         Err(CallExchangeError::Candid { .. }) => Outcome::CandidError,
+        // A price below the representable resolution is the same "upstream is up
+        // but quoting an unusable near-zero value" failure mode as ExtractedZero.
+        Err(CallExchangeError::RateBelowResolution) => Outcome::ExtractedZero,
         Err(CallExchangeError::NoRatesFound) => Outcome::NoRatesFound,
     };
     let kind_label: &'static str = kind.into();
@@ -1197,7 +1215,7 @@ pub fn transform_exchange_http_response(args: TransformArgs) -> HttpResponse {
     sanitized.body = match Exchange::encode_response(rate) {
         Ok(body) => body,
         Err(err) => {
-            ic_cdk::trap(format!("failed to encode rate ({}): {}", rate, err));
+            ic_cdk::trap(format!("failed to encode rate ({:?}): {}", rate, err));
         }
     };
 

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -246,17 +246,16 @@ pub(crate) enum Outcome {
     CandidError,
     #[strum(serialize = "empty_map")]
     EmptyMap,
-    /// The upstream returned `Ok` but the extracted rate truncated to
-    /// zero — e.g. the JSON parsed and the price field was present, but
-    /// the value was `"0"`, negative-or-NaN-coerced-to-`u64`, or an
-    /// ultra-low-value asset that underflowed `rate * RATE_UNIT`. The
-    /// canister's downstream code silently drops these (the zero-filter
-    /// in `QueriedExchangeRate::new` and the explicit invert-check in
-    /// `call_exchange_for_stablecoin`); the metric surfaces them so
-    /// alerts can fire on the "upstream is up but quoting zero"
-    /// failure mode.
-    #[strum(serialize = "extracted_zero")]
-    ExtractedZero,
+    /// A single exchange quoted a positive price below the canister's
+    /// representable resolution — it would scale to 0 in fixed point (an
+    /// ultra-low-value asset, i.e. a price below ~1e-9). The parser surfaces this
+    /// distinctly as [`exchanges::ExtractedRate::BelowResolution`] and downstream
+    /// code drops it rather than letting a zero into the rates; the metric
+    /// surfaces the "upstream is up but quoting below our resolution" failure
+    /// mode. (A literal zero/negative/over-range quote is not this — it is
+    /// rejected at parse and recorded as `http_error`.)
+    #[strum(serialize = "below_resolution")]
+    BelowResolution,
     #[strum(serialize = "no_rates_found")]
     NoRatesFound,
     /// A single exchange returned a well-formed response with no datapoint — an
@@ -1073,13 +1072,12 @@ fn record_exchange_outcome(
     now_secs: u64,
 ) {
     let outcome = match result {
-        Ok(0) => Outcome::ExtractedZero,
         Ok(_) => Outcome::Success,
         Err(CallExchangeError::Http { .. }) => Outcome::HttpError,
         Err(CallExchangeError::Candid { .. }) => Outcome::CandidError,
-        // A price below the representable resolution is the same "upstream is up
-        // but quoting an unusable near-zero value" failure mode as ExtractedZero.
-        Err(CallExchangeError::RateBelowResolution) => Outcome::ExtractedZero,
+        // The upstream is up but quoted a price below the representable
+        // resolution (it would scale to zero); surfaced as its own outcome.
+        Err(CallExchangeError::RateBelowResolution) => Outcome::BelowResolution,
         Err(CallExchangeError::NoRatesFound) => Outcome::NoRatesFound,
         Err(CallExchangeError::NoData { .. }) => Outcome::NoData,
     };
@@ -2469,14 +2467,19 @@ mod test {
         }
 
         #[test]
-        fn ok_zero_records_extracted_zero_without_advancing_gauge() {
-            // The canister's downstream code silently drops zero rates
-            // (filtered by `QueriedExchangeRate::new`, rejected by the
-            // stablecoin invert step). Recording them as `success` would
-            // mask exactly the "upstream is up but quoting zero" failure
-            // mode this PR was added to detect.
+        fn below_resolution_records_below_resolution_without_advancing_gauge() {
+            // A below-resolution quote (a positive price that scales to zero) is
+            // dropped downstream rather than entering the rates. Recording it as
+            // `success` would mask the "upstream is up but quoting below our
+            // resolution" failure mode, and it must not advance the last-success
+            // gauge.
             reset();
-            record_exchange_outcome("Mexc", ExchangeCallKind::Crypto, &Ok(0), 1_700_000_000);
+            record_exchange_outcome(
+                "Mexc",
+                ExchangeCallKind::Crypto,
+                &Err(CallExchangeError::RateBelowResolution),
+                1_700_000_000,
+            );
 
             with_labeled_counters(|m| {
                 let key = make_metric_key(
@@ -2484,13 +2487,16 @@ mod test {
                     &[
                         (LabelKey::Exchange, "Mexc"),
                         (LabelKey::Kind, ExchangeCallKind::Crypto.into()),
-                        (LabelKey::Outcome, Outcome::ExtractedZero.into()),
+                        (LabelKey::Outcome, Outcome::BelowResolution.into()),
                     ],
                 );
                 assert_eq!(m.get(&key).copied(), Some(1));
             });
             with_labeled_gauges(|m| {
-                assert!(m.is_empty(), "last_success gauge must not advance on Ok(0)");
+                assert!(
+                    m.is_empty(),
+                    "last_success gauge must not advance on a below-resolution quote"
+                );
             });
         }
 


### PR DESCRIPTION
## Purpose

A crypto token priced below 1e-9 USDT truncates to 0 when scaled into the canister's fixed-point representation, so such an asset previously surfaced as a generic "asset not found" / no-rate — indistinguishable from a genuinely missing market. This makes the canister report that case precisely, so callers can tell "no such market" apart from "price below our representable resolution".

## What this changes

- A sub-resolution crypto price is reported as a distinct `ExchangeRateError::Other` error code, consistently across crypto/USDT, crypto/crypto (either leg), crypto/fiat, and the inverted fiat/crypto direction.
- The exchange parser is hardened to reject invalid values (non-finite, non-positive, over-range) at the source so an invalid sample never enters the rate set. These stay distinct from the below-resolution case and continue to surface as a generic no-rate. (This parser hardening was moved here from DEFI-2896, as agreed, since it reworks the same `extract_rate` value classification.)
- **Observability:** a dedicated `xrc_rate_below_resolution_errors` request counter, and the per-exchange fetch outcome that used to be labelled `extracted_zero` is now `below_resolution` — after the hardening that outcome only ever meant below-resolution, so the explicit label is more honest.
- **Metadata:** a below-resolution quote no longer counts toward `num_received_rates`. Previously such a quote scaled to a zero that was counted before being filtered out; now it is rejected before aggregation, so `num_received_rates` reflects only rates that actually contributed. Visible in the metadata but does not change the returned rate.

## API compatibility

No candid change — the new error reuses the existing `Other` variant with a new code value; the candid-compatibility check passes. The transform→aggregator encoding that carries the below-resolution signal is internal (replica-to-replica within one canister build), not part of the public interface. The only external-surface change is on `/metrics` (the new counter and the renamed outcome label), which dashboards pick up dynamically; no alert keys on the label.

## Out of scope

Computing a representable cross-rate when both crypto legs are sub-1e-9 (e.g. AIDOGE/CATCOIN) — each USDT leg truncates to 0 independently before dividing. Returning the precise below-resolution error is the correct short-term behaviour; the per-asset-decimals design is tracked in DEFI-2898.
