### PR TITLE
feat: DEFI-2904: freshness gate for forward-filled stablecoin sources (Poloniex)

### DIFF
--- a/src/xrc/canbench_results.yml
+++ b/src/xrc/canbench_results.yml
@@ -2,63 +2,63 @@ benches:
   listing_parse_bitget:
     total:
       calls: 1
-      instructions: 28670209
+      instructions: 28679572
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   listing_parse_coinbase:
     total:
       calls: 1
-      instructions: 24001975
+      instructions: 24002313
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   listing_parse_cryptocom:
     total:
       calls: 1
-      instructions: 29066105
+      instructions: 29267936
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   listing_parse_digifinex:
     total:
       calls: 1
-      instructions: 14574176
+      instructions: 14581607
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   listing_parse_gateio:
     total:
       calls: 1
-      instructions: 78368408
+      instructions: 78391597
       heap_increase: 6
       stable_memory_increase: 0
     scopes: {}
   listing_parse_kucoin:
     total:
       calls: 1
-      instructions: 42051962
+      instructions: 42046320
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   listing_parse_mexc:
     total:
       calls: 1
-      instructions: 10777702
+      instructions: 10484970
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   listing_parse_okx:
     total:
       calls: 1
-      instructions: 84874330
+      instructions: 84876531
       heap_increase: 3
       stable_memory_increase: 0
     scopes: {}
   listing_parse_poloniex:
     total:
       calls: 1
-      instructions: 30555250
+      instructions: 30558237
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}

--- a/src/xrc/src/exchanges.rs
+++ b/src/xrc/src/exchanges.rs
@@ -846,6 +846,25 @@ impl IsExchange for Poloniex {
         })
     }
 
+    /// Freshness gate for the stablecoin path. Poloniex forward-fills: when no
+    /// trade occurred in the queried (closed) minute it still returns a candle,
+    /// carrying the stale price. Field 8 of the candle is the trade count, so a
+    /// zero there means the price is a carried-over stale value. Treat that as
+    /// "no datapoint" ([ExtractError::Extract], which the transform maps to
+    /// no_data) instead of feeding a stale price into the stablecoin median.
+    /// A real trade (count > 0) contributes its price as usual.
+    fn extract_stablecoin_rate(&self, bytes: &[u8]) -> Result<u64, ExtractError> {
+        extract_rate(bytes, |response: PoloniexResponse| {
+            response.first().and_then(|kline| {
+                if kline.8 == 0 {
+                    None
+                } else {
+                    Some(ExtractedValue::Str(kline.2.clone()))
+                }
+            })
+        })
+    }
+
     fn listing_url(&self) -> &str {
         "https://api.poloniex.com/markets"
     }
@@ -1318,6 +1337,48 @@ mod test {
         let query_response = load_file("test-data/exchanges/poloniex.json");
         let extracted_rate = poloniex.extract_rate(&query_response);
         assert!(matches!(extracted_rate, Ok(rate) if rate == 46_022_000_000));
+    }
+
+    /// The stablecoin freshness gate: a Poloniex candle whose trade count
+    /// (field 8) is zero is a forward-filled, stale price, so
+    /// `extract_stablecoin_rate` must report no datapoint
+    /// (`ExtractError::Extract`, which the transform maps to no_data) — while
+    /// the plain `extract_rate` (crypto path) still returns the price.
+    #[test]
+    fn poloniex_stablecoin_rate_gates_on_trade_count() {
+        let poloniex = Poloniex;
+        // field 2 (open) = "1.00" is the rate; field 8 is the trade count.
+        let no_trade =
+            br#"[["1.00","1.00","1.00","1.00","1.00","1.00","1.00","1.00",0,1677584374539,"1.00","MINUTE_1",1677584340000,1677584399999]]"#;
+        let traded =
+            br#"[["1.00","1.00","1.00","1.00","1.00","1.00","1.00","1.00",5,1677584374539,"1.00","MINUTE_1",1677584340000,1677584399999]]"#;
+
+        // No trade in the minute -> no datapoint on the stablecoin path.
+        assert!(matches!(
+            poloniex.extract_stablecoin_rate(no_trade),
+            Err(ExtractError::Extract(_))
+        ));
+        // ...but the crypto path is unaffected and still returns the price.
+        assert!(matches!(poloniex.extract_rate(no_trade), Ok(r) if r == RATE_UNIT));
+
+        // A real trade contributes its price on both paths.
+        assert!(matches!(poloniex.extract_stablecoin_rate(traded), Ok(r) if r == RATE_UNIT));
+        assert!(matches!(poloniex.extract_rate(traded), Ok(r) if r == RATE_UNIT));
+    }
+
+    /// Exchanges without an override expose the default `extract_stablecoin_rate`
+    /// (= `extract_rate`): a real KuCoin candle returns the same rate on both.
+    #[test]
+    fn default_stablecoin_rate_matches_extract_rate() {
+        let kucoin = KuCoin;
+        let query_response = load_file("test-data/exchanges/kucoin.json");
+        let via_default = kucoin
+            .extract_stablecoin_rate(&query_response)
+            .expect("should extract a rate");
+        let via_extract = kucoin
+            .extract_rate(&query_response)
+            .expect("should extract a rate");
+        assert_eq!(via_default, via_extract);
     }
 
     /// The function tests if the Crypto struct returns the correct exchange rate.

