### PR TITLE
feat: DEFI-2903: record empty exchange windows as no_data, not http_error

### DIFF
--- a/src/xrc/src/exchanges.rs
+++ b/src/xrc/src/exchanges.rs
@@ -1428,13 +1428,17 @@ mod test {
     }
 
     /// The function tests the ability of [Exchange] to encode a response body from the
-    /// exchange transform function, including the empty/no-data `None` case.
+    /// exchange transform function, including the empty/no-data `None` case. The
+    /// wire format is candid `(opt nat64,)`; the exact bytes are pinned for both
+    /// cases (and shown to round-trip).
     #[test]
     fn encode_response() {
-        let bytes = Exchange::encode_response(Some(100)).expect("should be able to encode value");
-        assert!(matches!(Exchange::decode_response(&bytes), Ok(Some(100))));
+        let some = Exchange::encode_response(Some(100)).expect("should be able to encode value");
+        assert_eq!(hex::encode(&some), "4449444c016e780100016400000000000000");
+        assert!(matches!(Exchange::decode_response(&some), Ok(Some(100))));
 
         let none = Exchange::encode_response(None).expect("should be able to encode no-data");
+        assert_eq!(hex::encode(&none), "4449444c016e78010000");
         assert!(matches!(Exchange::decode_response(&none), Ok(None)));
     }
 
@@ -1449,13 +1453,15 @@ mod test {
     }
 
     /// The function tests the ability of [Exchange] to decode a response body from the
-    /// exchange transform function, for both a present rate and the no-data case.
+    /// exchange transform function, for both a present rate and the no-data case,
+    /// from the pinned candid `(opt nat64,)` bytes.
     #[test]
     fn decode_response() {
-        let some = Exchange::encode_response(Some(100)).expect("should be able to encode value");
+        let some =
+            hex::decode("4449444c016e780100016400000000000000").expect("should be able to decode");
         assert!(matches!(Exchange::decode_response(&some), Ok(Some(rate)) if rate == 100));
 
-        let none = Exchange::encode_response(None).expect("should be able to encode no-data");
+        let none = hex::decode("4449444c016e78010000").expect("should be able to decode");
         assert!(matches!(Exchange::decode_response(&none), Ok(None)));
     }
 

--- a/src/xrc/src/exchanges.rs
+++ b/src/xrc/src/exchanges.rs
@@ -1427,18 +1427,19 @@ mod test {
         assert_eq!(hex_string, "4449444c0001780000000000000000");
     }
 
-    /// The function tests the ability of [Exchange] to encode a response body from the
-    /// exchange transform function, including the empty/no-data `None` case. The
-    /// wire format is candid `(opt nat64,)`; the exact bytes are pinned for both
-    /// cases (and shown to round-trip).
+    /// The function tests that [Exchange] encodes and decodes a response body
+    /// (the transform's `Option<u64>` payload) symmetrically, for both a present
+    /// rate and the empty/no-data `None` case. The exact byte layout is not
+    /// pinned: `encode_response`/`decode_response` are an ephemeral within-outcall
+    /// round-trip in a single canister build (the bytes are never persisted or
+    /// decoded by another version), so a round-trip is the only property that
+    /// matters.
     #[test]
