### PR TITLE
feat: DEFI-2916: add USDC as a privileged asset

### DIFF
--- a/src/xrc/src/lib.rs
+++ b/src/xrc/src/lib.rs
@@ -88,7 +88,7 @@ const PRIVILEGED_CANISTER_IDS: [Principal; 3] = [
     Principal::from_slice(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01, 0x01]),
 ];
 
-const PRIVILEGED_CRYPTO_ASSETS: [&str; 4] = [BTC, ETH, ICP, USDT];
+const PRIVILEGED_CRYPTO_ASSETS: [&str; 5] = [BTC, ETH, ICP, USDC, USDT];
 
 /// The currency symbol for the US dollar.
 const USD: &str = "USD";

--- a/src/xrc/src/utils.rs
+++ b/src/xrc/src/utils.rs
@@ -344,6 +344,10 @@ pub(crate) mod test {
             symbol: "ICP".to_string(),
             class: AssetClass::Cryptocurrency,
         };
+        let usdc = Asset {
+            symbol: "USDC".to_string(),
+            class: AssetClass::Cryptocurrency,
+        };
         let doge = Asset {
             symbol: "DOGE".to_string(),
             class: AssetClass::Cryptocurrency,
@@ -360,7 +364,7 @@ pub(crate) mod test {
             symbol: "EUR".to_string(),
             class: AssetClass::FiatCurrency,
         };
-        let privileged_crypto_without_usdt = vec![btc, eth, icp];
+        let privileged_crypto_without_usdt = vec![btc, eth, icp, usdc];
         let mut privileged_crypto_with_usdt = privileged_crypto_without_usdt.clone();
         privileged_crypto_with_usdt.push(usdt_asset());
         let unprivileged_crypto = vec![doge, pepe];


### PR DESCRIPTION
## Purpose

The XRC throttles its HTTP outcalls with a self-imposed rate limiter. Privileged asset pairs bypass this limiter for current-rate requests (`timestamp=None`), so the exchange rates consumers rely on most stay available even under load. Until now the privileged crypto assets were BTC, ETH, ICP, and USDT.

USDC was missing from that set, which meant USDC-against-fiat and USDC/USDT requests were subject to the limiter and could be rejected with `RateLimited` — despite USDC being just as important to consumers. This PR adds USDC as a privileged asset so those pairs bypass the rate limiter for current-rate requests, matching the treatment of the other privileged cryptos.

## Change

- Add `USDC` to `PRIVILEGED_CRYPTO_ASSETS`.
- Extend the `should_identify_privileged_assets` unit test to cover USDC with full parity to the existing privileged cryptos: privileged when paired with a fiat currency or USDT (both directions), and not privileged when paired with another non-USDT crypto.

[DEFI-2916](https://dfinity.atlassian.net/browse/DEFI-2916)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DEFI-2916]: https://dfinity.atlassian.net/browse/DEFI-2916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