### PR TITLE
fix: DEFI-2896: validate composed rate on the cache-only crypto/fiat path

### DIFF
--- a/src/xrc/src/api.rs
+++ b/src/xrc/src/api.rs
@@ -719,13 +719,16 @@ async fn handle_crypto_base_fiat_quote_pair(
     }
     let forex_rate = forex_rate_result?;
 
+    // We have all of the necessary rates in the cache; return the result.
+    // Validate the composed result here too, mirroring the fresh path, so a
+    // cache-only response can never bypass the validation boundary.
     if num_rates_needed == 0 {
         let crypto_base_rate =
             maybe_crypto_base_rate.expect("Crypto base rate should be set here.");
         let stablecoin_rate = stablecoin::get_stablecoin_rate(&stablecoin_rates, &usd_asset())
             .map_err(ExchangeRateError::from)?;
         let crypto_usd_base_rate = crypto_base_rate * stablecoin_rate;
-        return Ok(crypto_usd_base_rate / forex_rate);
+        return (crypto_usd_base_rate / forex_rate).validate();
     }
 
     with_inflight_tracking(

--- a/src/xrc/src/api/test.rs
+++ b/src/xrc/src/api/test.rs
@@ -463,7 +463,7 @@ fn cache_only_crypto_fiat_pair_validates_the_composed_rate() {
         cache.insert(&stablecoin_mock(USDS, &[RATE_UNIT]));
         cache.insert(&stablecoin_mock(USDC, &[RATE_UNIT]));
     });
-    set_inflight_tracking(vec!["BTC".to_string(), "ICP".to_string()], 60);
+    set_inflight_tracking(vec!["ICP".to_string()], 60);
     let call_exchanges_impl = TestCallExchangesImpl::builder().build();
     let env = TestEnvironment::builder()
         .with_cycles_available(XRC_REQUEST_CYCLES_COST)

--- a/src/xrc/src/api/test.rs
+++ b/src/xrc/src/api/test.rs
@@ -313,13 +313,13 @@ fn failed_validation_does_not_poison_cache_with_zero_rate() {
     );
 }
 
-/// End-to-end check that the cache-only path can never replay a zero rate.
-/// Because the empty post-filter intermediate is no longer cached, a second
-/// request for the same asset and timestamp re-fetches instead of being served
-/// from cache; with no data available it errors again rather than returning
-/// Ok(rate = 0).
+/// End-to-end check that an empty post-filter intermediate can never replay a
+/// zero rate from the cache. Because such an intermediate is no longer cached,
+/// a second request for the same asset and timestamp re-fetches (one outbound
+/// call) instead of being served from cache; with no data available it errors
+/// again rather than returning Ok(rate = 0).
 #[test]