-    fn encode_response() {
+    fn encode_decode_response_round_trips() {
         let some = Exchange::encode_response(Some(100)).expect("should be able to encode value");
-        assert_eq!(hex::encode(&some), "4449444c016e780100016400000000000000");
         assert!(matches!(Exchange::decode_response(&some), Ok(Some(100))));
 
         let none = Exchange::encode_response(None).expect("should be able to encode no-data");
-        assert_eq!(hex::encode(&none), "4449444c016e78010000");
         assert!(matches!(Exchange::decode_response(&none), Ok(None)));
     }
 
@@ -1452,17 +1453,31 @@ mod test {
         assert!(matches!(result, Ok(index) if index == 1));
     }
 
-    /// The function tests the ability of [Exchange] to decode a response body from the
-    /// exchange transform function, for both a present rate and the no-data case,
-    /// from the pinned candid `(opt nat64,)` bytes.
+    /// The function tests that [Exchange::extract_rate] discriminates an empty
+    /// response (no datapoint -> [ExtractError::Extract], which the transform
+    /// maps to no-data) from a malformed one (-> [ExtractError::JsonDeserialize],
+    /// which still traps -> http_error). Coinbase stands in for any exchange; the
+    /// `.first()`-based extractors all behave the same.
     #[test]
-    fn decode_response() {
-        let some =
-            hex::decode("4449444c016e780100016400000000000000").expect("should be able to decode");
-        assert!(matches!(Exchange::decode_response(&some), Ok(Some(rate)) if rate == 100));
+    fn extract_rate_distinguishes_empty_from_malformed() {
+        let coinbase = Exchange::Coinbase(Coinbase);
 
-        let none = hex::decode("4449444c016e78010000").expect("should be able to decode");
-        assert!(matches!(Exchange::decode_response(&none), Ok(None)));
+        // Empty candle window: parses as `[]`, yields no datapoint.
+        assert!(matches!(
+            coinbase.extract_rate(b"[]"),
+            Err(ExtractError::Extract(_))
+        ));
+
+        // Malformed body: not valid JSON for the expected shape.
+        assert!(matches!(
+            coinbase.extract_rate(b"not json"),
+            Err(ExtractError::JsonDeserialize { .. })
+        ));
+
+        // A real candle still extracts a rate.
+        assert!(coinbase
+            .extract_rate(b"[[1614596340, 1.0, 1.01, 0.99, 1.0, 5.0]]")
+            .is_ok());
     }
 
     #[test]

--- a/src/xrc/src/exchanges.rs
+++ b/src/xrc/src/exchanges.rs
@@ -121,14 +121,18 @@ macro_rules! exchanges {
                 decode_args::<(usize,)>(bytes).map(|decoded| decoded.0)
             }
 
-            /// Encodes the response in the exchange transform method.
-            pub fn encode_response(rate: u64) -> Result<Vec<u8>, CandidError> {
+            /// Encodes the response in the exchange transform method. `None`
+            /// signals that the response parsed but carried no datapoint (an
+            /// empty candle window), which the caller treats as "no data"
+            /// rather than an error.
+            pub fn encode_response(rate: Option<u64>) -> Result<Vec<u8>, CandidError> {
                 encode_args((rate,))
             }
 
-            /// Decodes the response from the exchange transform method.
-            pub fn decode_response(bytes: &[u8]) -> Result<u64, CandidError> {
-                decode_args::<(u64,)>(bytes).map(|decoded| decoded.0)
+            /// Decodes the response from the exchange transform method. `None`
+            /// means the upstream returned no datapoint (see [encode_response]).
+            pub fn decode_response(bytes: &[u8]) -> Result<Option<u64>, CandidError> {
+                decode_args::<(Option<u64>,)>(bytes).map(|decoded| decoded.0)
             }
 
             /// Encodes a parsed listing as the listing transform's output — the
@@ -1424,12 +1428,14 @@ mod test {
     }
 
     /// The function tests the ability of [Exchange] to encode a response body from the
-    /// exchange transform function.
+    /// exchange transform function, including the empty/no-data `None` case.
     #[test]
     fn encode_response() {
-        let bytes = Exchange::encode_response(100).expect("should be able to encode value");
-        let hex_string = hex::encode(bytes);
-        assert_eq!(hex_string, "4449444c0001786400000000000000");
+        let bytes = Exchange::encode_response(Some(100)).expect("should be able to encode value");
+        assert!(matches!(Exchange::decode_response(&bytes), Ok(Some(100))));
+
+        let none = Exchange::encode_response(None).expect("should be able to encode no-data");
+        assert!(matches!(Exchange::decode_response(&none), Ok(None)));
     }
 
     /// The function tests the ability of [Exchange] to decode a context in the exchange
@@ -1443,13 +1449,14 @@ mod test {
     }
 
     /// The function tests the ability of [Exchange] to decode a response body from the
-    /// exchange transform function.
+    /// exchange transform function, for both a present rate and the no-data case.
     #[test]
     fn decode_response() {
-        let hex_string = "4449444c0001786400000000000000";
-        let bytes = hex::decode(hex_string).expect("should be able to decode");
-        let result = Exchange::decode_response(&bytes);
-        assert!(matches!(result, Ok(rate) if rate == 100));
+        let some = Exchange::encode_response(Some(100)).expect("should be able to encode value");
+        assert!(matches!(Exchange::decode_response(&some), Ok(Some(rate)) if rate == 100));
+
+        let none = Exchange::encode_response(None).expect("should be able to encode no-data");
+        assert!(matches!(Exchange::decode_response(&none), Ok(None)));
     }
 
     #[test]

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -253,6 +253,13 @@ pub(crate) enum Outcome {
     ExtractedZero,
     #[strum(serialize = "no_rates_found")]
     NoRatesFound,
+    /// The upstream returned a well-formed response with no datapoint — an
+    /// empty candle window (e.g. a thinly-traded pair with no trade in the
+    /// queried minutes on an exchange that does not forward-fill). This is
+    /// expected market behaviour, not a failure, so it is kept out of
+    /// `http_error`; a rising rate here is a liquidity signal for that pair.
+    #[strum(serialize = "no_data")]
+    NoData,
 }
 
 /// Discriminates the two call contexts in which an exchange is queried.
@@ -880,6 +887,13 @@ pub enum CallExchangeError {
     },
     /// Error used when no rates have been found at all for an asset.
     NoRatesFound,
+    /// The upstream returned a well-formed response with no datapoint (an empty
+    /// candle window). Distinct from [`CallExchangeError::Http`] so it is
+    /// recorded as `no_data` rather than `http_error`.
+    NoData {
+        /// The exchange that is associated with the error.
+        exchange: String,
+    },
 }
 
 impl core::fmt::Display for CallExchangeError {
@@ -893,6 +907,9 @@ impl core::fmt::Display for CallExchangeError {
             }
             CallExchangeError::NoRatesFound => {
                 write!(f, "Failed to retrieve rates for asset")
+            }
+            CallExchangeError::NoData { exchange } => {
+                write!(f, "No data returned from {exchange} for the queried window")
             }
         }
     }
@@ -955,10 +972,19 @@ async fn call_exchange_raw(
             error,
         })?;
 
-    Exchange::decode_response(&response.body).map_err(|error| CallExchangeError::Candid {
-        exchange: exchange.to_string(),
-        error: format!("Failure while decoding response: {}", error),
-    })
+    match Exchange::decode_response(&response.body) {
+        Ok(Some(rate)) => Ok(rate),
+        // The transform signalled an empty/no-datapoint response (see
+        // `transform_exchange_http_response`). Surface it as its own error so it
+        // is recorded as `no_data`, not `http_error`.
+        Ok(None) => Err(CallExchangeError::NoData {
+            exchange: exchange.to_string(),
+        }),
+        Err(error) => Err(CallExchangeError::Candid {
+            exchange: exchange.to_string(),
+            error: format!("Failure while decoding response: {}", error),
+        }),
+    }
 }
 
 /// Fetches an exchange's public spot listing and returns the set of base assets
