### PR TITLE
chore: bump and pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -14,10 +14,10 @@ runs:
     # more information, see
     # https://github.com/docker/build-push-action/issues/539
     - name: Set up docker buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
     - name: Build Exchange Rate Canister Docker image
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
       with:
         context: .
         file: Dockerfile
@@ -25,7 +25,7 @@ runs:
         outputs: ./out
 
     - name: "Upload wasm module"
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: Exchange Rate Canister WASM Module
         path: ./out/xrc.wasm.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Release
-        uses: "softprops/action-gh-release@v1"
+        uses: "softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228" # v3.0.2
         with:
           files: |
             ./out/xrc.wasm.gz


### PR DESCRIPTION
Bump the GitHub Actions used in the build composite action and the release workflow to their latest major versions, pinned to full commit SHAs (version kept as a trailing comment).

Pinning to an immutable commit SHA prevents a moving version tag from being repointed at compromised code and makes CI builds reproducible.

Bumped actions:
- `docker/setup-buildx-action` v1 → v4.2.0 (`bb05f3f`)
- `docker/build-push-action` v2 → v7.3.0 (`53b7df9`)
- `actions/upload-artifact` v4 → v7.0.1 (`043fb46`, matches `tests.yml`)
- `softprops/action-gh-release` v1 → v3.0.2 (`3d0d988`)

The first three are exercised on this PR by the `assets` job (`docker-build.yml`), which is green. `softprops/action-gh-release` only runs on tag pushes (`release.yml`), so it is not exercised here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)