--- a/src/xrc/src/exchanges.rs
+++ b/src/xrc/src/exchanges.rs
@@ -72,6 +72,16 @@ macro_rules! exchanges {
                 }
             }
 
+            /// Extracts the rate for a stablecoin call, applying any
+            /// per-exchange freshness gate (see
+            /// [IsExchange::extract_stablecoin_rate]). For exchanges without a
+            /// gate this is identical to [Exchange::extract_rate].
+            pub fn extract_stablecoin_rate(&self, bytes: &[u8]) -> Result<u64, ExtractError> {
+                match self {
+                    $(Exchange::$name(exchange) => exchange.extract_stablecoin_rate(bytes)),*,
+                }
+            }
+
             /// This method returns the URL of the exchange's public spot-listing
             /// endpoint (used to discover tradable pairs).
             pub fn listing_url(&self) -> &str {
@@ -119,6 +129,22 @@ macro_rules! exchanges {
             /// A general method to decode contexts from an `Exchange`.
             pub fn decode_context(bytes: &[u8]) -> Result<usize, CandidError> {
                 decode_args::<(usize,)>(bytes).map(|decoded| decoded.0)
+            }
+
+            /// Encodes the transform context for a rate outcall: the exchange
+            /// index plus whether this is a stablecoin call. The flag lets
+            /// `transform_exchange_http_response` apply the stablecoin-only
+            /// freshness gate (see [Exchange::extract_stablecoin_rate]) without
+            /// affecting crypto calls.
+            pub fn encode_rate_context(&self, is_stablecoin: bool) -> Result<Vec<u8>, CandidError> {
+                let index = self.get_index();
+                encode_args((index, is_stablecoin))
+            }
+
+            /// Decodes the rate-outcall context produced by
+            /// [encode_rate_context] into `(exchange index, is_stablecoin)`.
+            pub fn decode_rate_context(bytes: &[u8]) -> Result<(usize, bool), CandidError> {
+                decode_args::<(usize, bool)>(bytes)
             }
 
             /// Encodes the response in the exchange transform method. `None`
@@ -350,6 +376,16 @@ trait IsExchange {
 
     /// The implementation to extract the rate from the response's body.
     fn extract_rate(&self, bytes: &[u8]) -> Result<u64, ExtractError>;
+
+    /// Extracts the rate from a stablecoin-call response. Defaults to
+    /// [IsExchange::extract_rate]; a forward-filling exchange overrides this to
+    /// drop a stale (no-trade) candle to "no data" — i.e. return
+    /// [ExtractError::Extract] — rather than feed a carried-over stale price
+    /// into the stablecoin median. Only the stablecoin path uses this; crypto
+    /// calls keep [IsExchange::extract_rate].
+    fn extract_stablecoin_rate(&self, bytes: &[u8]) -> Result<u64, ExtractError> {
+        self.extract_rate(bytes)
+    }
 
     /// The URL of the exchange's public spot-listing endpoint. Unlike
     /// [IsExchange::get_base_url] this takes no placeholders — the listing is

--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -943,7 +943,7 @@ async fn call_exchange(
     args: CallExchangeArgs,
     kind: ExchangeCallKind,
 ) -> Result<u64, CallExchangeError> {
-    let result = call_exchange_raw(exchange, args).await;
+    let result = call_exchange_raw(exchange, args, kind).await;
     record_exchange_outcome(exchange.name(), kind, &result, utils::time_secs());
     result
 }
@@ -953,14 +953,19 @@ async fn call_exchange(
 async fn call_exchange_raw(
     exchange: &Exchange,
     args: CallExchangeArgs,
+    kind: ExchangeCallKind,
 ) -> Result<u64, CallExchangeError> {
     let url = exchange.get_url(
         &args.base_asset.symbol,
         &args.quote_asset.symbol,
         args.timestamp,
     );
+    // The stablecoin flag travels in the transform context so the transform
+    // can apply the stablecoin-only freshness gate (forward-filled, no-trade
+    // candle -> no_data) without touching crypto calls.
+    let is_stablecoin = matches!(kind, ExchangeCallKind::Stablecoin);
     let context = exchange
-        .encode_context()
+        .encode_rate_context(is_stablecoin)
         .map_err(|error| CallExchangeError::Candid {
             exchange: exchange.to_string(),
             error: format!("Failure while encoding context: {}", error),
@@ -1200,8 +1205,8 @@ pub fn heartbeat() {
 pub fn transform_exchange_http_response(args: TransformArgs) -> HttpResponse {
     let mut sanitized = args.response;
 
-    let index = match Exchange::decode_context(&args.context) {
-        Ok(index) => index,
+    let (index, is_stablecoin) = match Exchange::decode_rate_context(&args.context) {
+        Ok(decoded) => decoded,
         Err(err) => ic_cdk::trap(format!("Failed to decode context: {}", err)),
     };
 
@@ -1216,7 +1221,15 @@ pub fn transform_exchange_http_response(args: TransformArgs) -> HttpResponse {
         }
     };
 
-    let rate = match exchange.extract_rate(&sanitized.body) {
+    // Stablecoin calls run the freshness gate (forward-filling sources drop a
+    // no-trade candle to no-data); crypto calls keep the plain extractor.
+    let extracted = if is_stablecoin {
+        exchange.extract_stablecoin_rate(&sanitized.body)
+    } else {
+        exchange.extract_rate(&sanitized.body)
+    };
+
+    let rate = match extracted {
         Ok(rate) => Some(rate),
         // The response parsed fine but carried no datapoint — i.e. the exchange
         // returned an empty candle window when no trade occurred in the queried
@@ -2459,7 +2472,7 @@ mod test {
                         // does not forward-fill).
                         body: b"[]".to_vec(),
                     },
-                    context: exchange.encode_context().unwrap(),
+                    context: exchange.encode_rate_context(false).unwrap(),
                 };
                 transform_exchange_http_response(args).body
             };
@@ -2484,7 +2497,7 @@ mod test {
                         // [time, low, high, open, close, volume] — a real candle.
                         body: b"[[1614596340, 1.0, 1.01, 0.99, 1.0, 5.0]]".to_vec(),
                     },
-                    context: exchange.encode_context().unwrap(),
+                    context: exchange.encode_rate_context(false).unwrap(),
                 };
                 transform_exchange_http_response(args).body
             };


### PR DESCRIPTION
## Why

Poloniex forward-fills its thin `USDT-USDC` market: when no trade occurs in a closed minute it still returns a candle carrying a stale price, so the fetch *succeeds* and the stale value silently enters the USDC median — harmless near the peg, dangerous during a depeg. DEFI-2903's empty-window → `no_data` reclassification can't catch this, because Poloniex never returns an empty `[]` window.

## What

A **stablecoin-only freshness gate**: a forward-filling source contributes a rate only when the candle reflects a real trade, otherwise `no_data`.

- The rate transform context now carries an `is_stablecoin` flag (`encode_rate_context`/`decode_rate_context`), so the gate applies to stablecoin calls only — crypto extraction is unchanged (crypto forward-fill is out of scope; see DEFI-2888).
- `Poloniex::extract_stablecoin_rate` treats a zero trade count (candle field 8) as no datapoint, which flows into the existing `no_data` plumbing from DEFI-2903 (`Option<u64>` → `CallExchangeError::NoData` → `Outcome::NoData`). No new outcome, metric, or API — the candle already carries the trade count.
- Other exchanges use the default (`= extract_rate`); the gate generalises to any future forward-filler by overriding the one method.

Result: Poloniex contributes a fresh price when it actually traded and `no_data` otherwise — the same honest behaviour Coinbase now has — so a stale forward-filled price never enters the median. Self-healing if liquidity returns.

Part 2 of the ticket (a sustained-`no_data` / "source effectively silent" observability signal) is alerting work and is left as a follow-up.

Jira: https://dfinity.atlassian.net/browse/DEFI-2904

## Source-count safety (no risk of running out of sources)

The gate only narrows the **USDC** pool, and only the two thin sources in it:

- **USDC — 8 sources:** six are the deeply liquid `USDC-USDT` markets (KuCoin, OKX, GateIo, MEXC, Bitget, Digifinex — ~100% of minutes traded, never gated), plus the two thin `USDT-USDC` sources, Coinbase and Poloniex. Even if both Coinbase (empty → `no_data`) and Poloniex (gated → `no_data`) drop out in a given minute, **6 liquid USDC rates always remain.**
- **USDS — 5 sources** (OKX, GateIo, MEXC, Bitget, Digifinex): Poloniex doesn't serve USDS, so the gate doesn't touch it at all.

The hard floor is `MIN_NUM_STABLECOIN_RATES = 2` *symbols* (USDC + USDS), each needing ≥1 exchange rate. With 6 and 5 real sources respectively, that floor holds with wide margin, so the gate cannot cause a "too few stablecoin rates" failure. And Poloniex's gated contribution was a **stale forward-filled price, not a genuine datapoint** — dropping it to `no_data` removes a fake source, not a real one, so the count of *real* sources goes up, not down.