@@ -1016,6 +1042,7 @@ fn record_exchange_outcome(
         Err(CallExchangeError::Http { .. }) => Outcome::HttpError,
         Err(CallExchangeError::Candid { .. }) => Outcome::CandidError,
         Err(CallExchangeError::NoRatesFound) => Outcome::NoRatesFound,
+        Err(CallExchangeError::NoData { .. }) => Outcome::NoData,
     };
     let kind_label: &'static str = kind.into();
     increment_labeled_counter(
@@ -1184,7 +1211,15 @@ pub fn transform_exchange_http_response(args: TransformArgs) -> HttpResponse {
     };
 
     let rate = match exchange.extract_rate(&sanitized.body) {
-        Ok(rate) => rate,
+        Ok(rate) => Some(rate),
+        // The response parsed fine but carried no datapoint — i.e. the exchange
+        // returned an empty candle window (e.g. Coinbase, which does not
+        // forward-fill, when no trade occurred in the queried minutes). That is
+        // "no data this minute", not a transport or parse failure, so signal it
+        // as `None` instead of trapping; the caller records it as a distinct
+        // `no_data` outcome rather than `http_error`. Genuine parse failures
+        // (malformed JSON, unconvertible numbers) still trap.
+        Err(ExtractError::Extract(_)) => None,
         Err(err) => {
             if let Exchange::KuCoin(_) = exchange {
                 ic_cdk::println!("{} [KuCoin] {}", LOG_PREFIX, err);
@@ -1197,7 +1232,7 @@ pub fn transform_exchange_http_response(args: TransformArgs) -> HttpResponse {
     sanitized.body = match Exchange::encode_response(rate) {
         Ok(body) => body,
         Err(err) => {
-            ic_cdk::trap(format!("failed to encode rate ({}): {}", rate, err));
+            ic_cdk::trap(format!("failed to encode rate ({:?}): {}", rate, err));
         }
     };
 
@@ -2366,6 +2401,75 @@ mod test {
             with_labeled_gauges(|m| {
                 assert!(m.is_empty(), "last_success gauge must not advance on NoRatesFound");
             });
+        }
+
+        #[test]
+        fn no_data_is_recorded_as_its_own_outcome() {
+            reset();
+            record_exchange_outcome(
+                "Coinbase",
+                ExchangeCallKind::Stablecoin,
+                &Err(CallExchangeError::NoData {
+                    exchange: "Coinbase".to_string(),
+                }),
+                0,
+            );
+
+            let key = make_metric_key(
+                MetricName::ExchangeFetchTotal,
+                &[
+                    (LabelKey::Exchange, "Coinbase"),
+                    (LabelKey::Kind, ExchangeCallKind::Stablecoin.into()),
+                    (LabelKey::Outcome, Outcome::NoData.into()),
+                ],
+            );
+            with_labeled_counters(|m| {
+                assert_eq!(m.get(&key).copied(), Some(1));
+            });
+            with_labeled_gauges(|m| {
+                assert!(m.is_empty(), "last_success gauge must not advance on NoData");
+            });
+        }
+
+        #[test]
+        fn transform_empty_window_signals_no_data() {
+            use ic_cdk::api::management_canister::http_request::{HttpResponse, TransformArgs};
+            let exchange = EXCHANGES.iter().find(|e| e.name() == "Coinbase").unwrap();
+            let args = TransformArgs {
+                response: HttpResponse {
+                    status: candid::Nat::from(200u64),
+                    headers: vec![],
+                    // Coinbase returns `[]` for a minute with no trade (it does
+                    // not forward-fill).
+                    body: b"[]".to_vec(),
+                },
+                context: exchange.encode_context().unwrap(),
+            };
+            let out = transform_exchange_http_response(args);
+            assert!(
+                matches!(Exchange::decode_response(&out.body), Ok(None)),
+                "empty candle window must transform to no-data (None), not trap"
+            );
+        }
+
+        #[test]
+        fn transform_populated_window_signals_rate() {
+            use ic_cdk::api::management_canister::http_request::{HttpResponse, TransformArgs};
+            let exchange = EXCHANGES.iter().find(|e| e.name() == "Coinbase").unwrap();
+            let args = TransformArgs {
+                response: HttpResponse {
+                    status: candid::Nat::from(200u64),
+                    headers: vec![],
+                    // [time, low, high, open, close, volume] — a real candle.
+                    body: b"[[1614596340, 1.0, 1.01, 0.99, 1.0, 5.0]]".to_vec(),
+                },
+                context: exchange.encode_context().unwrap(),
+            };
+            let out = transform_exchange_http_response(args);
+            assert!(matches!(
+                Exchange::decode_response(&out.body),
+                Ok(Some(_))
+            ));
         }
 
         #[test]

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -2433,43 +2433,50 @@ mod test {
 
         #[test]
         fn transform_empty_window_signals_no_data() {
-            use ic_cdk::api::management_canister::http_request::{HttpResponse, TransformArgs};
             let exchange = EXCHANGES.iter().find(|e| e.name() == "Coinbase").unwrap();
-            let args = TransformArgs {
-                response: HttpResponse {
-                    status: candid::Nat::from(200u64),
-                    headers: vec![],
-                    // Coinbase returns `[]` for a minute with no trade (it does
-                    // not forward-fill).
-                    body: b"[]".to_vec(),
-                },
-                context: exchange.encode_context().unwrap(),
+            // TODO(DEFI-2648): drop the allow once the transform moves off the
+            // deprecated `http_request` types it still takes in its signature.
+            #[allow(deprecated)]
+            let body = {
+                use ic_cdk::api::management_canister::http_request::{HttpResponse, TransformArgs};
+                let args = TransformArgs {
+                    response: HttpResponse {
+                        status: candid::Nat::from(200u64),
+                        headers: vec![],
+                        // Coinbase returns `[]` for a minute with no trade (it
+                        // does not forward-fill).
+                        body: b"[]".to_vec(),
+                    },
+                    context: exchange.encode_context().unwrap(),
+                };
+                transform_exchange_http_response(args).body
             };
-            let out = transform_exchange_http_response(args);
             assert!(
-                matches!(Exchange::decode_response(&out.body), Ok(None)),
+                matches!(Exchange::decode_response(&body), Ok(None)),
                 "empty candle window must transform to no-data (None), not trap"
             );
         }
 
         #[test]
         fn transform_populated_window_signals_rate() {
-            use ic_cdk::api::management_canister::http_request::{HttpResponse, TransformArgs};
             let exchange = EXCHANGES.iter().find(|e| e.name() == "Coinbase").unwrap();
-            let args = TransformArgs {
-                response: HttpResponse {
-                    status: candid::Nat::from(200u64),
-                    headers: vec![],
-                    // [time, low, high, open, close, volume] — a real candle.
-                    body: b"[[1614596340, 1.0, 1.01, 0.99, 1.0, 5.0]]".to_vec(),
-                },
-                context: exchange.encode_context().unwrap(),
+            // TODO(DEFI-2648): drop the allow once the transform moves off the
+            // deprecated `http_request` types it still takes in its signature.
+            #[allow(deprecated)]
+            let body = {
+                use ic_cdk::api::management_canister::http_request::{HttpResponse, TransformArgs};
+                let args = TransformArgs {
+                    response: HttpResponse {
+                        status: candid::Nat::from(200u64),
+                        headers: vec![],
+                        // [time, low, high, open, close, volume] — a real candle.
+                        body: b"[[1614596340, 1.0, 1.01, 0.99, 1.0, 5.0]]".to_vec(),
+                    },
+                    context: exchange.encode_context().unwrap(),
+                };
+                transform_exchange_http_response(args).body
             };
-            let out = transform_exchange_http_response(args);
-            assert!(matches!(
-                Exchange::decode_response(&out.body),
-                Ok(Some(_))
-            ));
+            assert!(matches!(Exchange::decode_response(&body), Ok(Some(_))));
         }
 
         #[test]

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -253,11 +253,17 @@ pub(crate) enum Outcome {
     ExtractedZero,
     #[strum(serialize = "no_rates_found")]
     NoRatesFound,
-    /// The upstream returned a well-formed response with no datapoint — an
+    /// A single exchange returned a well-formed response with no datapoint — an
     /// empty candle window (e.g. a thinly-traded pair with no trade in the
     /// queried minutes on an exchange that does not forward-fill). This is
     /// expected market behaviour, not a failure, so it is kept out of
     /// `http_error`; a rising rate here is a liquidity signal for that pair.
+    ///
+    /// Distinct from [`Outcome::NoRatesFound`]: that maps from
+    /// `CallExchangeError::NoRatesFound`, the *aggregate* "nothing found for the
+    /// asset" produced by the api-level rate collection (and the stablecoin
+    /// invert-zero case), which — unlike `NoData` — is not emitted through
+    /// `call_exchange`/`record_exchange_outcome` for an individual exchange call.
     #[strum(serialize = "no_data")]
     NoData,
 }
@@ -1213,11 +1219,13 @@ pub fn transform_exchange_http_response(args: TransformArgs) -> HttpResponse {
     let rate = match exchange.extract_rate(&sanitized.body) {
         Ok(rate) => Some(rate),
         // The response parsed fine but carried no datapoint — i.e. the exchange
-        // returned an empty candle window (e.g. Coinbase, which does not
-        // forward-fill, when no trade occurred in the queried minutes). That is
-        // "no data this minute", not a transport or parse failure, so signal it
-        // as `None` instead of trapping; the caller records it as a distinct
-        // `no_data` outcome rather than `http_error`. Genuine parse failures
+        // returned an empty candle window when no trade occurred in the queried
+        // minutes (Coinbase is the clearest case as it does not forward-fill,
+        // but this applies to any exchange and to both crypto and stablecoin
+        // calls). That is "no data this minute", not a transport or parse
+        // failure, so signal it as `None` instead of trapping; the caller
+        // records it as a distinct `no_data` outcome rather than `http_error`.
+        // Genuine parse failures
         // (malformed JSON, unconvertible numbers) still trap.
         Err(ExtractError::Extract(_)) => None,
         Err(err) => {
@@ -1362,7 +1370,11 @@ pub enum ExtractError {
         /// The set of errors that were found when the filter was compiled.
         errors: Vec<String>,
     },
-    /// The filter failed to extract from the JSON as the filter selects a value improperly.
+    /// The response parsed successfully but no datapoint could be extracted —
+    /// e.g. an empty candle array, a market with no trade in the queried window.
+    /// For exchange rate responses this is "no data", not a malformed response
+    /// (which surfaces as [ExtractError::JsonDeserialize]); the rate transform
+    /// treats it as a no-data outcome rather than trapping.
     Extract(String),
     /// The filter found a rate, but it could not be converted to a valid form.
     InvalidNumericRate {


### PR DESCRIPTION
## Why

Coinbase's stablecoin `http_error` rate sits near 50% in production — but those aren't transport failures. Coinbase doesn't forward-fill, so a minute with no trade returns an empty `[]`; the outcall transform trapped on that, surfacing as `CallExchangeError::Http` → `Outcome::HttpError`. That conflated "no trades this minute" with genuine HTTP failures and polluted the dashboard. The forex path already makes this distinction (`CallForexError::Empty` → `Outcome::EmptyMap`); the exchange-rate path now does too.

## Change

The empty case is already a distinct extractor result — `ExtractError::Extract` ("parsed, no datapoint") vs `ExtractError::JsonDeserialize` (malformed). The transform now signals it through the success channel instead of trapping:

- `encode_response`/`decode_response` carry `Option<u64>`;
- the transform emits `None` for `ExtractError::Extract` (genuine parse failures still trap);
- `call_exchange_raw` maps `None` → a new `CallExchangeError::NoData`;
- `record_exchange_outcome` records it as a new `Outcome::NoData` (`no_data`).

## Scope & safety

- **Applies to every exchange and both call kinds.** The reclassification keys on `ExtractError::Extract`, which all 9 exchange extractors produce only for an empty candle collection, so any exchange's empty crypto *or* stablecoin window now records `no_data` (an empty crypto window was previously mislabeled `http_error` too). This is intended.
- **Purely outcome classification.** The source set and `supported_stablecoin_pairs()` are unchanged — **Coinbase is kept** (its no-forward-fill behaviour is the *safe* one during a depeg: it returns no data rather than a stale price). No change for Poloniex/CryptoCom.
- **No rate change.** An empty window contributed nothing to the median before (it errored out) and contributes nothing now (`no_data`), so rates and the e2e golden values are unaffected — verified by a full local e2e run (6/6 green).
- `http_error` now reflects only real transport failures; `no_data` is a per-`(exchange, kind)` liquidity signal.

Tests: `encode`/`decode` `Option` round-trip incl. `None`; `extract_rate` empty→`Extract` vs malformed→`JsonDeserialize`; `record_exchange_outcome` → `no_data`; transform empty `[]` → `None` and a populated candle → `Some`. 262 unit tests + 6 e2e pass.

Jira: https://dfinity.atlassian.net/browse/DEFI-2903