-fn cache_only_request_never_returns_zero_rate_after_failed_validation() {
+fn empty_post_filter_rate_is_not_cached_and_forces_refetch() {
     set_request_counter(0);
 
     let timestamp: u64 = 12_345_660;
@@ -388,6 +388,102 @@ fn cache_only_request_never_returns_zero_rate_after_failed_validation() {
             .len(),
         1,
         "the second request should have re-fetched rather than hit a poisoned cache"
+    );
+}
+
+/// Builds a crypto/USDT rate whose post-filter rate vector is internally
+/// inconsistent. The struct is built directly rather than via
+/// `QueriedExchangeRate::new` on purpose: `new` would filter the outliers out,
+/// so this stands in for any rate that could reach the cache without passing
+/// validation. It lets the tests below assert that the cache-only paths
+/// re-validate the composed result instead of returning it unchecked.
+fn inconsistent_crypto_usdt_rate_mock(base_asset: Asset) -> QueriedExchangeRate {
+    QueriedExchangeRate {
+        base_asset,
+        quote_asset: usdt_asset(),
+        timestamp: 0,
+        // 1.0 / 3.0 / 9.0: the median is non-zero, but the spread is far beyond
+        // the allowed deviation, so `validate` returns InconsistentRatesReceived.
+        // The ratios are preserved under division by a constant, so the composed
+        // rate stays inconsistent.
+        rates: vec![RATE_UNIT, 3 * RATE_UNIT, 9 * RATE_UNIT],
+        base_asset_num_queried_sources: EXCHANGES.len(),
+        base_asset_num_received_rates: 3,
+        quote_asset_num_queried_sources: EXCHANGES.len(),
+        quote_asset_num_received_rates: 3,
+        ..Default::default()
+    }
+}
+
+/// The cache-only crypto/crypto path must re-validate the composed result,
+/// mirroring the fresh path, so a cached rate that does not pass validation can
+/// never be returned unchecked. BTC/USDT is inconsistent in the cache and
+/// ICP/USDT is a single-rate entry, so the composed BTC/ICP rate is inconsistent
+/// and the request must fail rather than return Ok.
+#[test]
+fn cache_only_crypto_pair_validates_the_composed_rate() {
+    with_cache_mut(|cache| {
+        cache.insert(&inconsistent_crypto_usdt_rate_mock(btc_asset()));
+        cache.insert(&icp_queried_exchange_rate_with_one_rate_mock());
+    });
+    set_inflight_tracking(vec!["BTC".to_string(), "ICP".to_string()], 60);
+    // An empty builder proves the result comes from the cache-only path: if it
+    // tried to re-fetch instead, the request would fail with a different error.
+    let call_exchanges_impl = TestCallExchangesImpl::builder().build();
+    let env = TestEnvironment::builder()
+        .with_cycles_available(XRC_REQUEST_CYCLES_COST)
+        .with_accepted_cycles(XRC_BASE_CYCLES_COST)
+        .with_time_secs(90)
+        .build();
+    let request = GetExchangeRateRequest {
+        base_asset: btc_asset(),
+        quote_asset: icp_asset(),
+        timestamp: None,
+    };
+
+    let result = get_exchange_rate_internal(&env, &call_exchanges_impl, &request)
+        .now_or_never()
+        .expect("future should complete");
+
+    assert!(
+        matches!(result, Err(ExchangeRateError::InconsistentRatesReceived)),
+        "the cache-only crypto/crypto path must validate the composed rate, got: {:#?}",
+        result
+    );
+}
+
+/// The cache-only crypto/fiat path must likewise re-validate the composed
+/// result. ICP/USDT is inconsistent in the cache and the stablecoins resolve to
+/// the unit rate, so the composed ICP/USD rate is inconsistent and the request
+/// must fail rather than return Ok.
+#[test]
+fn cache_only_crypto_fiat_pair_validates_the_composed_rate() {
+    with_cache_mut(|cache| {
+        cache.insert(&inconsistent_crypto_usdt_rate_mock(icp_asset()));
+        cache.insert(&stablecoin_mock(USDS, &[RATE_UNIT]));
+        cache.insert(&stablecoin_mock(USDC, &[RATE_UNIT]));
+    });
+    set_inflight_tracking(vec!["BTC".to_string(), "ICP".to_string()], 60);
+    let call_exchanges_impl = TestCallExchangesImpl::builder().build();
+    let env = TestEnvironment::builder()
+        .with_cycles_available(XRC_REQUEST_CYCLES_COST)
+        .with_accepted_cycles(XRC_BASE_CYCLES_COST)
+        .with_time_secs(90)
+        .build();
+    let request = GetExchangeRateRequest {
+        base_asset: icp_asset(),
+        quote_asset: usd_asset(),
+        timestamp: None,
+    };
+
+    let result = get_exchange_rate_internal(&env, &call_exchanges_impl, &request)
+        .now_or_never()
+        .expect("future should complete");
+
+    assert!(
+        matches!(result, Err(ExchangeRateError::InconsistentRatesReceived)),
+        "the cache-only crypto/fiat path must validate the composed rate, got: {:#?}",
+        result
     );
 }
 


### PR DESCRIPTION
## Purpose

Follow-up to #343, which closed the empty/zero-rate validation boundary on the cache-only crypto/crypto path but left the identical asymmetry in the crypto/fiat path.

The fresh crypto/fiat path validates the composed crypto/USD rate, but the cache-only branch returned it directly with `Ok(...)` and no `validate()`. As a result a composed rate the system would reject as `InconsistentRatesReceived` on a fresh request could be served as a success once its inputs were cached — i.e. the same request returned different results depending on cache state.

## What this changes

- The cache-only crypto/fiat branch now validates the composed result, mirroring the fresh path, so a cache-only response can no longer bypass the validation boundary.
- Adds a test asserting the cache-only crypto/fiat path rejects an inconsistent composed rate (fails on pre-fix code).
- Adds a test for the cache-only crypto/crypto path, which #343 fixed but left untested.
- Renames `cache_only_request_never_returns_zero_rate_after_failed_validation` to reflect what it actually asserts (the empty intermediate is not cached, so the next request re-fetches).

## Severity

This is not the critical zero-rate cache poisoning #343 fixed — that path is closed at the source (empty rates are neither produced nor cached). This closes a lower-severity consistency gap: a rate deemed inconsistent on a fresh fetch could still be served from cache. No zero/garbage rate results, but fresh and cache-only requests should agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)