### PR TITLE
test: retry dfx canister create/install in e2e harness

### DIFF
--- a/src/xrc-tests/src/container/utils.rs
+++ b/src/xrc-tests/src/container/utils.rs
@@ -287,28 +287,61 @@ pub enum InstallCanisterError {
     FailedToInstallCanister(String),
 }
 
+/// Number of attempts for each `dfx canister` command in [install_canister].
+/// `dfx canister create` (which also creates the cycles wallet) issues update
+/// calls to the management canister; these fail transiently when the subnet is
+/// not yet ready to process them right after the replica starts. Retrying with
+/// a short backoff turns those flakes into a brief delay.
+const INSTALL_CANISTER_ATTEMPTS: usize = 5;
+
+/// Delay between [install_canister] attempts.
+const INSTALL_CANISTER_RETRY_DELAY: Duration = Duration::from_secs(2);
+
+/// Runs a `dfx canister` command, retrying until its stderr contains
+/// `success_marker`. Transient failures (stderr without the marker) are retried
+/// up to [INSTALL_CANISTER_ATTEMPTS] times; the final stderr is passed to
+/// `on_failure` to build the error returned when all attempts are exhausted.
+fn run_dfx_until_success(
+    container: &Container,
+    command: &str,
+    success_marker: &str,
+    on_failure: impl Fn(String) -> InstallCanisterError,
+) -> Result<(), InstallCanisterError> {
+    let mut last_stderr = String::new();
+    for attempt in 1..=INSTALL_CANISTER_ATTEMPTS {
+        let (_, stderr) = compose_exec(container, command).map_err(InstallCanisterError::Io)?;
+        if stderr.contains(success_marker) {
+            return Ok(());
+        }
+
+        last_stderr = stderr.replace('\n', " ");
+        println!(
+            "`{}` did not succeed (attempt {}/{}): {}",
+            command, attempt, INSTALL_CANISTER_ATTEMPTS, last_stderr
+        );
+        if attempt < INSTALL_CANISTER_ATTEMPTS {
+            sleep(INSTALL_CANISTER_RETRY_DELAY);
+        }
+    }
+
+    Err(on_failure(last_stderr))
+}
+
 /// Creates and installs the canister on the container's replica.
 pub fn install_canister(container: &Container) -> Result<(), InstallCanisterError> {
-    let (_, stderr) =
-        compose_exec(container, "dfx canister create xrc").map_err(InstallCanisterError::Io)?;
+    run_dfx_until_success(
+        container,
+        "dfx canister create xrc",
+        "xrc canister created",
+        InstallCanisterError::FailedToCreateCanister,
+    )?;
 
-    if !stderr.contains("xrc canister created") {
-        return Err(InstallCanisterError::FailedToCreateCanister(
-            stderr.replace('\n', " "),
-        ));
-    }
-
-    let (_, stderr) = compose_exec(
+    run_dfx_until_success(
         container,
         "dfx canister install xrc --wasm /canister/xrc.wasm.gz",
-    )
-    .map_err(InstallCanisterError::Io)?;
-
-    if !stderr.contains("Installing code for canister xrc") {
-        return Err(InstallCanisterError::FailedToInstallCanister(
-            stderr.replace('\n', " "),
-        ));
-    }
+        "Installing code for canister xrc",
+        InstallCanisterError::FailedToInstallCanister,
+    )?;
 
     println!("xrc canister successfully installed!");
     Ok(())


### PR DESCRIPTION
## Purpose

The `e2e-tests` CI job has been intermittently failing at the `dfx canister create xrc` step with `Failed to create wallet: Failed create canister call.` — twice in two days. This makes the suite flaky and forces manual restarts.

The failure is a harness-level race, not a problem with the XRC code under test: the replica readiness check only confirms `dfx ping` returns `ic_api_version`, which does not guarantee the subnet can yet process the update calls that cycles-wallet creation issues. The create step was single-shot, so one transient miss failed the whole test.

## Change

Route both the `dfx canister create` and `dfx canister install` steps through a retry loop (5 attempts, 2s backoff) so the transient subnet-not-ready race becomes a brief delay instead of a test failure. I/O errors still fail immediately, and each failed attempt is logged with its attempt number so a genuinely broken setup still fails fast and visibly.

The longer-term fix remains the PocketIC migration (DEFI-2600 / DEFI-2881), which removes dfx and this race entirely.